### PR TITLE
Fix for TypeError in `llm templates list` when template contains empty prompt

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -541,7 +541,7 @@ def templates_list():
             if template.prompt:
                 text.append(f" prompt: {template.prompt}")
         else:
-            text = [template.prompt]
+            text = [template.prompt if template.prompt else ""]
         pairs.append((name, "".join(text).replace("\n", " ")))
     try:
         max_name_len = max(len(p[0]) for p in pairs)


### PR DESCRIPTION
A TypeError is getting triggered when running the command `llm templates list` if a template contains an empty prompt.

To reproduce the issue, quickly close the editor after using the `llm templates edit new-prompt-name` command.

For reference, here's a snippet of the traceback:
```
  File ".../lib/python3.9/site-packages/llm/cli.py", line 545, in templates_list
    pairs.append((name, "".join(text).replace("\n", " ")))
TypeError: sequence item 0: expected str instance, NoneType found
```