### PR TITLE
Print usage message when no prompt and no input redirect #502

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## UNRELEASED
+
+- Instead of reading stdin, print usage message when no arguments are provided and no redirect. [#502] 
+
 (v0_16)=
 ## 0.16 (2024-09-12)
 

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -143,6 +143,11 @@ def prompt(
 
     Documentation: https://llm.datasette.io/en/stable/usage.html
     """
+    # If no prompt is provided, and we are in a TTY, show the help
+    if sys.stdin.isatty() and not prompt:
+        click.echo(click.Context(cli).get_help())
+        return
+
     if log and no_log:
         raise click.ClickException("--log and --no-log are mutually exclusive")
 
@@ -153,8 +158,7 @@ def prompt(
 
         # Is there extra prompt available on stdin?
         stdin_prompt = None
-        if not sys.stdin.isatty():
-            stdin_prompt = sys.stdin.read()
+        stdin_prompt = sys.stdin.read()
 
         if stdin_prompt:
             bits = [stdin_prompt]
@@ -162,9 +166,6 @@ def prompt(
                 bits.append(prompt)
             prompt = " ".join(bits)
 
-        if prompt is None and not save and sys.stdin.isatty():
-            # Hang waiting for input to stdin (unless --save)
-            prompt = sys.stdin.read()
         return prompt
 
     if save:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,6 +139,23 @@ def register_embed_demo_model(embed_demo, mock_model):
         pm.unregister(name="undo-mock-models-plugin")
 
 
+@pytest.fixture(autouse=True)
+def fix_httpx_mock(httpx_mock):
+    """As of version 0.31.0 httpx_mock takes no arguments in reset method.
+    https://github.com/Colin-b/pytest_httpx/blob/develop/CHANGELOG.md#0310
+    """
+    org_reset = httpx_mock.reset
+
+    def better_reset(self, assert_all_responses_were_requested: bool = False):
+        """Reset the mock, regardless of httpx_mock version."""
+        try:
+            org_reset()
+        except TypeError:
+            org_reset(assert_all_responses_were_requested)
+
+    httpx_mock.reset = better_reset.__get__(httpx_mock)
+
+
 @pytest.fixture
 def mocked_openai_chat(httpx_mock):
     httpx_mock.add_response(

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -52,6 +52,7 @@ def test_keys_list(monkeypatch, tmpdir, args):
     assert result2.output.strip() == "openai"
 
 
+@pytest.mark.httpx_mock(can_send_already_matched_responses=True)
 def test_uses_correct_key(mocked_openai_chat, monkeypatch, tmpdir):
     user_dir = tmpdir / "user-dir"
     pathlib.Path(user_dir).mkdir()

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -572,6 +572,9 @@ def test_model_defaults(tmpdir, monkeypatch):
     assert llm.get_model().model_id == "gpt-4o"
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("win"), reason="ptys are not supported on Windows"
+)
 def test_interactive_llm_empty_prompt():
     runner = CliRunner()
     # use a pty for stdin

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -570,3 +570,16 @@ def test_model_defaults(tmpdir, monkeypatch):
     assert config_path.exists()
     assert llm.get_default_model() == "gpt-4o"
     assert llm.get_model().model_id == "gpt-4o"
+
+
+def test_interactive_llm_empty_prompt():
+    runner = CliRunner()
+    # use a pty for stdin
+    master, _ = os.openpty()
+    input = os.fdopen(master, "r")
+    args = ["--no-stream"]
+    result = runner.invoke(cli, args, input=input, catch_exceptions=False)
+    assert result.exit_code == 0
+    # ensure the result is the help message
+    assert result.output.startswith("Usage:")
+    input.close()

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -183,4 +183,4 @@ def test_template_basic(
     else:
         assert result.exit_code == 1
         assert result.output.strip() == expected_error
-        mocked_openai_chat.reset(assert_all_responses_were_requested=False)
+        mocked_openai_chat.reset()


### PR DESCRIPTION
Thanks for a great project.

Input redirect works as before as well as `llm <<EOF`. 

This PR changes the behavior for users who are using stdin to enter the prompt as it won't work anymore. I believe this is OK as we have the `chat` subcommand now.