### PR TITLE
Allow for use of Pydantic v1 as well as v2.

### DIFF
--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -9,7 +9,7 @@ try:
     from pydantic import field_validator, Field
 except ImportError:
     from pydantic.fields import Field
-    from pydantic.class_validators import validator as field_validator # type: ignore [no-redef]
+    from pydantic.class_validators import validator as field_validator  # type: ignore [no-redef]
 import requests
 from typing import List, Optional, Union
 import json

--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -4,6 +4,7 @@ from llm.utils import dicts_to_table_string
 import click
 import datetime
 import openai
+
 try:
     from pydantic import field_validator, Field
 except ImportError:

--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -4,7 +4,11 @@ from llm.utils import dicts_to_table_string
 import click
 import datetime
 import openai
-from pydantic import field_validator, Field
+try:
+    from pydantic import field_validator, Field
+except ImportError:
+    from pydantic.fields import Field
+    from pydantic.class_validators import validator as field_validator
 import requests
 from typing import List, Optional, Union
 import json

--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -9,7 +9,7 @@ try:
     from pydantic import field_validator, Field
 except ImportError:
     from pydantic.fields import Field
-    from pydantic.class_validators import validator as field_validator
+    from pydantic.class_validators import validator as field_validator # type: ignore [no-redef]
 import requests
 from typing import List, Optional, Union
 import json

--- a/llm/models.py
+++ b/llm/models.py
@@ -200,7 +200,11 @@ class Response(ABC):
 
 
 class Options(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+
+    # Note: using pydantic v1 style Configs,
+    # these are also compatible with pydantic v2
+    class Config:
+        extra = "forbid"
 
 
 _Options = Options

--- a/llm/models.py
+++ b/llm/models.py
@@ -200,7 +200,6 @@ class Response(ABC):
 
 
 class Options(BaseModel):
-
     # Note: using pydantic v1 style Configs,
     # these are also compatible with pydantic v2
     class Config:

--- a/llm/models.py
+++ b/llm/models.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Iterator, List, Optional, Set
 from abc import ABC, abstractmethod
 import os
 import json
-from pydantic import ConfigDict, BaseModel
+from pydantic import BaseModel
 from ulid import ULID
 
 CONVERSATION_NAME_LENGTH = 32

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "openai",
         "click-default-group-wheel",
         "sqlite-utils",
-        "pydantic>=2.0.0",
+        "pydantic>=1.10.2",
         "PyYAML",
         "pluggy",
         "python-ulid",


### PR DESCRIPTION
Use v1-style configuration. While this is officially
deprecated (https://docs.pydantic.dev/latest/usage/model_config/),
it is supported by v2. I would assume this support will remain
for a while, this will help ease the transition to v2.

Background: llm may be used in combination with other libraries that may directly or indirectly depend on pydantic v1, this PR is designed to give groups the ability to combine llm with their other libraries and have some breathing space to transition
