### PR TITLE
Keys in environment should precede static configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ venv
 *.egg-info
 .DS_Store
 .idea/
+.direnv/
+.envrc

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -123,11 +123,9 @@ Keys can also be set using an environment variable. These are different for diff
 
 For OpenAI models the key will be read from the `OPENAI_API_KEY` environment variable.
 
-The environment variable will be used if no `--key` option is passed to the command and there is not a key configured in `keys.json`
-
-To use an environment variable in place of the `keys.json` key run the prompt like this:
+The environment variable will be used if no `--key` option is passed to the command:
 ```bash
-llm 'my prompt' --key $OPENAI_API_KEY
+OPENAI_API_KEY="my-key" llm 'my prompt'
 ```
 
 ## Configuration

--- a/llm/__init__.py
+++ b/llm/__init__.py
@@ -222,12 +222,12 @@ def get_key(
     if explicit_key:
         # User specified a key that's not an alias, use that
         return explicit_key
-    # Stored key over-rides environment variables over-ride the default key
-    if key_alias in stored_keys:
-        return stored_keys[key_alias]
     # Finally try environment variable
     if env_var and os.environ.get(env_var):
         return os.environ[env_var]
+    # Stored key over-rides environment variables over-ride the default key
+    if key_alias in stored_keys:
+        return stored_keys[key_alias]
     # Couldn't find it
     return None
 

--- a/llm/__init__.py
+++ b/llm/__init__.py
@@ -222,10 +222,10 @@ def get_key(
     if explicit_key:
         # User specified a key that's not an alias, use that
         return explicit_key
-    # Finally try environment variable
+    # Environment variable overrides stored key
     if env_var and os.environ.get(env_var):
         return os.environ[env_var]
-    # Stored key over-rides environment variables over-ride the default key
+    # Finally try stored key
     if key_alias in stored_keys:
         return stored_keys[key_alias]
     # Couldn't find it

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -77,7 +77,6 @@ def test_uses_correct_key(mocked_openai_chat, monkeypatch, tmpdir):
     }
     keys_path.write_text(json.dumps(KEYS), "utf-8")
     monkeypatch.setenv("LLM_USER_PATH", str(user_dir))
-    monkeypatch.setenv("OPENAI_API_KEY", "from-env")
 
     def assert_key(key):
         request = mocked_openai_chat.get_requests()[-1]
@@ -85,17 +84,27 @@ def test_uses_correct_key(mocked_openai_chat, monkeypatch, tmpdir):
 
     runner = CliRunner()
 
-    # Called without --key uses stored key
-    result = runner.invoke(cli, ["hello", "--no-stream"], catch_exceptions=False)
+    # Called without --key an no environment variable uses stored key
+    result = runner.invoke(
+        cli, ["hello", "--no-stream"], catch_exceptions=False)
     assert result.exit_code == 0
     assert_key("from-keys-file")
 
+    monkeypatch.setenv("OPENAI_API_KEY", "from-env")
+
     # Called without --key and without keys.json uses environment variable
     keys_path.write_text("{}", "utf-8")
-    result2 = runner.invoke(cli, ["hello", "--no-stream"], catch_exceptions=False)
+    result2 = runner.invoke(
+        cli, ["hello", "--no-stream"], catch_exceptions=False)
     assert result2.exit_code == 0
     assert_key("from-env")
     keys_path.write_text(json.dumps(KEYS), "utf-8")
+
+    # Called without --key and with keys.json still uses environment variable
+    result = runner.invoke(
+        cli, ["hello", "--no-stream"], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert_key("from-env")
 
     # Called with --key name-in-keys.json uses that value
     result3 = runner.invoke(

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -85,8 +85,7 @@ def test_uses_correct_key(mocked_openai_chat, monkeypatch, tmpdir):
     runner = CliRunner()
 
     # Called without --key an no environment variable uses stored key
-    result = runner.invoke(
-        cli, ["hello", "--no-stream"], catch_exceptions=False)
+    result = runner.invoke(cli, ["hello", "--no-stream"], catch_exceptions=False)
     assert result.exit_code == 0
     assert_key("from-keys-file")
 
@@ -94,15 +93,13 @@ def test_uses_correct_key(mocked_openai_chat, monkeypatch, tmpdir):
 
     # Called without --key and without keys.json uses environment variable
     keys_path.write_text("{}", "utf-8")
-    result2 = runner.invoke(
-        cli, ["hello", "--no-stream"], catch_exceptions=False)
+    result2 = runner.invoke(cli, ["hello", "--no-stream"], catch_exceptions=False)
     assert result2.exit_code == 0
     assert_key("from-env")
     keys_path.write_text(json.dumps(KEYS), "utf-8")
 
     # Called without --key and with keys.json still uses environment variable
-    result = runner.invoke(
-        cli, ["hello", "--no-stream"], catch_exceptions=False)
+    result = runner.invoke(cli, ["hello", "--no-stream"], catch_exceptions=False)
     assert result.exit_code == 0
     assert_key("from-env")
 


### PR DESCRIPTION
This allows more specific methods to override more general ones. One can override persistent configurations (files) with temporary ones (env vars), and override both with one-time CLI parameters.

* CLI parameters are most explicit and specific to that execution
* Environment variables provide session-level configuration
* Config files offer system-wide/default settings

