### PR TITLE
enable $ without template variables in system prompts

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -27,9 +27,9 @@ llm --system 'Summarize this text in the voice of $voice' \
   --model gpt-4 -p voice GlaDOS --save summarize
 ```
 
-To use `$` characters that don't refer to a template variable, escape them with another `$`:
+To use `$` characters in strings that look like a template variable but aren't, escape them with another `$`:
 ```bash
-llm 'Summarize this and add a $$ at the end: $input' --save summarize
+llm 'Replace all instances of $$replace_me with the string "$ dollars" in this text: $input' --save replace
 ```
 ## Using a template
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -26,6 +26,11 @@ You can also save default parameters:
 llm --system 'Summarize this text in the voice of $voice' \
   --model gpt-4 -p voice GlaDOS --save summarize
 ```
+
+To use `$` characters that don't refer to a template variable, escape them with another `$`:
+```bash
+llm 'Summarize this and add a $$ at the end: $input' --save summarize
+```
 ## Using a template
 
 You can execute a named template using the `-t/--template` option:

--- a/llm/templates.py
+++ b/llm/templates.py
@@ -42,12 +42,12 @@ class Template(BaseModel):
         # Confirm all variables in text are provided
         string_template = string.Template(text)
         vars = cls.extract_vars(string_template)
-        missing = [p for p in vars if p not in params]
+        missing = [p for p in vars if p is not None and p not in params]
         if missing:
             raise cls.MissingVariables(
                 "Missing variables: {}".format(", ".join(missing))
             )
-        return string_template.substitute(**params)
+        return string_template.safe_substitute(**params)
 
     @staticmethod
     def extract_vars(string_template: string.Template) -> List[str]:

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -26,6 +26,7 @@ import yaml
             None,
             None,
         ),
+        ("$ not a $$template_var", None, None, None, "$ not a $template_var", None, None),
     ),
 )
 def test_template_evaluate(


### PR DESCRIPTION
while working with a system prompt for latex generation, i found that `$` characters in a template system prompt that don't refer to a template variable will cause an error since `Template.extract_vars` will return a list containing `None` values. by ignoring `None` when checking for missing template vars, this error is avoided. using `safe_substitute` over `substitute` should be fine here because there is already a check for missing variables, and allows the use of `$` characters that don't refer to template vars in a system prompt without raising an error for an invalid placeholder. 