### PR TITLE
Update directory.md -- add llm-bedrock-amazon

### DIFF
--- a/docs/plugins/directory.md
+++ b/docs/plugins/directory.md
@@ -33,6 +33,7 @@ These plugins can be used to interact with remotely hosted models via their API:
 - **[llm-openrouter](https://github.com/simonw/llm-openrouter)** provides access to models hosted on [OpenRouter](https://openrouter.ai/).
 - **[llm-cohere](https://github.com/Accudio/llm-cohere)** by Alistair Shepherd provides `cohere-generate` and `cohere-summarize` API models, powered by [Cohere](https://cohere.com/).
 - **[llm-bedrock-anthropic](https://github.com/sblakey/llm-bedrock-anthropic)** by Sean Blakey adds support for Claude and Claude Instant by Anthropic via Amazon Bedrock.
+- **[llm-bedrock-amazon](https://github.com/avoidik/llm-bedrock-amazon)** by Viacheslav Vasilyev adds support for Amazon Titan Express via Amazon Bedrock.
 - **[llm-bedrock-meta](https://github.com/flabat/llm-bedrock-meta)** by Fabian Labat adds support for Llama 2 and Llama 3 by Meta via Amazon Bedrock.
 - **[llm-together](https://github.com/wearedevx/llm-together)** adds support for the [Together AI](https://www.together.ai/) extensive family of hosted openly licensed models.
 


### PR DESCRIPTION
Hello,

I would like to contribute this LLM plugin to be able to access Amazon Titan Express model on AWS Bedrock.

Refers to https://github.com/avoidik/llm-bedrock-amazon

Kind regards