### PR TITLE
Cli short help arg (-h)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,10 @@ cat mycode.py | llm -s "Explain this code"
 
 ## Help
 
-For help, run:
+For help use `-h/--help` option:
 
-    llm --help
+    llm -h
 
-You can also use:
+You can also invoke using `python`:
 
     python -m llm --help

--- a/docs/help.md
+++ b/docs/help.md
@@ -55,8 +55,8 @@ Usage: llm [OPTIONS] COMMAND [ARGS]...
       llm 'Five outrageous names for a pet pelican'
 
 Options:
-  --version  Show the version and exit.
-  --help     Show this message and exit.
+  --version   Show the version and exit.
+  -h, --help  Show this message and exit.
 
 Commands:
   prompt*       Execute a prompt
@@ -99,7 +99,7 @@ Options:
   --cid, --conversation TEXT   Continue the conversation with the given ID.
   --key TEXT                   API key to use
   --save TEXT                  Save prompt with this template name
-  --help                       Show this message and exit.
+  -h, --help                   Show this message and exit.
 ```
 
 (help-chat)=
@@ -119,7 +119,7 @@ Options:
   -o, --option <TEXT TEXT>...  key/value options for the model
   --no-stream                  Do not stream output
   --key TEXT                   API key to use
-  --help                       Show this message and exit.
+  -h, --help                   Show this message and exit.
 ```
 
 (help-keys)=
@@ -130,7 +130,7 @@ Usage: llm keys [OPTIONS] COMMAND [ARGS]...
   Manage stored API keys for different models
 
 Options:
-  --help  Show this message and exit.
+  -h, --help  Show this message and exit.
 
 Commands:
   list*  List names of all stored keys
@@ -146,7 +146,7 @@ Usage: llm keys list [OPTIONS]
   List names of all stored keys
 
 Options:
-  --help  Show this message and exit.
+  -h, --help  Show this message and exit.
 ```
 
 (help-keys-path)=
@@ -157,7 +157,7 @@ Usage: llm keys path [OPTIONS]
   Output the path to the keys.json file
 
 Options:
-  --help  Show this message and exit.
+  -h, --help  Show this message and exit.
 ```
 
 (help-keys-set)=
@@ -174,7 +174,7 @@ Usage: llm keys set [OPTIONS] NAME
 
 Options:
   --value TEXT  Value to set
-  --help        Show this message and exit.
+  -h, --help    Show this message and exit.
 ```
 
 (help-logs)=
@@ -185,7 +185,7 @@ Usage: llm logs [OPTIONS] COMMAND [ARGS]...
   Tools for exploring logged prompts and responses
 
 Options:
-  --help  Show this message and exit.
+  -h, --help  Show this message and exit.
 
 Commands:
   list*   Show recent logged prompts and their responses
@@ -203,7 +203,7 @@ Usage: llm logs path [OPTIONS]
   Output the path to the logs.db file
 
 Options:
-  --help  Show this message and exit.
+  -h, --help  Show this message and exit.
 ```
 
 (help-logs-status)=
@@ -214,7 +214,7 @@ Usage: llm logs status [OPTIONS]
   Show current status of database logging
 
 Options:
-  --help  Show this message and exit.
+  -h, --help  Show this message and exit.
 ```
 
 (help-logs-on)=
@@ -225,7 +225,7 @@ Usage: llm logs on [OPTIONS]
   Turn on logging for all prompts
 
 Options:
-  --help  Show this message and exit.
+  -h, --help  Show this message and exit.
 ```
 
 (help-logs-off)=
@@ -236,7 +236,7 @@ Usage: llm logs off [OPTIONS]
   Turn off logging for all prompts
 
 Options:
-  --help  Show this message and exit.
+  -h, --help  Show this message and exit.
 ```
 
 (help-logs-list)=
@@ -256,7 +256,7 @@ Options:
   -c, --current               Show logs from the current conversation
   --cid, --conversation TEXT  Show logs for this conversation ID
   --json                      Output logs as JSON
-  --help                      Show this message and exit.
+  -h, --help                  Show this message and exit.
 ```
 
 (help-models)=
@@ -267,7 +267,7 @@ Usage: llm models [OPTIONS] COMMAND [ARGS]...
   Manage available models
 
 Options:
-  --help  Show this message and exit.
+  -h, --help  Show this message and exit.
 
 Commands:
   list*    List available models
@@ -282,8 +282,8 @@ Usage: llm models list [OPTIONS]
   List available models
 
 Options:
-  --options  Show options for each model, if available
-  --help     Show this message and exit.
+  --options   Show options for each model, if available
+  -h, --help  Show this message and exit.
 ```
 
 (help-models-default)=
@@ -294,7 +294,7 @@ Usage: llm models default [OPTIONS] [MODEL]
   Show or set the default model
 
 Options:
-  --help  Show this message and exit.
+  -h, --help  Show this message and exit.
 ```
 
 (help-templates)=
@@ -305,7 +305,7 @@ Usage: llm templates [OPTIONS] COMMAND [ARGS]...
   Manage stored prompt templates
 
 Options:
-  --help  Show this message and exit.
+  -h, --help  Show this message and exit.
 
 Commands:
   list*  List available prompt templates
@@ -322,7 +322,7 @@ Usage: llm templates list [OPTIONS]
   List available prompt templates
 
 Options:
-  --help  Show this message and exit.
+  -h, --help  Show this message and exit.
 ```
 
 (help-templates-show)=
@@ -333,7 +333,7 @@ Usage: llm templates show [OPTIONS] NAME
   Show the specified prompt template
 
 Options:
-  --help  Show this message and exit.
+  -h, --help  Show this message and exit.
 ```
 
 (help-templates-edit)=
@@ -344,7 +344,7 @@ Usage: llm templates edit [OPTIONS] NAME
   Edit the specified prompt template using the default $EDITOR
 
 Options:
-  --help  Show this message and exit.
+  -h, --help  Show this message and exit.
 ```
 
 (help-templates-path)=
@@ -355,7 +355,7 @@ Usage: llm templates path [OPTIONS]
   Output the path to the templates directory
 
 Options:
-  --help  Show this message and exit.
+  -h, --help  Show this message and exit.
 ```
 
 (help-aliases)=
@@ -366,7 +366,7 @@ Usage: llm aliases [OPTIONS] COMMAND [ARGS]...
   Manage model aliases
 
 Options:
-  --help  Show this message and exit.
+  -h, --help  Show this message and exit.
 
 Commands:
   list*   List current aliases
@@ -383,8 +383,8 @@ Usage: llm aliases list [OPTIONS]
   List current aliases
 
 Options:
-  --json  Output as JSON
-  --help  Show this message and exit.
+  --json      Output as JSON
+  -h, --help  Show this message and exit.
 ```
 
 (help-aliases-set)=
@@ -399,7 +399,7 @@ Usage: llm aliases set [OPTIONS] ALIAS MODEL_ID
       $ llm aliases set turbo gpt-3.5-turbo
 
 Options:
-  --help  Show this message and exit.
+  -h, --help  Show this message and exit.
 ```
 
 (help-aliases-remove)=
@@ -414,7 +414,7 @@ Usage: llm aliases remove [OPTIONS] ALIAS
       $ llm aliases remove turbo
 
 Options:
-  --help  Show this message and exit.
+  -h, --help  Show this message and exit.
 ```
 
 (help-aliases-path)=
@@ -425,7 +425,7 @@ Usage: llm aliases path [OPTIONS]
   Output the path to the aliases.json file
 
 Options:
-  --help  Show this message and exit.
+  -h, --help  Show this message and exit.
 ```
 
 (help-plugins)=
@@ -436,8 +436,8 @@ Usage: llm plugins [OPTIONS]
   List installed plugins
 
 Options:
-  --all   Include built-in default plugins
-  --help  Show this message and exit.
+  --all       Include built-in default plugins
+  -h, --help  Show this message and exit.
 ```
 
 (help-install)=
@@ -453,7 +453,7 @@ Options:
   --force-reinstall    Reinstall all packages even if they are already up-to-
                        date
   --no-cache-dir       Disable the cache
-  --help               Show this message and exit.
+  -h, --help           Show this message and exit.
 ```
 
 (help-uninstall)=
@@ -464,8 +464,8 @@ Usage: llm uninstall [OPTIONS] PACKAGES...
   Uninstall Python packages from the LLM environment
 
 Options:
-  -y, --yes  Don't ask for confirmation
-  --help     Show this message and exit.
+  -y, --yes   Don't ask for confirmation
+  -h, --help  Show this message and exit.
 ```
 
 (help-embed)=
@@ -485,7 +485,7 @@ Options:
   --metadata TEXT                 JSON object metadata to store
   -f, --format [json|blob|base64|hex]
                                   Output format
-  --help                          Show this message and exit.
+  -h, --help                      Show this message and exit.
 ```
 
 (help-embed-multi)=
@@ -521,7 +521,7 @@ Options:
   -m, --model TEXT             Embedding model to use
   --store                      Store the text itself in the database
   -d, --database FILE
-  --help                       Show this message and exit.
+  -h, --help                   Show this message and exit.
 ```
 
 (help-similar)=
@@ -545,7 +545,7 @@ Options:
   --binary              Treat input as binary data
   -n, --number INTEGER  Number of results to return
   -d, --database FILE
-  --help                Show this message and exit.
+  -h, --help            Show this message and exit.
 ```
 
 (help-embed-models)=
@@ -556,7 +556,7 @@ Usage: llm embed-models [OPTIONS] COMMAND [ARGS]...
   Manage available embedding models
 
 Options:
-  --help  Show this message and exit.
+  -h, --help  Show this message and exit.
 
 Commands:
   list*    List available embedding models
@@ -571,7 +571,7 @@ Usage: llm embed-models list [OPTIONS]
   List available embedding models
 
 Options:
-  --help  Show this message and exit.
+  -h, --help  Show this message and exit.
 ```
 
 (help-embed-models-default)=
@@ -583,7 +583,7 @@ Usage: llm embed-models default [OPTIONS] [MODEL]
 
 Options:
   --remove-default  Reset to specifying no default model
-  --help            Show this message and exit.
+  -h, --help        Show this message and exit.
 ```
 
 (help-collections)=
@@ -594,7 +594,7 @@ Usage: llm collections [OPTIONS] COMMAND [ARGS]...
   View and manage collections of embeddings
 
 Options:
-  --help  Show this message and exit.
+  -h, --help  Show this message and exit.
 
 Commands:
   list*   View a list of collections
@@ -610,7 +610,7 @@ Usage: llm collections path [OPTIONS]
   Output the path to the embeddings database
 
 Options:
-  --help  Show this message and exit.
+  -h, --help  Show this message and exit.
 ```
 
 (help-collections-list)=
@@ -623,7 +623,7 @@ Usage: llm collections list [OPTIONS]
 Options:
   -d, --database FILE  Path to embeddings database
   --json               Output as JSON
-  --help               Show this message and exit.
+  -h, --help           Show this message and exit.
 ```
 
 (help-collections-delete)=
@@ -639,7 +639,7 @@ Usage: llm collections delete [OPTIONS] COLLECTION
 
 Options:
   -d, --database FILE  Path to embeddings database
-  --help               Show this message and exit.
+  -h, --help           Show this message and exit.
 ```
 
 (help-openai)=
@@ -650,7 +650,7 @@ Usage: llm openai [OPTIONS] COMMAND [ARGS]...
   Commands for working directly with the OpenAI API
 
 Options:
-  --help  Show this message and exit.
+  -h, --help  Show this message and exit.
 
 Commands:
   models  List models available to you from the OpenAI API
@@ -666,6 +666,6 @@ Usage: llm openai models [OPTIONS]
 Options:
   --json      Output as JSON
   --key TEXT  OpenAI API key
-  --help      Show this message and exit.
+  -h, --help  Show this message and exit.
 ```
 <!-- [[[end]]] -->

--- a/docs/help.md
+++ b/docs/help.md
@@ -1,6 +1,6 @@
 # CLI reference
 
-This page lists the `--help` output for all of the `llm` commands.
+This page lists the `-h/--help` output for all of the `llm` commands.
 
 <!-- [[[cog
 from click.testing import CliRunner

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -40,6 +40,8 @@ import yaml
 
 warnings.simplefilter("ignore", ResourceWarning)
 
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+
 DEFAULT_MODEL = "gpt-3.5-turbo"
 DEFAULT_EMBEDDING_MODEL = "ada-002"
 
@@ -62,6 +64,7 @@ def _validate_metadata_json(ctx, param, value):
     cls=DefaultGroup,
     default="prompt",
     default_if_no_args=True,
+    context_settings=CONTEXT_SETTINGS
 )
 @click.version_option()
 def cli():


### PR DESCRIPTION
It is more convenient to use the `help` short counterpart `-h` for learning the `llm` tool interactively.

I've updated the docs as well (including autogenerated via `just cog`)