### PR TITLE
Add support for Azure, OpenAI, Palm, Anthropic, Cohere Models - using litellm

### DIFF
--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -9,6 +9,7 @@ import requests
 from typing import List, Optional, Union
 import json
 import yaml
+import litellm
 
 
 @hookimpl
@@ -211,7 +212,7 @@ class Chat(Model):
             # openai client library requires one
             kwargs["api_key"] = "DUMMY_KEY"
         if stream:
-            completion = openai.ChatCompletion.create(
+            completion = litellm.completion(
                 model=self.model_name or self.model_id,
                 messages=messages,
                 stream=True,
@@ -225,7 +226,7 @@ class Chat(Model):
                     yield content
             response.response_json = combine_chunks(chunks)
         else:
-            completion = openai.ChatCompletion.create(
+            completion = litellm.completion(
                 model=self.model_name or self.model_id,
                 messages=messages,
                 stream=False,

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     install_requires=[
         "click",
         "openai",
+        "litellm",
         "click-default-group-wheel",
         "sqlite-utils",
         "pydantic>=2.0.0",


### PR DESCRIPTION
I'm the maintainer of litellm https://github.com/BerriAI/litellm - a simple & light package to call OpenAI, Azure, Cohere, Anthropic API Endpoints

This PR adds support for models from all the above mentioned providers

Here's a sample of how it's used:

```
from litellm import completion

## set ENV variables
# ENV variables can be set in .env file, too. Example in .env.example
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion("command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```