### PR TITLE
Fix logprobs error

### DIFF
--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -427,7 +427,7 @@ def combine_chunks(chunks: List) -> dict:
 
     for item in chunks:
         for choice in item.choices:
-            if choice.logprobs and hasattr(choice.logprobs, "top_logprobs"):
+            if hasattr(choice, 'logprobs') and choice.logprobs and hasattr(choice.logprobs, "top_logprobs"):
                 logprobs.append(
                     {
                         "text": choice.text if hasattr(choice, "text") else None,


### PR DESCRIPTION
When I use some OpenAI-compatible LLM plugins, this kind of error occurs because some APIs do not support this parameter `logprobs`. However, when making the judgment here, it seems that the existence of the parameter is not correctly verified.

Reproducing the error 
<img width="685" alt="image" src="https://github.com/simonw/llm/assets/3949397/f7113029-25f3-4fda-81a5-6447001e47d8">
