### PR TITLE
Fixes file path tests on Windows

### DIFF
--- a/tests/test_embed_cli.py
+++ b/tests/test_embed_cli.py
@@ -5,7 +5,6 @@ import json
 import pathlib
 import pytest
 import sqlite_utils
-import sys
 from unittest.mock import ANY
 
 

--- a/tests/test_embed_cli.py
+++ b/tests/test_embed_cli.py
@@ -423,7 +423,6 @@ def multi_files(tmpdir):
     return db_path, tmpdir / "files"
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Expected to fail on Windows")
 @pytest.mark.parametrize("scenario", ("single", "multi"))
 def test_embed_multi_files(multi_files, scenario):
     db_path, files = multi_files
@@ -473,9 +472,9 @@ def test_embed_multi_files(multi_files, scenario):
         assert rows == [
             {"id": "file1.txt", "content": "hello world"},
             {"id": "file2.txt", "content": "goodbye world"},
-            {"id": "nested/more/three.txt", "content": "three"},
-            {"id": "nested/one.txt", "content": "one"},
-            {"id": "nested/two.txt", "content": "two"},
+            {"id": str(pathlib.Path("nested/more/three.txt")), "content": "three"},
+            {"id": str(pathlib.Path("nested/one.txt")), "content": "one"},
+            {"id": str(pathlib.Path("nested/two.txt")), "content": "two"},
         ]
     else:
         assert rows == [

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -3,10 +3,8 @@ import json
 from llm.cli import cli
 import pathlib
 import pytest
-import sys
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Expected to fail on Windows")
 @pytest.mark.parametrize("env", ({}, {"LLM_USER_PATH": "/tmp/llm-keys-test"}))
 def test_keys_in_user_path(monkeypatch, env, user_path):
     for key, value in env.items():
@@ -18,10 +16,10 @@ def test_keys_in_user_path(monkeypatch, env, user_path):
         expected = env["LLM_USER_PATH"] + "/keys.json"
     else:
         expected = user_path + "/keys.json"
-    assert result.output.strip() == expected
+    assert pathlib.Path(result.output.strip()) == pathlib.Path(expected)
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Expected to fail on Windows")
+# @pytest.mark.xfail(sys.platform == "win32", reason="Expected to fail on Windows")
 def test_keys_set(monkeypatch, tmpdir):
     user_path = tmpdir / "user/keys"
     monkeypatch.setenv("LLM_USER_PATH", str(user_path))

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -3,6 +3,7 @@ import json
 from llm.cli import cli
 import pathlib
 import pytest
+import sys
 
 
 @pytest.mark.parametrize("env", ({}, {"LLM_USER_PATH": "/tmp/llm-keys-test"}))

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -19,7 +19,7 @@ def test_keys_in_user_path(monkeypatch, env, user_path):
     assert pathlib.Path(result.output.strip()) == pathlib.Path(expected)
 
 
-# @pytest.mark.xfail(sys.platform == "win32", reason="Expected to fail on Windows")
+@pytest.mark.xfail(sys.platform == "win32", reason="Expected to fail on Windows")
 def test_keys_set(monkeypatch, tmpdir):
     user_path = tmpdir / "user/keys"
     monkeypatch.setenv("LLM_USER_PATH", str(user_path))

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -9,7 +9,6 @@ import pathlib
 import pytest
 import re
 import sqlite_utils
-import sys
 from ulid import ULID
 from unittest import mock
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -5,6 +5,7 @@ from llm.cli import cli
 from llm.migrations import migrate
 import json
 import os
+import pathlib
 import pytest
 import re
 import sqlite_utils
@@ -97,7 +98,6 @@ def test_logs_json(n, log_path):
     assert len(logs) == expected_length
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Expected to fail on Windows")
 @pytest.mark.parametrize("env", ({}, {"LLM_USER_PATH": "/tmp/llm-user-path"}))
 def test_logs_path(monkeypatch, env, user_path):
     for key, value in env.items():
@@ -109,7 +109,7 @@ def test_logs_path(monkeypatch, env, user_path):
         expected = env["LLM_USER_PATH"] + "/logs.db"
     else:
         expected = str(user_path) + "/logs.db"
-    assert result.output.strip() == expected
+    assert pathlib.Path(result.output.strip()) == pathlib.Path(expected)
 
 
 @pytest.mark.parametrize("model", ("davinci", "curie"))


### PR DESCRIPTION
This PR fixes the easier issues with #409, but does not completely resolve it.  

The `\n` vs `\r\n` is likely a red herring, as Python does a lot of newline normalization for you.

As noted in the commit message, this leaves two areas unresolved:
* File permissions in `tests/test_keys::test_keys_set`. Windows handles file permissions differently than -nix OSes, and i don't know the fix to this offhand. I may poke at this next
* `llm chat` issues. I'm not deeply familiar with `pyreadline3`, but even on their landing page they note "It is not complete." It's possible that on Windows you can't bind `\\e[D: backward-char`, or that the mechanism to do so is different on Windows.