### PR TITLE
Include `model_name` for example with extra-openai-models

### DIFF
--- a/docs/other-models.md
+++ b/docs/other-models.md
@@ -43,9 +43,10 @@ Let's say OpenAI have just released the `gpt-3.5-turbo-0613` model and you want 
 
 ```yaml
 - model_id: gpt-3.5-turbo-0613
+  model_name: gpt-3.5-turbo-0613
   aliases: ["0613"]
 ```
-The `model_id` is the identifier that will be recorded in the LLM logs. You can use this to specify the model, or you can optionally include a list of aliases for that model.
+The `model_id` is the identifier that will be recorded in the LLM logs. You can use this to specify the model, or you can optionally include a list of aliases for that model. Both the `model_name` and `model_id` should match the OpenAI identifier.
 
 If the model is a completion model (such as `gpt-3.5-turbo-instruct`) add `completion: true` to the configuration.
 


### PR DESCRIPTION
Without it I was getting `KeyError: 'model_name'` - see https://github.com/simonw/llm/issues/323#issuecomment-1796426430 for the final config for GPT-4 Turbo. 

```python
Traceback (most recent call last):
  File "/Users/mathew/.local/bin/llm", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/Users/mathew/.local/pipx/venvs/llm/lib/python3.11/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mathew/.local/pipx/venvs/llm/lib/python3.11/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/mathew/.local/pipx/venvs/llm/lib/python3.11/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mathew/.local/pipx/venvs/llm/lib/python3.11/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mathew/.local/pipx/venvs/llm/lib/python3.11/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mathew/.local/pipx/venvs/llm/lib/python3.11/site-packages/llm/cli.py", line 147, in prompt
    model_aliases = get_model_aliases()
                    ^^^^^^^^^^^^^^^^^^^
  File "/Users/mathew/.local/pipx/venvs/llm/lib/python3.11/site-packages/llm/__init__.py", line 134, in get_model_aliases
    for model_with_aliases in get_models_with_aliases():
                              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mathew/.local/pipx/venvs/llm/lib/python3.11/site-packages/llm/__init__.py", line 78, in get_models_with_aliases
    pm.hook.register_models(register=register)
  File "/Users/mathew/.local/pipx/venvs/llm/lib/python3.11/site-packages/pluggy/_hooks.py", line 493, in __call__
    return self._hookexec(self.name, self._hookimpls, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mathew/.local/pipx/venvs/llm/lib/python3.11/site-packages/pluggy/_manager.py", line 115, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mathew/.local/pipx/venvs/llm/lib/python3.11/site-packages/pluggy/_callers.py", line 113, in _multicall
    raise exception.with_traceback(exception.__traceback__)
  File "/Users/mathew/.local/pipx/venvs/llm/lib/python3.11/site-packages/pluggy/_callers.py", line 77, in _multicall
    res = hook_impl.function(*args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mathew/.local/pipx/venvs/llm/lib/python3.11/site-packages/llm/default_plugins/openai_models.py", line 48, in register_models
    model_name = extra_model["model_name"]
```