### PR TITLE
Workaround for litellm proxy -> ollama issue

### DIFF
--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -410,7 +410,8 @@ def combine_chunks(chunks: List[dict]) -> dict:
             if "role" in choice["delta"]:
                 role = choice["delta"]["role"]
             if "content" in choice["delta"]:
-                content += choice["delta"]["content"]
+                chunk = choice["delta"]["content"]
+                if chunk: content += chunk
             if choice.get("finish_reason") is not None:
                 finish_reason = choice["finish_reason"]
 


### PR DESCRIPTION
When streaming responses from a model served by ollama, through a litellm proxy that provides an OpenAI compatible API, the last chunk (i.e. choice["delta"]["content"]) of the streaming response will be set to None

This causes an exception to be thrown during the following, since None can't be appended to a string:
content += choice["delta"]["content"]

To avoid this, I simply added a check so that choice["delta"]["content"] is only appended to content if it's not None.