### PR TITLE
Added support for passing conversation history as a JSON blob to prompt command

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1,3 +1,5 @@
+import os
+
 import click
 from click_default_group import DefaultGroup
 from dataclasses import asdict
@@ -20,7 +22,7 @@ from llm import (
     get_models_with_aliases,
     user_dir,
     set_alias,
-    remove_alias,
+    remove_alias, Prompt,
 )
 
 from .migrations import migrate
@@ -120,6 +122,11 @@ def cli():
     "--conversation",
     help="Continue the conversation with the given ID.",
 )
+@click.option(
+    "conversation_json",
+    "--conversation-json",
+    help="Continue the conversation whose history is in the given JSON blob",
+)
 @click.option("--key", help="API key to use")
 @click.option("--save", help="Save prompt with this template name")
 def prompt(
@@ -134,6 +141,7 @@ def prompt(
     log,
     _continue,
     conversation_id,
+    conversation_json,
     key,
     save,
 ):
@@ -144,6 +152,9 @@ def prompt(
     """
     if log and no_log:
         raise click.ClickException("--log and --no-log are mutually exclusive")
+
+    if conversation_json and (conversation_id or _continue):
+        raise click.ClickException("--conversation-json cannot be used with --cid or --continue")
 
     model_aliases = get_model_aliases()
 
@@ -243,6 +254,38 @@ def prompt(
     # Provide the API key, if one is needed and has been provided
     if model.needs_key:
         model.key = get_key(key, model.needs_key, model.key_env_var)
+
+    if conversation_json:
+        # Load response history from JSON
+        try:
+            history_data = json.loads(conversation_json)
+            if not all('prompt' in item and 'response' in item for item in history_data):
+                raise ValueError("Each item in the JSON must have a 'prompt' and 'response' key")
+        except json.JSONDecodeError as e:
+            raise click.ClickException(f"Invalid JSON format: {e}")
+        except ValueError as e:
+            raise click.ClickException(str(e))
+
+        # Create a new conversation object
+        conversation = Conversation(model=model)
+        for item in history_data:
+            resp = Response(
+                model=model,
+                prompt=Prompt(
+                    prompt=item["prompt"],
+                    system=system,
+                    model=model,
+                    options=model.Options(**item.get("options", {})),
+                ),
+                stream=False,
+            )
+            if "id" in item:
+                resp.id = item["id"]
+            resp._prompt_json = item.get("prompt_json", None)
+            resp.response_json = item.get("response_json", None)
+            resp._done = item.get("done", True)
+            resp._chunks = [item["response"]]
+            conversation.responses.append(resp)
 
     if conversation:
         # To ensure it can see the key


### PR DESCRIPTION
Implemented a new `--conversation-json` flag that allows users to supply a JSON-formatted conversation history when using the prompt command. This enhancement enables better interoperability.


## Usage

Users can now pass conversation history in the form of a JSON string using the `--conversation-json` parameter.

Example command:
```shell
llm "What did you say?" -s "You are an AI assistant" --conversation-json "[{\"prompt\": \"Hi\", \"response\": \"Hello, how can I help you?\"}]"
```

## Goal

The primary goal of this feature is to facilitate better integration between `llm` and other programs that handle conversation histories.

By allowing an external entity to manage the conversation state, this feature opens up new possibilities for developers to create more complex solutions which can leverage this CLI tool.

## Still Needs
- [ ] Tests
- [ ] Documentation