### PR TITLE
add azure-llm plugin to allow using the Azure OpenAI API

### DIFF
--- a/docs/plugins/directory.md
+++ b/docs/plugins/directory.md
@@ -28,6 +28,7 @@ These plugins can be used to interact with remotely hosted models via their API:
 - **[llm-bedrock-anthropic](https://github.com/sblakey/llm-bedrock-anthropic)** by Sean Blakey adds support for Claude and Claude Instant by Anthropic via Amazon Bedrock.
 - **[llm-bedrock-meta](https://github.com/flabat/llm-bedrock-meta)** by Fabian Labat  adds support for Llama 2 by Meta via Amazon Bedrock.
 - **[llm-together](https://github.com/wearedevx/llm-together)** adds support for the [Together AI](https://www.together.ai/) extensive family of hosted openly licensed models.
+- **[llm-azure](https://github.com/fabge/llm-azure)** by Fabian Geiger adds support for using the Azure API by the `AzureOpenAI` class.
 
 If an API model host provides an OpenAI-compatible API you can also [configure LLM to talk to it](https://llm.datasette.io/en/stable/other-models.html#openai-compatible-models) without needing an extra plugin.
 


### PR DESCRIPTION
since `openai >= 1.*` using azure as backend means having to use the `AzureOpenAI` class of the [`openai` python package](https://pypi.org/project/openai/), instead of just using the `OpenAI` class. this plugin does just that.
https://github.com/fabge/llm-azure