### PR TITLE
change type of cli "embed -c" to be STR not FILE

### DIFF
--- a/docs/help.md
+++ b/docs/help.md
@@ -480,7 +480,7 @@ Options:
   -m, --model TEXT                Embedding model to use
   --store                         Store the text itself in the database
   -d, --database FILE
-  -c, --content FILE              Content to embed
+  -c, --content TEXT              Content to embed
   --metadata TEXT                 JSON object metadata to store
   -f, --format [json|blob|base64|hex]
                                   Output format

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1040,7 +1040,6 @@ def uninstall(packages, yes):
     "-c",
     "--content",
     help="Content to embed",
-    type=click.Path(file_okay=True, allow_dash=False, dir_okay=False, writable=True),
 )
 @click.option(
     "--metadata",


### PR DESCRIPTION
The type of the "content" argument was erroneously set to be FILE with a "type=click.Path(...)" argument, which content is a string.