### PR TITLE
feat: allow to customize key_env_var for extra models

### DIFF
--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -73,6 +73,8 @@ def register_models(register):
             chat_model.needs_key = None
         if extra_model.get("api_key_name"):
             chat_model.needs_key = extra_model["api_key_name"]
+        if extra_model.get("api_key_env_var"):
+            chat_model.key_env_var = extra_model["api_key_env_var"]
         register(
             chat_model,
             aliases=aliases,


### PR DESCRIPTION
This allows to add a `api_key_env_var` to the `extra-openai-models.yaml` file:

```yaml
- model_id: ik
  model_name: mixtral8x22b
  api_base: https://api.infomaniak.com/1/ai/24/openai
  api_key_name: ik
  api_key_env_var: IK_LLM_API_KEY
```

The goal being to avoid having a cleartext token stored on disk in `keys.json` (and using some password manager to populate it).
