### PR TITLE
Updated error message for invalid or missing embedding model

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1181,7 +1181,7 @@ def embed_multi(
         )
     except ValueError:
         raise click.ClickException(
-            "You need to specify a model (no default model is set)"
+            "You need to specify an embedding model (no default model is set)"
         )
 
     expected_length = None

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1047,7 +1047,7 @@ def embed(collection, id, input, model, store, database, content, metadata, form
                 model = get_default_embedding_model()
                 if model is None:
                     raise click.ClickException(
-                        "You need to specify a model (no default model is set)"
+                        "You need to specify an embedding model (no default model is set)"
                     )
             collection_obj = Collection(collection, db=db, model_id=model)
             model_obj = collection_obj.model()
@@ -1057,7 +1057,7 @@ def embed(collection, id, input, model, store, database, content, metadata, form
             model_obj = get_embedding_model(model)
         except UnknownModelError:
             raise click.ClickException(
-                "You need to specify a model (no default model is set)"
+                "You need to specify an embedding model (no default model is set)"
             )
 
     show_output = True

--- a/tests/test_embed_cli.py
+++ b/tests/test_embed_cli.py
@@ -474,7 +474,7 @@ def test_default_embed_model_errors(user_path, default_is_set, command):
         assert result.exit_code == 0
     else:
         assert result.exit_code == 1
-        assert "You need to specify a model (no default model is set)" in result.output
+        assert "You need to specify an embedding model (no default model is set)" in result.output
         # Now set the default model and try again
         result2 = runner.invoke(cli, ["embed-models", "default", "embed-demo"])
         assert result2.exit_code == 0

--- a/tests/test_embed_cli.py
+++ b/tests/test_embed_cli.py
@@ -474,7 +474,10 @@ def test_default_embed_model_errors(user_path, default_is_set, command):
         assert result.exit_code == 0
     else:
         assert result.exit_code == 1
-        assert "You need to specify an embedding model (no default model is set)" in result.output
+        assert (
+            "You need to specify an embedding model (no default model is set)"
+            in result.output
+        )
         # Now set the default model and try again
         result2 = runner.invoke(cli, ["embed-models", "default", "embed-demo"])
         assert result2.exit_code == 0


### PR DESCRIPTION
Hey, just an improvement on the error message for missing default embedding model. I was confused with default models here (thought it was asking me for a LLM model)