### PR TITLE
Add `prefill` option, along with implementation for OpenAI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+tags
 .venv
 __pycache__/
 *.py[cod]

--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -281,6 +281,10 @@ class Chat(Model):
 
     def execute(self, prompt, stream, response, conversation=None):
 
+        def _stream_preproc(x):
+            "OpenAI stores stream results in a nested structure; this grabs the content"
+            return x.choices[0].delta.content
+
         messages = []
         current_system = None
         if conversation is not None:
@@ -313,7 +317,7 @@ class Chat(Model):
                 **kwargs,
             )
             chunks = []
-            for content in remove_pref(prompt.prefill, completion, store=chunks):
+            for content in remove_pref(prompt.prefill, completion, store=chunks, preproc=_stream_preproc):
                 if content is not None and content != '':
                     yield content
             response.response_json = remove_dict_none_values(combine_chunks(chunks))

--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -1,3 +1,4 @@
+import re
 from llm import EmbeddingModel, Model, hookimpl
 import llm
 from llm.utils import dicts_to_table_string, remove_dict_none_values, logging_client
@@ -245,6 +246,7 @@ class Chat(Model):
     needs_key = "openai"
     key_env_var = "OPENAI_API_KEY"
     can_stream: bool = True
+    supports_prefill: bool = True
 
     default_max_tokens = None
 
@@ -278,6 +280,7 @@ class Chat(Model):
         return "OpenAI Chat: {}".format(self.model_id)
 
     def execute(self, prompt, stream, response, conversation=None):
+        
         messages = []
         current_system = None
         if conversation is not None:
@@ -297,6 +300,8 @@ class Chat(Model):
         if prompt.system and prompt.system != current_system:
             messages.append({"role": "system", "content": prompt.system})
         messages.append({"role": "user", "content": prompt.prompt})
+        if prompt.prefill: 
+            messages.append({"role": "assistant", "content": prompt.prefill})
         response._prompt_json = {"messages": messages}
         kwargs = self.build_kwargs(prompt)
         client = self.get_client()
@@ -322,7 +327,16 @@ class Chat(Model):
                 **kwargs,
             )
             response.response_json = remove_dict_none_values(completion.dict())
-            yield completion.choices[0].message.content
+            content = completion.choices[0].message.content
+            # Add the prefill
+            if not content.startswith(prompt.prefill):
+                s = prompt.prefill
+                # LLMs seem to assume there's a whitespace at the end of prefill
+                # So we add one if there isn't one
+                if not re.search(r'\s$', s):
+                    s += ' '
+                content = s + content
+            yield content
 
     def get_client(self):
         kwargs = {}

--- a/llm/models.py
+++ b/llm/models.py
@@ -19,13 +19,15 @@ class Prompt:
     model: "Model"
     system: Optional[str]
     prompt_json: Optional[str]
+    prefill: Optional[str]
     options: "Options"
 
-    def __init__(self, prompt, model, system=None, prompt_json=None, options=None):
+    def __init__(self, prompt, model, system=None, prompt_json=None, prefill=None, options=None):
         self.prompt = prompt
         self.model = model
         self.system = system
         self.prompt_json = prompt_json
+        self.prefill = prefill
         self.options = options or {}
 
 
@@ -246,6 +248,7 @@ class Model(ABC, _get_key_mixin):
     needs_key: Optional[str] = None
     key_env_var: Optional[str] = None
     can_stream: bool = False
+    supports_prefill: bool=False
 
     class Options(_Options):
         pass
@@ -272,10 +275,11 @@ class Model(ABC, _get_key_mixin):
         prompt: Optional[str],
         system: Optional[str] = None,
         stream: bool = True,
+        prefill: Optional[str] = None,
         **options
     ):
         return self.response(
-            Prompt(prompt, system=system, model=self, options=self.Options(**options)),
+            Prompt(prompt, system=system, model=self, prefill=prefill, options=self.Options(**options)),
             stream=stream,
         )
 

--- a/llm/utils.py
+++ b/llm/utils.py
@@ -108,7 +108,7 @@ def logging_client() -> httpx.Client:
         event_hooks={"request": [_no_accept_encoding], "response": [_log_response]},
     )
 
-def remove_pref(p:str, r:Iterable[str], store:Optional[List]=None, preproc:Optional[Callable]=None) -> Generator[str,None,None]:
+def remove_pref(p:Optional[str], r:Iterable[str], store:Optional[List]=None, preproc:Optional[Callable]=None) -> Generator[str,None,None]:
     "Remove prefill `p` from result chunks `r` if the prefill matches the initial chunks"
     # The requirement is that the `p` values should be added to the start of the concatenated list `r`
     # if it's not already there. However, the function is a streaming function which yields one item from
@@ -118,6 +118,7 @@ def remove_pref(p:str, r:Iterable[str], store:Optional[List]=None, preproc:Optio
     # To implement this, we iterate through r and accumulate items into `buffer`.
     # At each step, check if the buffer starts with p. Once it does, yield p, then the rest of the buffer (after p)
     # and each subsequent item from r individually.
+    if p is None: p=''
     buffer = ''
     ir = iter(r)
     has_pre = False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,21 @@
+import pytest
+from llm.utils import remove_pref
+
+inps = [('My fave color',['is', ' orange']),
+    ('My fave color',['My', ' fave', ' is', ' orange']),
+    ('My fave color',['My', ' fave', ' color', ' is', ' orange']),
+    ('My fave color',['fave', ' color', ' is', ' orange']),
+    ('My fave color',['My fave color is', ' orange']),
+    ('My fave color',['My fave color', ' is orange'])]
+
+exps = ['My fave color is orange',
+    'My fave color My fave is orange',
+    'My fave color is orange',
+    'My fave color fave color is orange',
+    'My fave color is orange',
+    'My fave color is orange']
+
+@pytest.mark.parametrize("p_r,exp", zip(inps, exps))
+def test_remove_pref(p_r, exp):
+    assert ''.join(remove_pref(*p_r)) == exp
+


### PR DESCRIPTION
This is an implementation of `prefill` in the API. It's not yet implemented in the CLI -- submitting this for review first. We've done the OpenAI implementation of it. OpenAI has the slightly tricky feature that it sometimes adds the prefill to its own response, and sometimes doesn't -- so we look for it, and only add it if needed (on the basis that all model plugins will be expected to include the prefill in their response, which is generally what you'll want as a user). For non-streaming, it's basically trivial to implement. For streaming, it requires keeping track of enough chunks until you can see whether the prefill is being output or not, and accruing them -- it's not rocket science, but it's slightly awkward to keep track of, so we've created tests with all the edge cases we can think of (and they even pass!)

Example usage:

```python
response = model.prompt("What are some favourite colors that people often like? Tell me all about what they like most about it.", prefill="Favourite colors", stream=True)
```

Partially fixes #463 .