### PR TITLE
avoid crash when response has no attachments

### DIFF
--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -312,7 +312,7 @@ class Chat(Model):
                         {"role": "system", "content": prev_response.prompt.system}
                     )
                     current_system = prev_response.prompt.system
-                if prev_response.attachments:
+                if hasattr(prev_response, 'attachments') and prev_response.attachments:
                     attachment_message = [
                         {"type": "text", "text": prev_response.prompt.prompt}
                     ]


### PR DESCRIPTION
# Description

## Symptoms

I noticed `llm chat` was crashing a ... *lot*.

Tracebacks looked like this:

```
Traceback (most recent call last):
  File "/opt/homebrew/bin/llm", line 8, in <module>
    sys.exit(cli())
             ~~~^^
  File "/opt/homebrew/Cellar/llm/0.17/libexec/lib/python3.13/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/llm/0.17/libexec/lib/python3.13/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/opt/homebrew/Cellar/llm/0.17/libexec/lib/python3.13/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/opt/homebrew/Cellar/llm/0.17/libexec/lib/python3.13/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/llm/0.17/libexec/lib/python3.13/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/opt/homebrew/Cellar/llm/0.17/libexec/lib/python3.13/site-packages/llm/cli.py", line 535, in chat
    for chunk in response:
                 ^^^^^^^^
  File "/opt/homebrew/Cellar/llm/0.17/libexec/lib/python3.13/site-packages/llm/models.py", line 169, in __iter__
    for chunk in self.model.execute(
                 ~~~~~~~~~~~~~~~~~~^
        self.prompt,
        ^^^^^^^^^^^^
    ...<2 lines>...
        conversation=self.conversation,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ):
    ^
  File "/opt/homebrew/Cellar/llm/0.17/libexec/lib/python3.13/site-packages/llm/default_plugins/openai_models.py", line 315, in execute
    if prev_response.attachments:
       ^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Response' object has no attribute 'attachments'
```

## Problem

The python code is not checking if there is an `attachments` attribute before accessing it.

### Introduction of Issue

Came in this change: https://github.com/simonw/llm/pull/590

## Solution

Check for existence of `attachments` attribute before accessing.



# Testing

Made the change to my local version of the code in my homebrew install path, and the crashes went away.

