### PR TITLE
Update outdated reference to gpt-4-turbo

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -22,7 +22,7 @@ To switch from ChatGPT 3.5 (the default) to GPT-4o:
 ```bash
 llm 'Ten names for cheesecakes' -m gpt-4o
 ```
-You can use `-m 4t` as an even shorter shortcut.
+You can use `-m 4o` as an even shorter shortcut.
 
 Pass `--model <model name>` to use a different model. Run `llm models` to see a list of available models.
 


### PR DESCRIPTION
Looks like this alias was overlooked in 8171c9a. This commit makes it
match with the usage of gpt-4o in the associated example.
