### PR TITLE
use the AzureOpenAI class for the azure api

### DIFF
--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -345,6 +345,9 @@ class Chat(Model):
             kwargs["default_headers"] = self.headers
         if os.environ.get("LLM_OPENAI_SHOW_RESPONSES"):
             kwargs["http_client"] = logging_client()
+        if self.api_type == 'azure':
+            key_env_var = "AZURE_OPENAI_API_KEY"
+            return openai.AzureOpenAI(api_version=self.api_version, azure_endpoint=self.api_base)
         return openai.OpenAI(**kwargs)
 
     def build_kwargs(self, prompt):


### PR DESCRIPTION
use the AzureOpenAI class for the azure api, because since openai>1.0…0 the openai python package uses a different class when using the azure openai api

this is just a preliminary suggestion which makes the current llm version work with azure - subject to feedback and change.