### PR TITLE
Add support for options in templates

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -218,6 +218,12 @@ def prompt(
             raise click.ClickException(str(ex))
         if model_id is None and template_obj.model:
             model_id = template_obj.model
+        if template_obj.options:
+            merged_options = template_obj.options.copy()
+            if options:
+                for key, value in options:
+                    merged_options[key] = value
+            options = tuple((key, str(value)) for key, value in merged_options.items())
 
     conversation = None
     if conversation_id or _continue:
@@ -366,6 +372,12 @@ def chat(
         template_obj = load_template(template)
         if model_id is None and template_obj.model:
             model_id = template_obj.model
+        if template_obj.options:
+            merged_options = template_obj.options.copy()
+            if options:
+                for key, value in options:
+                    merged_options[key] = value
+            options = tuple((key, str(value)) for key, value in merged_options.items())
 
     # Figure out which model we are using
     if model_id is None:

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -178,9 +178,7 @@ def prompt(
             if var:
                 disallowed_options.append(option)
         if disallowed_options:
-            raise click.ClickException(
-                "--save cannot be used with {}".format(", ".join(disallowed_options))
-            )
+            raise click.ClickException("--save cannot be used with {}".format(", ".join(disallowed_options)))
         path = template_dir() / f"{save}.yaml"
         to_save = {}
         if model_id:
@@ -219,11 +217,7 @@ def prompt(
         if model_id is None and template_obj.model:
             model_id = template_obj.model
         if template_obj.options:
-            merged_options = template_obj.options.copy()
-            if options:
-                for key, value in options:
-                    merged_options[key] = value
-            options = tuple((key, str(value)) for key, value in merged_options.items())
+            options = template_obj.evaluate_options(options)
 
     conversation = None
     if conversation_id or _continue:
@@ -259,11 +253,7 @@ def prompt(
     if options:
         # Validate with pydantic
         try:
-            validated_options = dict(
-                (key, value)
-                for key, value in model.Options(**dict(options))
-                if value is not None
-            )
+            validated_options = dict((key, value) for key, value in model.Options(**dict(options)) if value is not None)
         except pydantic.ValidationError as ex:
             raise click.ClickException(render_errors(ex.errors()))
 
@@ -373,11 +363,7 @@ def chat(
         if model_id is None and template_obj.model:
             model_id = template_obj.model
         if template_obj.options:
-            merged_options = template_obj.options.copy()
-            if options:
-                for key, value in options:
-                    merged_options[key] = value
-            options = tuple((key, str(value)) for key, value in merged_options.items())
+            options = template_obj.evaluate_options(options)
 
     # Figure out which model we are using
     if model_id is None:
@@ -407,11 +393,7 @@ def chat(
     validated_options = {}
     if options:
         try:
-            validated_options = dict(
-                (key, value)
-                for key, value in model.Options(**dict(options))
-                if value is not None
-            )
+            validated_options = dict((key, value) for key, value in model.Options(**dict(options)) if value is not None)
         except pydantic.ValidationError as ex:
             raise click.ClickException(render_errors(ex.errors()))
 
@@ -471,14 +453,10 @@ def load_conversation(conversation_id: Optional[str]) -> Optional[Conversation]:
     try:
         row = cast(sqlite_utils.db.Table, db["conversations"]).get(conversation_id)
     except sqlite_utils.db.NotFoundError:
-        raise click.ClickException(
-            "No conversation found with id={}".format(conversation_id)
-        )
+        raise click.ClickException("No conversation found with id={}".format(conversation_id))
     # Inflate that conversation
     conversation = Conversation.from_row(row)
-    for response in db["responses"].rows_where(
-        "conversation_id = ?", [conversation_id]
-    ):
+    for response in db["responses"].rows_where("conversation_id = ?", [conversation_id]):
         conversation.responses.append(Response.from_row(response))
     return conversation
 
@@ -569,9 +547,7 @@ def logs_status():
     click.echo("Found log database at {}".format(path))
     click.echo("Number of conversations logged:\t{}".format(db["conversations"].count))
     click.echo("Number of responses logged:\t{}".format(db["responses"].count))
-    click.echo(
-        "Database file size: \t\t{}".format(_human_readable_size(path.stat().st_size))
-    )
+    click.echo("Database file size: \t\t{}".format(_human_readable_size(path.stat().st_size)))
 
 
 @logs.command(name="on")
@@ -684,11 +660,7 @@ def logs_list(
 
     if current_conversation:
         try:
-            conversation_id = next(
-                db.query(
-                    "select conversation_id from responses order by id desc limit 1"
-                )
-            )["conversation_id"]
+            conversation_id = next(db.query("select conversation_id from responses order by id desc limit 1"))["conversation_id"]
         except StopIteration:
             # No conversations yet
             raise click.ClickException("No conversations found")
@@ -770,16 +742,8 @@ def logs_list(
             click.echo(
                 "# {}{}\n{}".format(
                     row["datetime_utc"].split(".")[0],
-                    (
-                        "    conversation: {}".format(row["conversation_id"])
-                        if should_show_conversation
-                        else ""
-                    ),
-                    (
-                        "\nModel: **{}**\n".format(row["model"])
-                        if should_show_conversation
-                        else ""
-                    ),
+                    ("    conversation: {}".format(row["conversation_id"]) if should_show_conversation else ""),
+                    ("\nModel: **{}**\n".format(row["model"]) if should_show_conversation else ""),
                 )
             )
             # In conversation log mode only show it for the first one
@@ -811,9 +775,7 @@ _type_lookup = {
 
 
 @models.command(name="list")
-@click.option(
-    "--options", is_flag=True, help="Show options for each model, if available"
-)
+@click.option("--options", is_flag=True, help="Show options for each model, if available")
 def models_list(options):
     "List available models"
     models_that_have_shown_options = set()
@@ -823,25 +785,14 @@ def models_list(options):
             extra = " (aliases: {})".format(", ".join(model_with_aliases.aliases))
         output = str(model_with_aliases.model) + extra
         if options and model_with_aliases.model.Options.schema()["properties"]:
-            for name, field in model_with_aliases.model.Options.schema()[
-                "properties"
-            ].items():
+            for name, field in model_with_aliases.model.Options.schema()["properties"].items():
                 any_of = field.get("anyOf")
                 if any_of is None:
                     any_of = [{"type": field["type"]}]
-                types = ", ".join(
-                    [
-                        _type_lookup.get(item["type"], item["type"])
-                        for item in any_of
-                        if item["type"] != "null"
-                    ]
-                )
+                types = ", ".join([_type_lookup.get(item["type"], item["type"]) for item in any_of if item["type"] != "null"])
                 bits = ["\n  ", name, ": ", types]
                 description = field.get("description", "")
-                if description and (
-                    model_with_aliases.model.__class__
-                    not in models_that_have_shown_options
-                ):
+                if description and (model_with_aliases.model.__class__ not in models_that_have_shown_options):
                     wrapped = textwrap.wrap(description, 70)
                     bits.append("\n    ")
                     bits.extend("\n    ".join(wrapped))
@@ -922,18 +873,12 @@ def aliases_list(json_):
         if alias != embedding_model.model_id:
             to_output.append((alias, embedding_model.model_id, "embedding"))
     if json_:
-        click.echo(
-            json.dumps({key: value for key, value, type_ in to_output}, indent=4)
-        )
+        click.echo(json.dumps({key: value for key, value, type_ in to_output}, indent=4))
         return
     max_alias_length = max(len(a) for a, _, _ in to_output)
     fmt = "{alias:<" + str(max_alias_length) + "} : {model_id}{type_}"
     for alias, model_id, type_ in to_output:
-        click.echo(
-            fmt.format(
-                alias=alias, model_id=model_id, type_=f" ({type_})" if type_ else ""
-            )
-        )
+        click.echo(fmt.format(alias=alias, model_id=model_id, type_=f" ({type_})" if type_ else ""))
 
 
 @aliases.command(name="set")
@@ -1024,9 +969,7 @@ def templates_path():
 
 @cli.command()
 @click.argument("packages", nargs=-1, required=False)
-@click.option(
-    "-U", "--upgrade", is_flag=True, help="Upgrade packages to latest version"
-)
+@click.option("-U", "--upgrade", is_flag=True, help="Upgrade packages to latest version")
 @click.option(
     "-e",
     "--editable",
@@ -1102,9 +1045,7 @@ def uninstall(packages, yes):
     type=click.Choice(["json", "blob", "base64", "hex"]),
     help="Output format",
 )
-def embed(
-    collection, id, input, model, store, database, content, binary, metadata, format_
-):
+def embed(collection, id, input, model, store, database, content, binary, metadata, format_):
     """Embed text and store or return the result"""
     if collection and not id:
         raise click.ClickException("Must provide both collection and id")
@@ -1132,9 +1073,7 @@ def embed(
             if not model:
                 model = get_default_embedding_model()
                 if model is None:
-                    raise click.ClickException(
-                        "You need to specify an embedding model (no default model is set)"
-                    )
+                    raise click.ClickException("You need to specify an embedding model (no default model is set)")
             collection_obj = Collection(collection, db=db, model_id=model)
             model_obj = collection_obj.model()
 
@@ -1144,9 +1083,7 @@ def embed(
         try:
             model_obj = get_embedding_model(model)
         except UnknownModelError:
-            raise click.ClickException(
-                "You need to specify an embedding model (no default model is set)"
-            )
+            raise click.ClickException("You need to specify an embedding model (no default model is set)")
 
     show_output = True
     if collection and (format_ is None):
@@ -1214,9 +1151,7 @@ def embed(
     multiple=True,
     help="Additional databases to attach - specify alias and file path",
 )
-@click.option(
-    "--batch-size", type=int, help="Batch size to use when running embeddings"
-)
+@click.option("--batch-size", type=int, help="Batch size to use when running embeddings")
 @click.option("--prefix", help="Prefix to add to the IDs", default="")
 @click.option("-m", "--model", help="Embedding model to use")
 @click.option("--store", is_flag=True, help="Store the text itself in the database")
@@ -1266,9 +1201,7 @@ def embed_multi(
 
     if files:
         if input_path or sql or format:
-            raise click.UsageError(
-                "Cannot use --files with --sql, input path or --format"
-            )
+            raise click.UsageError("Cannot use --files with --sql, input path or --format")
 
     if database:
         db = sqlite_utils.Database(database)
@@ -1279,13 +1212,9 @@ def embed_multi(
         db.attach(alias, attach_path)
 
     try:
-        collection_obj = Collection(
-            collection, db=db, model_id=model or get_default_embedding_model()
-        )
+        collection_obj = Collection(collection, db=db, model_id=model or get_default_embedding_model())
     except ValueError:
-        raise click.ClickException(
-            "You need to specify an embedding model (no default model is set)"
-        )
+        raise click.ClickException("You need to specify an embedding model (no default model is set)")
 
     expected_length = None
     if files:
@@ -1345,17 +1274,11 @@ def embed_multi(
                     for _ in load_rows(fp):
                         expected_length += 1
 
-            rows = load_rows(
-                open(input_path, "rb")
-                if input_path != "-"
-                else io.BufferedReader(sys.stdin.buffer)
-            )
+            rows = load_rows(open(input_path, "rb") if input_path != "-" else io.BufferedReader(sys.stdin.buffer))
         except json.JSONDecodeError as ex:
             raise click.ClickException(str(ex))
 
-    with click.progressbar(
-        rows, label="Embedding", show_percent=True, length=expected_length
-    ) as rows:
+    with click.progressbar(rows, label="Embedding", show_percent=True, length=expected_length) as rows:
 
         def tuples() -> Iterable[Tuple[str, Union[bytes, str]]]:
             for row in rows:
@@ -1383,9 +1306,7 @@ def embed_multi(
 )
 @click.option("-c", "--content", help="Content to embed for comparison")
 @click.option("--binary", is_flag=True, help="Treat input as binary data")
-@click.option(
-    "-n", "--number", type=int, default=10, help="Number of results to return"
-)
+@click.option("-n", "--number", type=int, default=10, help="Number of results to return")
 @click.option(
     "-d",
     "--database",
@@ -1469,9 +1390,7 @@ def embed_models_list():
 
 @embed_models.command(name="default")
 @click.argument("model", required=False)
-@click.option(
-    "--remove-default", is_flag=True, help="Reset to specifying no default model"
-)
+@click.option("--remove-default", is_flag=True, help="Reset to specifying no default model")
 def embed_models_default(model, remove_default):
     "Show or set the default embedding model"
     if not model and not remove_default:
@@ -1540,11 +1459,7 @@ def embed_db_collections(database, json_):
     else:
         for row in rows:
             click.echo("{}: {}".format(row["name"], row["model"]))
-            click.echo(
-                "  {} embedding{}".format(
-                    row["num_embeddings"], "s" if row["num_embeddings"] != 1 else ""
-                )
-            )
+            click.echo("  {} embedding{}".format(row["num_embeddings"], "s" if row["num_embeddings"] != 1 else ""))
 
 
 @collections.command(name="delete")
@@ -1646,9 +1561,7 @@ def get_history(chat_id):
             chat_id = last_row[0].get("chat_id") or last_row[0].get("id")
         else:  # Database is empty
             return None, []
-    rows = db["logs"].rows_where(
-        "id = ? or chat_id = ?", [chat_id, chat_id], order_by="id"
-    )
+    rows = db["logs"].rows_where("id = ? or chat_id = ?", [chat_id, chat_id], order_by="id")
     return chat_id, rows
 
 

--- a/llm/templates.py
+++ b/llm/templates.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel
 import string
-from typing import Optional, Any, Dict, List, Tuple
+from typing import Optional, Any, Dict, List, Tuple, Union
 
 
 class Template(BaseModel):
@@ -9,6 +9,7 @@ class Template(BaseModel):
     system: Optional[str] = None
     model: Optional[str] = None
     defaults: Optional[Dict[str, Any]] = None
+    options: Optional[Dict[str, Union[float, int, str, bool]]] = None
 
     class Config:
         extra = "forbid"

--- a/llm/templates.py
+++ b/llm/templates.py
@@ -17,7 +17,9 @@ class Template(BaseModel):
     class MissingVariables(Exception):
         pass
 
-    def evaluate(self, input: str, params: Optional[Dict[str, Any]] = None) -> Tuple[Optional[str], Optional[str]]:
+    def evaluate(
+        self, input: str, params: Optional[Dict[str, Any]] = None
+    ) -> Tuple[Optional[str], Optional[str]]:
         params = params or {}
         params["input"] = input
         if self.defaults:
@@ -34,7 +36,9 @@ class Template(BaseModel):
             system = self.interpolate(self.system, params)
         return prompt, system
 
-    def evaluate_options(self, options=Optional[Tuple[Tuple[str, Any]]]) -> Tuple[Tuple[str, Any]]:
+    def evaluate_options(
+        self, options=Optional[Tuple[Tuple[str, Any]]]
+    ) -> Tuple[Tuple[str, Any]]:
         ret = {}
         if self.options:
             ret.update(self.options)
@@ -51,9 +55,14 @@ class Template(BaseModel):
         vars = cls.extract_vars(string_template)
         missing = [p for p in vars if p not in params]
         if missing:
-            raise cls.MissingVariables("Missing variables: {}".format(", ".join(missing)))
+            raise cls.MissingVariables(
+                "Missing variables: {}".format(", ".join(missing))
+            )
         return string_template.substitute(**params)
 
     @staticmethod
     def extract_vars(string_template: string.Template) -> List[str]:
-        return [match.group("named") for match in string_template.pattern.finditer(string_template.template)]
+        return [
+            match.group("named")
+            for match in string_template.pattern.finditer(string_template.template)
+        ]

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -9,18 +9,28 @@ import yaml
 
 
 @pytest.mark.parametrize(
-    "prompt,system,defaults,params,expected_prompt,expected_system,expected_error",
+    "prompt,system,defaults,options,params,expected_prompt,expected_system,expected_error",
     (
-        ("S: $input", None, None, {}, "S: input", None, None),
-        ("S: $input", "system", None, {}, "S: input", "system", None),
-        ("No vars", None, None, {}, "No vars", None, None),
-        ("$one and $two", None, None, {}, None, None, "Missing variables: one, two"),
-        ("$one and $two", None, None, {"one": 1, "two": 2}, "1 and 2", None, None),
-        ("$one and $two", None, {"one": 1}, {"two": 2}, "1 and 2", None, None),
+        ("S: $input", None, None, {}, {}, "S: input", None, None),
+        ("S: $input", "system", None, {}, {}, "S: input", "system", None),
+        ("No vars", None, None, {}, {}, "No vars", None, None),
+        (
+            "$one and $two",
+            None,
+            None,
+            {},
+            {},
+            None,
+            None,
+            "Missing variables: one, two",
+        ),
+        ("$one and $two", None, None, {}, {"one": 1, "two": 2}, "1 and 2", None, None),
+        ("$one and $two", None, {"one": 1}, {}, {"two": 2}, "1 and 2", None, None),
         (
             "$one and $two",
             None,
             {"one": 99},
+            {},
             {"one": 1, "two": 2},
             "1 and 2",
             None,
@@ -29,9 +39,18 @@ import yaml
     ),
 )
 def test_template_evaluate(
-    prompt, system, defaults, params, expected_prompt, expected_system, expected_error
+    prompt,
+    system,
+    defaults,
+    options,
+    params,
+    expected_prompt,
+    expected_system,
+    expected_error,
 ):
-    t = Template(name="t", prompt=prompt, system=system, defaults=defaults)
+    t = Template(
+        name="t", prompt=prompt, system=system, defaults=defaults, options=options
+    )
     if expected_error:
         with pytest.raises(Template.MissingVariables) as ex:
             prompt, system = t.evaluate("input", params)


### PR DESCRIPTION
I discovered that I couldn't set up options for templates. Until now I just made aliases to combine templates with options, but I'd rather have it stored with the template. I saw that someone else ran into this as well (#308). So here's my attempt on implementing it. Options can be passed like this per template:
```yaml
options:
  temperature: 0.2
  # more options key: value
# the rest of the template, e.g. system: ...
# ...
```

Is this something that could be implemented?