### PR TITLE
Fix support for Python template syntax

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -92,6 +92,8 @@ prompt: >
 ```
 The `prompt: >` causes the following indented text to be treated as a single string, with newlines collapsed to spaces. Use `prompt: |` to preserve newlines.
 
+Strings in `prompt` and `system` use the Python `string.Template` [syntax](https://docs.python.org/3/library/string.html#template-strings). This means you can escape dollar signs by doubling them, or use curly braces to put placeholders inside words.
+
 Running that with `llm -t steampunk` against GPT-4 (via [strip-tags](https://github.com/simonw/strip-tags) to remove HTML tags from the input and minify whitespace):
 ```bash
 curl -s 'https://til.simonwillison.net/macos/imovie-slides-and-audio' | \

--- a/llm/templates.py
+++ b/llm/templates.py
@@ -41,17 +41,10 @@ class Template(BaseModel):
             return text
         # Confirm all variables in text are provided
         string_template = string.Template(text)
-        vars = cls.extract_vars(string_template)
+        vars = string_template.get_identifiers()
         missing = [p for p in vars if p not in params]
         if missing:
             raise cls.MissingVariables(
                 "Missing variables: {}".format(", ".join(missing))
             )
         return string_template.substitute(**params)
-
-    @staticmethod
-    def extract_vars(string_template: string.Template) -> List[str]:
-        return [
-            match.group("named")
-            for match in string_template.pattern.finditer(string_template.template)
-        ]

--- a/llm/templates.py
+++ b/llm/templates.py
@@ -51,7 +51,7 @@ class Template(BaseModel):
         return string_template.substitute(**params)
 
     @classmethod
-    def extract_identifiers(cls, template: string.Template) -> list[str]:
+    def extract_identifiers(cls, template: string.Template) -> List[str]:
         (major, minor, patchlevel) = platform.python_version_tuple()
         if int(major) >= 3 and int(minor) >= 11:
             # Added in Python 3.11 

--- a/llm/templates.py
+++ b/llm/templates.py
@@ -54,7 +54,7 @@ class Template(BaseModel):
     def extract_identifiers(cls, template: string.Template) -> List[str]:
         (major, minor, patchlevel) = platform.python_version_tuple()
         if int(major) >= 3 and int(minor) >= 11:
-            # Added in Python 3.11 
+            # Added in Python 3.11
             return template.get_identifiers()
         else:
             result = set()

--- a/llm/templates.py
+++ b/llm/templates.py
@@ -55,7 +55,7 @@ class Template(BaseModel):
         (major, minor, patchlevel) = platform.python_version_tuple()
         if int(major) >= 3 and int(minor) >= 11:
             # Added in Python 3.11
-            return template.get_identifiers()
+            return sort(template.get_identifiers()) # type: ignore
         else:
             result = set()
             # Adapted from source at https://github.com/python/cpython/blob/86e5e063aba76a7f4fc58f7d06b17b0a4730fd8e/Lib/string.py#L157
@@ -63,4 +63,4 @@ class Template(BaseModel):
                 named = match.group("named") or match.group("braced")
                 if named is not None:
                     result.add(match.group("named"))
-            return list(result)
+            return sort(list(result))

--- a/llm/templates.py
+++ b/llm/templates.py
@@ -54,13 +54,17 @@ class Template(BaseModel):
     def extract_identifiers(cls, template: string.Template) -> List[str]:
         (major, minor, patchlevel) = platform.python_version_tuple()
         if int(major) >= 3 and int(minor) >= 11:
+            result = template.get_identifiers() # type: ignore
+            result.sort()
             # Added in Python 3.11
-            return sort(template.get_identifiers()) # type: ignore
+            return result
         else:
             result = set()
             # Adapted from source at https://github.com/python/cpython/blob/86e5e063aba76a7f4fc58f7d06b17b0a4730fd8e/Lib/string.py#L157
             for match in template.pattern.finditer(template.template):
                 named = match.group("named") or match.group("braced")
                 if named is not None:
-                    result.add(match.group("named"))
-            return sort(list(result))
+                    result.add(named)
+            result = list(result)
+            result.sort()
+            return result

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -13,6 +13,7 @@ import yaml
     (
         ("$$test", None, None, {}, "$test", None, None),
         ("S: $input", None, None, {}, "S: input", None, None),
+        ("S: ${input}", None, None, {}, "S: input", None, None),
         ("S: $input", "system", None, {}, "S: input", "system", None),
         ("No vars", None, None, {}, "No vars", None, None),
         ("$one and $two", None, None, {}, None, None, "Missing variables: one, two"),

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -11,6 +11,7 @@ import yaml
 @pytest.mark.parametrize(
     "prompt,system,defaults,params,expected_prompt,expected_system,expected_error",
     (
+        ("$$test", None, None, {}, "$test", None, None),
         ("S: $input", None, None, {}, "S: input", None, None),
         ("S: $input", "system", None, {}, "S: input", "system", None),
         ("No vars", None, None, {}, "No vars", None, None),


### PR DESCRIPTION
All dollar signs in a template's `prompt` or `system` values are interpreted as introducing `placeholders`. The documentation for `string.Template` says that doubling a dollar sign should escape it.

Due to the custom implementation of `Template.extract_vars`, this did not work, as it extracted a double dollar sign as an identifier with an empty named group. By using `string.Template.get_identifiers()` instead, this now works. Additionally, this automatically adds support for parenthesized identifiers as well.
