### PR TITLE
Accept PROMPT from --stdin

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -27,18 +27,23 @@ def cli():
 
 
 @cli.command()
-@click.argument("prompt")
+@click.argument("prompt", required=False)
 @click.option("--system", help="System prompt to use")
 @click.option("-4", "--gpt4", is_flag=True, help="Use GPT-4")
+@click.option('-i', '--stdin', is_flag=True, help="Read prompt from standard input")
 @click.option("-m", "--model", help="Model to use")
 @click.option("-s", "--stream", is_flag=True, help="Stream output")
 @click.option("-n", "--no-log", is_flag=True, help="Don't log to database")
 @click.option("--code", is_flag=True, help="System prompt to optimize for code output")
-def chatgpt(prompt, system, gpt4, model, stream, no_log, code):
+def chatgpt(prompt, system, gpt4, stdin, model, stream, no_log, code):
     "Execute prompt against ChatGPT"
     openai.api_key = get_openai_api_key()
     if gpt4:
         model = "gpt-4"
+    if prompt is None and stdin:
+        prompt = sys.stdin.read()
+    if not prompt:
+        raise click.UsageError("No prompt provided")
     if not model:
         model = "gpt-3.5-turbo"
     if code and system:


### PR DESCRIPTION
The idea here is to accept longer, multi-line, prompts that are harder to provide as a simple argument:

```
% cat longer-prompt.txt
Given:

def unwrap_markdown(content):
    # Remove first and last line if they are triple backticks
    lines = [l for l in content.split("\n")]
    if lines[0].strip().startswith("```"):
        lines = lines[1:]
    if lines[-1].strip() == "```":
        lines = lines[:-1]
    return "\n".join(lines)

write a simple pytest.
% cat longer-prompt.txt | python -m llm --model gpt-4 --stdin --stream
import pytest
from unwrap_markdown import unwrap_markdown

def test_unwrap_markdown():
    content = "```\nThis is a test string\nwith multiple lines\n```"
    expected_output = "This is a test string\nwith multiple lines"
    assert unwrap_markdown(content) == expected_output

    content_no_backticks = "This is a test string\nwith multiple lines"
    assert unwrap_markdown(content_no_backticks) == content_no_backticks

    content_mixed = "```\nThis is a test string\nwith multiple lines"
    assert unwrap_markdown(content_mixed) == expected_output

    content_empty = ""
    assert unwrap_markdown(content_empty) == content_empty

    content_single_backtick = "`This is a test string with single backticks`"
    assert unwrap_markdown(content_single_backtick) == content_single_backtick

if __name__ == "__main__":
    pytest.main(["-v", "test_unwrap_markdown.py"])
```