### PR TITLE
[Proof of concept] Support shell autocomplete for templates

### DIFF
--- a/docs/help.md
+++ b/docs/help.md
@@ -90,7 +90,7 @@ Options:
   -s, --system TEXT            System prompt to use
   -m, --model TEXT             Model to use
   -o, --option <TEXT TEXT>...  key/value options for the model
-  -t, --template TEXT          Template to use
+  -t, --template TEMPLATE      Template to use
   -p, --param <TEXT TEXT>...   Parameters for template
   --no-stream                  Do not stream output
   -n, --no-log                 Don't log to database

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -97,10 +97,24 @@ class TemplateType(click.ParamType):
         ]
 
 
+class ModelType(click.ParamType):
+    """Support shell auto-complete for --model parameter."""
+
+    name = "model_id"
+
+    def shell_complete(self, ctx, param, incomplete):
+        model_aliases = get_model_aliases().keys()
+        return [
+            CompletionItem(model_id)
+            for model_id in model_aliases
+            if model_id.startswith(incomplete)
+        ]
+
+
 @cli.command(name="prompt")
 @click.argument("prompt", required=False)
 @click.option("-s", "--system", help="System prompt to use")
-@click.option("model_id", "-m", "--model", help="Model to use")
+@click.option("model_id", "-m", "--model", type=ModelType(), help="Model to use")
 @click.option(
     "options",
     "-o",
@@ -308,7 +322,7 @@ def prompt(
 
 @cli.command()
 @click.option("-s", "--system", help="System prompt to use")
-@click.option("model_id", "-m", "--model", help="Model to use")
+@click.option("model_id", "-m", "--model", type=ModelType(), help="Model to use")
 @click.option(
     "_continue",
     "-c",
@@ -617,7 +631,7 @@ order by responses_fts.rank desc{limit}
     type=click.Path(readable=True, exists=True, dir_okay=False),
     help="Path to log database",
 )
-@click.option("-m", "--model", help="Filter by model or model alias")
+@click.option("-m", "--model", type=ModelType(), help="Filter by model or model alias")
 @click.option("-q", "--query", help="Search for logs matching this string")
 @click.option("-t", "--truncate", is_flag=True, help="Truncate long strings in output")
 @click.option(
@@ -818,7 +832,7 @@ def models_list(options):
 
 
 @models.command(name="default")
-@click.argument("model", required=False)
+@click.argument("model", required=False, type=ModelType())
 def models_default(model):
     "Show or set the default model"
     if not model:
@@ -913,7 +927,7 @@ def aliases_list(json_):
 
 @aliases.command(name="set")
 @click.argument("alias")
-@click.argument("model_id")
+@click.argument("model_id", type=ModelType())
 def aliases_set(alias, model_id):
     """
     Set an alias for a model
@@ -1051,7 +1065,7 @@ def uninstall(packages, yes):
     type=click.File("r"),
     help="File to embed",
 )
-@click.option("-m", "--model", help="Embedding model to use")
+@click.option("-m", "--model", type=ModelType(), help="Embedding model to use")
 @click.option("--store", is_flag=True, help="Store the text itself in the database")
 @click.option(
     "-d",
@@ -1180,7 +1194,7 @@ def embed(collection, id, input, model, store, database, content, metadata, form
     help="Additional databases to attach - specify alias and file path",
 )
 @click.option("--prefix", help="Prefix to add to the IDs", default="")
-@click.option("-m", "--model", help="Embedding model to use")
+@click.option("-m", "--model", type=ModelType(), help="Embedding model to use")
 @click.option("--store", is_flag=True, help="Store the text itself in the database")
 @click.option(
     "-d",
@@ -1405,7 +1419,7 @@ def embed_models_list():
 
 
 @embed_models.command(name="default")
-@click.argument("model", required=False)
+@click.argument("model", required=False, type=ModelType())
 @click.option(
     "--remove-default", is_flag=True, help="Reset to specifying no default model"
 )

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -975,7 +975,7 @@ def templates_show(name):
 
 
 @templates.command(name="edit")
-@click.argument("name")
+@click.argument("name", type=TemplateType())
 def templates_edit(name):
     "Edit the specified prompt template using the default $EDITOR"
     # First ensure it exists

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -90,7 +90,11 @@ class TemplateType(click.ParamType):
 
     def shell_complete(self, ctx, param, incomplete):
         template_names = get_templates().keys()
-        return [CompletionItem(name) for name in template_names]
+        return [
+            CompletionItem(name)
+            for name in template_names
+            if name.startswith(incomplete)
+        ]
 
 
 @cli.command(name="prompt")
@@ -961,7 +965,7 @@ def display_truncated(text):
 
 
 @templates.command(name="show")
-@click.argument("name")
+@click.argument("name", type=TemplateType())
 def templates_show(name):
     "Show the specified prompt template"
     template = load_template(name)


### PR DESCRIPTION
Together with click's Shell Completion support, this allows to auto-complete `llm -t <tab>` invocations.

This is an initial proof of concept. If you think this is the right thing to do, I can invest a little time to polish it. A few tasks I see as open:

* Check which other arguments would benefit from such treatment.
* Extend the documentation to include the autocomplete setup in the user guide.
* Fix auto-completion on the initial command. For example `llm <tab>` currently doesn't work.
* Performance is an issue, it's rather slow on my end.

For information how to set up the autocomplete here, see the official [Click Shell Completion documentation](https://click.palletsprojects.com/en/8.1.x/shell-completion/).