### PR TITLE
Fix broken tests.  Drop python 3.8.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -38,7 +38,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: '3.13'
         cache: pip
         cache-dependency-path: setup.py
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         pydantic: ["==1.10.2", ">=2.0.0"]
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         pydantic: ["==1.10.2", ">=2.0.0"]
     steps:
     - uses: actions/checkout@v4

--- a/setup.py
+++ b/setup.py
@@ -63,5 +63,5 @@ setup(
             "types-setuptools",
         ]
     },
-    python_requires=">=3.8",
+    python_requires=">=3.9",
 )

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -52,6 +52,9 @@ def test_keys_list(monkeypatch, tmpdir, args):
     assert result2.output.strip() == "openai"
 
 
+@pytest.mark.httpx_mock(
+    assert_all_requests_were_expected=False, can_send_already_matched_responses=True
+)
 def test_uses_correct_key(mocked_openai_chat, monkeypatch, tmpdir):
     user_dir = tmpdir / "user-dir"
     pathlib.Path(user_dir).mkdir()

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -133,19 +133,21 @@ def test_templates_prompt_save(templates_path, args, expected_prompt, expected_e
             "Summarize this: Input text",
             None,
         ),
-        (
+        pytest.param(
             "boo",
             ["-s", "s"],
             None,
             None,
             "Error: Cannot use -t/--template and --system together",
+            marks=pytest.mark.httpx_mock(assert_all_responses_were_requested=False),
         ),
-        (
+        pytest.param(
             "prompt: 'Say $hello'",
             [],
             None,
             None,
             "Error: Missing variables: hello",
+            marks=pytest.mark.httpx_mock(assert_all_responses_were_requested=False),
         ),
         (
             "prompt: 'Say $hello'",
@@ -183,4 +185,4 @@ def test_template_basic(
     else:
         assert result.exit_code == 1
         assert result.output.strip() == expected_error
-        mocked_openai_chat.reset(assert_all_responses_were_requested=False)
+        mocked_openai_chat.reset()


### PR DESCRIPTION
A number of tests are failing on main, apparently because tests always use the latest version of every dependency (no `Pipfile.lock`) and e.g. `pytest_httpx` has breaking changes.

Also `pytest_httpx` now requires python>=3.9 so I dropped 3.8 support.

What do you think about switching from `setup.py` to isolated builds using `uv` and checking in a `uv.lock` so tests don't fail over time?

```
=========================== short test summary info ============================
FAILED tests/test_keys.py::test_uses_correct_key - assert 1 == 0
FAILED tests/test_templates.py::test_template_basic[boo-extra_args3-None-None-Error: Cannot use -t/--template and --system together] - TypeError: HTTPXMock.reset() got an unexpected keyword argument 'assert_all...
FAILED tests/test_templates.py::test_template_basic[prompt: 'Say $hello'-extra_args4-None-None-Error: Missing variables: hello] - TypeError: HTTPXMock.reset() got an unexpected keyword argument 'assert_all...
ERROR tests/test_keys.py::test_uses_correct_key - AssertionError: The following requests were not expected:
ERROR tests/test_templates.py::test_template_basic[boo-extra_args3-None-None-Error: Cannot use -t/--template and --system together] - AssertionError: The following responses are mocked but not requested:
ERROR tests/test_templates.py::test_template_basic[prompt: 'Say $hello'-extra_args4-None-None-Error: Missing variables: hello] - AssertionError: The following responses are mocked but not requested:
============ 3 failed, 181 passed, 638 warnings, 3 errors in 3.23s =============
error: Recipe `test` failed on line 10 with exit code 1
```