### PR TITLE
Set min/max constraints to float arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ venv
 .pytest_cache
 *.egg-info
 .DS_Store
+.idea/

--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -94,6 +94,8 @@ class Chat(Model):
                 "0.8 will make the output more random, while lower values like 0.2 will "
                 "make it more focused and deterministic."
             ),
+            ge=0,
+            le=2,
             default=None,
         )
         max_tokens: Optional[int] = Field(
@@ -107,6 +109,8 @@ class Chat(Model):
                 "10% probability mass are considered. Recommended to use top_p or "
                 "temperature but not both."
             ),
+            ge=0,
+            le=1,
             default=None,
         )
         frequency_penalty: Optional[float] = Field(
@@ -115,6 +119,8 @@ class Chat(Model):
                 "on their existing frequency in the text so far, decreasing the model's "
                 "likelihood to repeat the same line verbatim."
             ),
+            ge=-2,
+            le=2,
             default=None,
         )
         presence_penalty: Optional[float] = Field(
@@ -123,6 +129,8 @@ class Chat(Model):
                 "on whether they appear in the text so far, increasing the model's "
                 "likelihood to talk about new topics."
             ),
+            ge=-2,
+            le=2,
             default=None,
         )
         stop: Optional[str] = Field(

--- a/tests/test_cli_openai_models.py
+++ b/tests/test_cli_openai_models.py
@@ -44,16 +44,21 @@ def test_openai_options_min_max(mocked_models):
         "temperature": [0, 2],
         "top_p": [0, 1],
         "frequency_penalty": [-2, 2],
-        "presence_penalty": [-2, 2]
+        "presence_penalty": [-2, 2],
     }
     runner = CliRunner()
 
     for option, [min_val, max_val] in options.items():
-
         result = runner.invoke(cli, ["-m", "chatgpt", "-o", option, "-10"])
         assert result.exit_code == 1
-        assert result.output == f"Error: {option}\n  Input should be greater than or equal to {min_val}\n"
+        assert (
+            result.output
+            == f"Error: {option}\n  Input should be greater than or equal to {min_val}\n"
+        )
 
         result = runner.invoke(cli, ["-m", "chatgpt", "-o", option, "10"])
         assert result.exit_code == 1
-        assert result.output == f"Error: {option}\n  Input should be less than or equal to {max_val}\n"
+        assert (
+            result.output
+            == f"Error: {option}\n  Input should be less than or equal to {max_val}\n"
+        )

--- a/tests/test_cli_openai_models.py
+++ b/tests/test_cli_openai_models.py
@@ -37,3 +37,23 @@ def test_openai_models(mocked_models):
         "ada:2020-05-03        openai      2020-05-03T20:26:40\n"
         "babbage:2020-05-03    openai      2020-05-03T20:26:40\n"
     )
+
+
+def test_openai_options_min_max(mocked_models):
+    options = {
+        "temperature": [0, 2],
+        "top_p": [0, 1],
+        "frequency_penalty": [-2, 2],
+        "presence_penalty": [-2, 2]
+    }
+    runner = CliRunner()
+
+    for option, [min_val, max_val] in options.items():
+
+        result = runner.invoke(cli, ["-m", "chatgpt", "-o", option, "-10"])
+        assert result.exit_code == 1
+        assert result.output == f"Error: {option}\n  Input should be greater than or equal to {min_val}\n"
+
+        result = runner.invoke(cli, ["-m", "chatgpt", "-o", option, "10"])
+        assert result.exit_code == 1
+        assert result.output == f"Error: {option}\n  Input should be less than or equal to {max_val}\n"


### PR DESCRIPTION
Closes this [issue](https://github.com/simonw/llm/issues/115).

```
llm -m chatgpt 'say hello twice' -o temperature -1
Error: temperature
  Input should be greater than or equal to 0
```
