### PR TITLE
Fix typo and broken link for llm-gemini in directory

### DIFF
--- a/docs/plugins/directory.md
+++ b/docs/plugins/directory.md
@@ -17,7 +17,7 @@ These plugins all help you run LLMs directly on your own computer:
 These plugins can be used to interact with remotely hosted models via their API:
 
 - **[llm-mistral](https://github.com/simonw/llm-mistral)** adds support for [Mistral AI](https://mistral.ai/)'s language and embedding models.
-- **[llm-gemini](https://github.com/simonw/llm-gemini)** adds support for Google's [Gemina]([https://developers.generativeai.google/](https://ai.google.dev/docs)) models.
+- **[llm-gemini](https://github.com/simonw/llm-gemini)** adds support for Google's [Gemini](https://ai.google.dev/docs) models.
 - **[llm-claude](https://github.com/tomviner/llm-claude)** by Tom Viner adds support for Claude and Claude Instant by Anthropic.
 - **[llm-anyscale-endpoints](https://github.com/simonw/llm-anyscale-endpoints)** supports models hosted on the [Anyscale Endpoints](https://app.endpoints.anyscale.com/) platform, including Llama 2 70B.
 - **[llm-replicate](https://github.com/simonw/llm-replicate)** adds support for remote models hosted on [Replicate](https://replicate.com/), including Llama 2 from Meta AI.


### PR DESCRIPTION
Nothing major, just fixing a typo and broken link in the description of `llm-gemini` in the plugin directory.

EDIT: I hit the pencil icon on the top of the page to pull up GitHub not realizing it would mean the PR I created would be for the `stable` branch, oops! Feel free to incorporate this change however you want and close it afterwards.