### PR TITLE
Change default command to `--help`

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -61,7 +61,7 @@ def _validate_metadata_json(ctx, param, value):
 
 @click.group(
     cls=DefaultGroup,
-    default="prompt",
+    default="--help",
     default_if_no_args=True,
 )
 @click.version_option()


### PR DESCRIPTION
Improve user experience using the CLI by making help the default option for no arguments. See #529

This would be considered a breaking change any script is piping stdin (`echo | llm`) with no arguments instead of the non-ambiguous (`echo | llm prompt`).