### PR TITLE
Use readline for command-line editing in chats

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -3,6 +3,13 @@ from click_default_group import DefaultGroup
 from dataclasses import asdict
 import io
 import json
+
+try:
+    import readline  # noqa: F401
+except ImportError:
+    # Readline is not built into Python on Windows
+    pass
+
 from llm import (
     Collection,
     Conversation,


### PR DESCRIPTION
Just importing the standard Python `readline` module allows editing with GNU readline keys. This is not explicitly documented in `click`, but is implied by their Changelog.

On Windows, the `readline` module is not standard. This could be fixed by using `pyreadline3` in that case, but that should be a separate change. This change ignores the failure to load `readline` on Windows.

The import ignores symbol unused error F401 from `ruff`, as that is by design. The `readline` module just needs importing to work.

No specific unit tests, as `click` doesn't process mocks in a way that uses `readline`.