### PR TITLE
Add `cchardet` to `install_requires` deps in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         "python-ulid",
         "setuptools",
         "pip",
+        "cchardet",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
```~ [ v21.5.0][☁️  (us-west-2)][⏱ 4s] ❯
(base)
llm keys set openai
Traceback (most recent call last):
  File "/Users/jgoldin/miniconda3/lib/python3.10/site-packages/aiohttp/client_reqrep.py", line 70, in <module>
    import cchardet as chardet
ModuleNotFoundError: No module named 'cchardet'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/jgoldin/miniconda3/bin/llm", line 5, in <module>
    from llm.cli import cli
  File "/Users/jgoldin/miniconda3/lib/python3.10/site-packages/llm/__init__.py", line 18, in <module>
    from .plugins import pm
  File "/Users/jgoldin/miniconda3/lib/python3.10/site-packages/llm/plugins.py", line 37, in <module>
    mod = importlib.import_module(plugin)
  File "/Users/jgoldin/miniconda3/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "/Users/jgoldin/miniconda3/lib/python3.10/site-packages/llm/default_plugins/openai_models.py", line 6, in <module>
    import openai
  File "/Users/jgoldin/miniconda3/lib/python3.10/site-packages/openai/__init__.py", line 19, in <module>
    from openai.api_resources import (
  File "/Users/jgoldin/miniconda3/lib/python3.10/site-packages/openai/api_resources/__init__.py", line 1, in <module>
    from openai.api_resources.audio import Audio  # noqa: F401
  File "/Users/jgoldin/miniconda3/lib/python3.10/site-packages/openai/api_resources/audio.py", line 4, in <module>
    from openai import api_requestor, util
  File "/Users/jgoldin/miniconda3/lib/python3.10/site-packages/openai/api_requestor.py", line 24, in <module>
    import aiohttp
  File "/Users/jgoldin/miniconda3/lib/python3.10/site-packages/aiohttp/__init__.py", line 6, in <module>
    from .client import (
  File "/Users/jgoldin/miniconda3/lib/python3.10/site-packages/aiohttp/client.py", line 59, in <module>
    from .client_reqrep import (
  File "/Users/jgoldin/miniconda3/lib/python3.10/site-packages/aiohttp/client_reqrep.py", line 72, in <module>
    import charset_normalizer as chardet  # type: ignore[no-redef]
  File "/Users/jgoldin/miniconda3/lib/python3.10/site-packages/charset_normalizer/__init__.py", line 23, in <module>
    from charset_normalizer.api import from_fp, from_path, from_bytes, normalize
  File "/Users/jgoldin/miniconda3/lib/python3.10/site-packages/charset_normalizer/api.py", line 10, in <module>
    from charset_normalizer.md import mess_ratio
  File "charset_normalizer/md.py", line 5, in <module>
ImportError: cannot import name 'COMMON_SAFE_ASCII_CHARACTERS' from 'charset_normalizer.constant' (/Users/jgoldin/miniconda3/lib/python3.10/site-packages/charset_normalizer/constant.py)```
```

Saw the above after a fresh install of `llm`. After `pip install cchardet`, it ran successfully.