### PR TITLE
Add a defaults parameter to templates.

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -131,6 +131,34 @@ I got this:
 
 > My previous test subject seemed to have learned something new about iMovie. They exported keynote slides as individual images [...] Quite impressive for a human.
 
+## Specifying default parameters
+
+You can also specify default values for parameters, using a `defaults:` key.
+
+```yaml
+prompt: Summarize this text in the voice of $voice
+defaults:
+  voice: GlaDOS
+```
+
+When running without `-p` it will choose the default:
+
+```bash
+curl -s 'https://til.simonwillison.net/macos/imovie-slides-and-audio' | \
+  strip-tags -m | llm -t summarize
+```
+
+But you can override the defaults with `-p`:
+
+```bash
+curl -s 'https://til.simonwillison.net/macos/imovie-slides-and-audio' | \
+  strip-tags -m | llm -t summarize -p voice Yoda
+```
+
+I got this:
+
+> Text, summarize in Yoda's voice, I will: "Hmm, young padawan. Summary of this text, you seek. Hmmm. ...
+
 ## Setting a default model for a template
 
 Templates executed using `llm -t template-name` will execute using the default model that the user has configured for the tool - or `gpt-3.5-turbo` if they have not configured their own default.

--- a/llm/__init__.py
+++ b/llm/__init__.py
@@ -10,6 +10,7 @@ class Template(BaseModel):
     prompt: Optional[str]
     system: Optional[str]
     model: Optional[str]
+    defaults: Optional[dict]
 
     class Config:
         extra = "forbid"
@@ -20,6 +21,10 @@ class Template(BaseModel):
     def execute(self, input, params=None):
         params = params or {}
         params["input"] = input
+        if self.defaults:
+            for k, v in self.defaults.items():
+                if k not in params:
+                    params[k] = v
         if not self.prompt:
             system = self.interpolate(self.system, params)
             prompt = input

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -7,19 +7,21 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    "prompt,system,params,expected_prompt,expected_system,expected_error",
+    "prompt,system,defaults,params,expected_prompt,expected_system,expected_error",
     (
-        ("S: $input", None, {}, "S: input", None, None),
-        ("S: $input", "system", {}, "S: input", "system", None),
-        ("No vars", None, {}, "No vars", None, None),
-        ("$one and $two", None, {}, None, None, "Missing variables: one, two"),
-        ("$one and $two", None, {"one": 1, "two": 2}, "1 and 2", None, None),
+        ("S: $input", None, None, {}, "S: input", None, None),
+        ("S: $input", "system", None, {}, "S: input", "system", None),
+        ("No vars", None, None, {}, "No vars", None, None),
+        ("$one and $two", None, None, {}, None, None, "Missing variables: one, two"),
+        ("$one and $two", None, None, {"one": 1, "two": 2}, "1 and 2", None, None),
+        ("$one and $two", None, {"one": 1}, {"two": 2}, "1 and 2", None, None),
+        ("$one and $two", None, {"one": 99}, {"one": 1, "two": 2}, "1 and 2", None, None),
     ),
 )
 def test_template_execute(
-    prompt, system, params, expected_prompt, expected_system, expected_error
+    prompt, system, defaults, params, expected_prompt, expected_system, expected_error
 ):
-    t = Template(name="t", prompt=prompt, system=system)
+    t = Template(name="t", prompt=prompt, system=system, defaults=defaults)
     if expected_error:
         with pytest.raises(Template.MissingVariables) as ex:
             prompt, system = t.execute("input", params)


### PR DESCRIPTION
This allows default values to be filled for templates.

For example:


```yaml
prompt: Summarize this text in the voice of $voice
defaults:
  voice: GlaDOS
```

When running without `-p` it will choose the default:

```bash
curl -s 'https://til.simonwillison.net/macos/imovie-slides-and-audio' | \
  strip-tags -m | llm -t summarize
```

But you can override the defaults with `-p`:

```bash
curl -s 'https://til.simonwillison.net/macos/imovie-slides-and-audio' | \
  strip-tags -m | llm -t summarize -p voice Yoda
```

I got this:

> Text, summarize in Yoda's voice, I will: "Hmm, young padawan. Summary of this text, you seek. Hmmm. ...

