### PR TITLE
Rich markdown formatting (including streaming) in any mode with `--rich`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,16 @@
 # Changelog
 
+(v0_16)=
+## 0.16 (2024-09-12)
+
+- OpenAI models now use the internal `self.get_key()` mechanism, which means they can be used from Python code in a way that will pick up keys that have been configured using `llm keys set` or the `OPENAI_API_KEY` environment variable. [#552](https://github.com/simonw/llm/issues/552). This code now works correctly:
+    ```python
+    import llm
+    print(llm.get_model("gpt-4o-mini").prompt("hi"))
+    ```
+- New documented API methods: `llm.get_default_model()`, `llm.set_default_model(alias)`, `llm.get_default_embedding_model(alias)`, `llm.set_default_embedding_model()`. [#553](https://github.com/simonw/llm/issues/553)
+- Support for OpenAI's new [o1 family](https://openai.com/o1/) of preview models, `llm -m o1-preview "prompt"` and `llm -m o1-mini "prompt"`. These models are currently only available to [tier 5](https://platform.openai.com/docs/guides/rate-limits/usage-tiers?context=tier-five) OpenAI API users, though this may change in the future. [#570](https://github.com/simonw/llm/issues/570)
+
 (v0_15)=
 ## 0.15 (2024-07-18)
 

--- a/docs/help.md
+++ b/docs/help.md
@@ -99,6 +99,7 @@ Options:
   --cid, --conversation TEXT   Continue the conversation with the given ID.
   --key TEXT                   API key to use
   --save TEXT                  Save prompt with this template name
+  -r, --rich                   Format output as rich markdown text
   --help                       Show this message and exit.
 ```
 
@@ -119,6 +120,7 @@ Options:
   -o, --option <TEXT TEXT>...  key/value options for the model
   --no-stream                  Do not stream output
   --key TEXT                   API key to use
+  -r, --rich                   Format output as rich markdown text
   --help                       Show this message and exit.
 ```
 

--- a/docs/openai-models.md
+++ b/docs/openai-models.md
@@ -41,6 +41,8 @@ OpenAI Chat: gpt-4-turbo-2024-04-09
 OpenAI Chat: gpt-4-turbo (aliases: gpt-4-turbo-preview, 4-turbo, 4t)
 OpenAI Chat: gpt-4o (aliases: 4o)
 OpenAI Chat: gpt-4o-mini (aliases: 4o-mini)
+OpenAI Chat: o1-preview
+OpenAI Chat: o1-mini
 OpenAI Completion: gpt-3.5-turbo-instruct (aliases: 3.5-instruct, chatgpt-instruct)
 ```
 <!-- [[[end]]] -->

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -345,6 +345,26 @@ OpenAI Chat: gpt-4o-mini (aliases: 4o-mini)
   logit_bias: dict, str
   seed: int
   json_object: boolean
+OpenAI Chat: o1-preview
+  temperature: float
+  max_tokens: int
+  top_p: float
+  frequency_penalty: float
+  presence_penalty: float
+  stop: str
+  logit_bias: dict, str
+  seed: int
+  json_object: boolean
+OpenAI Chat: o1-mini
+  temperature: float
+  max_tokens: int
+  top_p: float
+  frequency_penalty: float
+  presence_penalty: float
+  stop: str
+  logit_bias: dict, str
+  seed: int
+  json_object: boolean
 OpenAI Completion: gpt-3.5-turbo-instruct (aliases: 3.5-instruct, chatgpt-instruct)
   temperature: float
     What sampling temperature to use, between 0 and 2. Higher values like

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -33,6 +33,9 @@ import base64
 import pathlib
 import pydantic
 import readline
+from rich.console import Console
+from rich.live import Live
+from rich.markdown import Markdown
 from runpy import run_module
 import shutil
 import sqlite_utils
@@ -46,6 +49,8 @@ import yaml
 warnings.simplefilter("ignore", ResourceWarning)
 
 DEFAULT_TEMPLATE = "prompt: "
+
+console = Console()
 
 
 def _validate_metadata_json(ctx, param, value):
@@ -123,6 +128,7 @@ def cli():
 )
 @click.option("--key", help="API key to use")
 @click.option("--save", help="Save prompt with this template name")
+@click.option("--rich", "-r", is_flag=True, default=False, help="Format output as rich markdown text")
 def prompt(
     prompt,
     system,
@@ -137,6 +143,7 @@ def prompt(
     conversation_id,
     key,
     save,
+    rich,
 ):
     """
     Execute a prompt
@@ -274,13 +281,7 @@ def prompt(
 
     try:
         response = prompt_method(prompt, system, **validated_options)
-        if should_stream:
-            for chunk in response:
-                print(chunk, end="")
-                sys.stdout.flush()
-            print("")
-        else:
-            print(response.text())
+        print_response(response=response, stream=should_stream, rich=rich)
     except Exception as ex:
         raise click.ClickException(str(ex))
 
@@ -328,6 +329,7 @@ def prompt(
 )
 @click.option("--no-stream", is_flag=True, help="Do not stream output")
 @click.option("--key", help="API key to use")
+@click.option("--rich", "-r", is_flag=True, help="Format output as rich markdown text")
 def chat(
     system,
     model_id,
@@ -338,6 +340,7 @@ def chat(
     options,
     no_stream,
     key,
+    rich,
 ):
     """
     Hold an ongoing chat with a model.
@@ -440,11 +443,9 @@ def chat(
         response = conversation.prompt(prompt, system, **validated_options)
         # System prompt only sent for the first message:
         system = None
-        for chunk in response:
-            print(chunk, end="")
-            sys.stdout.flush()
+        print_response(response=response, stream=True, rich=rich)
         response.log_to_db(db)
-        print("")
+        console.print("")
 
 
 def load_conversation(conversation_id: Optional[str]) -> Optional[Conversation]:
@@ -1645,3 +1646,19 @@ def _human_readable_size(size_bytes):
 
 def logs_on():
     return not (user_dir() / "logs-off").exists()
+
+
+def print_response(response: Response, stream: bool = True, rich: bool = False):
+    if stream is True and rich is False:
+        for chunk in response:
+            console.print(chunk, end="")
+    elif stream is True and rich is True:
+        md = ""
+        with Live(Markdown(""), console=console) as live:
+            for chunk in response:
+                md += chunk
+                live.update(Markdown(md))
+    elif stream is False and rich is True:
+        console.print(Markdown(response.text()))
+    else:
+        console.print(Markdown(response.text()))

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1659,19 +1659,19 @@ def logs_on():
     return not (user_dir() / "logs-off").exists()
 
 
-def print_response(response: Response, stream: bool = True, rich: bool = False):
-    if stream:
-        if rich:
-            md = ""
-            with Live(Markdown(""), console=console) as live:
-                for chunk in response:
-                    md += chunk
-                    live.update(Markdown(md))
-        else:
+def print_response(response, stream=True, rich=False):
+
+    if stream and rich:
+        md = ""
+        with Live(Markdown(""), console=console) as live:
             for chunk in response:
-                console.print(chunk, end="")
-                sys.stdout.flush()
-            console.print()
+                md += chunk
+                live.update(Markdown(md))
+    if stream and not rich:
+        for chunk in response:
+            console.print(chunk, end="")
+            sys.stdout.flush()
+        console.print()
     else:
         if rich:
             console.print(Markdown(response.text()))

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1661,4 +1661,4 @@ def print_response(response: Response, stream: bool = True, rich: bool = False):
     elif stream is False and rich is True:
         console.print(Markdown(response.text()))
     else:
-        console.print(Markdown(response.text()))
+        console.print(response.text())

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1660,18 +1660,19 @@ def logs_on():
 
 
 def print_response(response, stream=True, rich=False):
-
-    if stream and rich:
-        md = ""
-        with Live(Markdown(""), console=console) as live:
+    # These nested ifs are necessary!? Only way this works.
+    if stream:
+        if rich:
+            md = ""
+            with Live(Markdown(""), console=console) as live:
+                for chunk in response:
+                    md += chunk
+                    live.update(Markdown(md))
+        else:
             for chunk in response:
-                md += chunk
-                live.update(Markdown(md))
-    if stream and not rich:
-        for chunk in response:
-            console.print(chunk, end="")
-            sys.stdout.flush()
-        console.print()
+                console.print(chunk, end="")
+                sys.stdout.flush()
+            console.print()
     else:
         if rich:
             console.print(Markdown(response.text()))

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -335,7 +335,13 @@ def prompt(
 )
 @click.option("--no-stream", is_flag=True, help="Do not stream output")
 @click.option("--key", help="API key to use")
-@click.option("--rich", "-r", is_flag=True, help="Format output as rich markdown text")
+@click.option(
+    "--rich",
+    "-r",
+    is_flag=True,
+    default=False,
+    help="Format output as rich markdown text",
+)
 def chat(
     system,
     model_id,

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -457,7 +457,6 @@ def chat(
         system = None
         print_response(response=response, stream=True, rich=rich)
         response.log_to_db(db)
-        console.print("")
 
 
 def load_conversation(conversation_id: Optional[str]) -> Optional[Conversation]:
@@ -1661,16 +1660,20 @@ def logs_on():
 
 
 def print_response(response: Response, stream: bool = True, rich: bool = False):
-    if stream is True and rich is False:
-        for chunk in response:
-            console.print(chunk, end="")
-    elif stream is True and rich is True:
-        md = ""
-        with Live(Markdown(""), console=console) as live:
+    if stream:
+        if rich:
+            md = ""
+            with Live(Markdown(""), console=console) as live:
+                for chunk in response:
+                    md += chunk
+                    live.update(Markdown(md))
+        else:
             for chunk in response:
-                md += chunk
-                live.update(Markdown(md))
-    elif stream is False and rich is True:
-        console.print(Markdown(response.text()))
+                console.print(chunk, end="")
+                sys.stdout.flush()
+            console.print()
     else:
-        console.print(response.text())
+        if rich:
+            console.print(Markdown(response.text()))
+        else:
+            console.print(response.text())

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -128,7 +128,13 @@ def cli():
 )
 @click.option("--key", help="API key to use")
 @click.option("--save", help="Save prompt with this template name")
-@click.option("--rich", "-r", is_flag=True, default=False, help="Format output as rich markdown text")
+@click.option(
+    "--rich",
+    "-r",
+    is_flag=True,
+    default=False,
+    help="Format output as rich markdown text",
+)
 def prompt(
     prompt,
     system,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-VERSION = "0.15"
+VERSION = "0.16"
 
 
 def get_long_description():

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         "setuptools",
         "pip",
         "pyreadline3; sys_platform == 'win32'",
+        "rich",
     ],
     extras_require={
         "test": [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -212,6 +212,31 @@ def mocked_openai_completion(httpx_mock):
     return httpx_mock
 
 
+@pytest.fixture
+def mocked_openai_completion_richtext(httpx_mock):
+    httpx_mock.add_response(
+        method="POST",
+        url="https://api.openai.com/v1/completions",
+        json={
+            "id": "cmpl-uqkvlQyYK7bGYrRHQ0eXlWi7",
+            "object": "text_completion",
+            "created": 1589478378,
+            "model": "gpt-3.5-turbo-instruct",
+            "choices": [
+                {
+                    "text": "\n\nThis is a `rich` _text_ **test**",
+                    "index": 0,
+                    "logprobs": None,
+                    "finish_reason": "length",
+                }
+            ],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12},
+        },
+        headers={"Content-Type": "application/json"},
+    )
+    return httpx_mock
+
+
 def stream_completion_events():
     choices_chunks = [
         [


### PR DESCRIPTION
# Overview

Fixes #12

This builds on the excellent foundation that @juftin laid down in #278 and 
1. fixes a mysterious bug that was failing some tests and 
2. resolves merge conflicts caused by changes since #278 was proposed. 

I love `llm` and use it constantly. My only gripe has been the lack of rich formatting in the terminal. I recently used [rich](https://pypi.org/project/rich/) for a project and found it excellent, so I was excited to add this to `llm`. I found #278 was open but dormant, so I decided to nudge things along. 

@simonw thanks for your amazing tools and awsome blog!

# Screenshots

<img width="976" alt="SCR-20240912-rpqh" src="https://github.com/user-attachments/assets/dcc7576d-650a-4e46-b98d-546a2e113a03">
<img width="976" alt="SCR-20240912-rpxr" src="https://github.com/user-attachments/assets/b556db5f-838c-4544-9091-429a8e199b3c">
<img width="976" alt="SCR-20240912-rqws" src="https://github.com/user-attachments/assets/e1bd11d4-6686-41b4-92cd-a60a574cda51">
