### PR TITLE
Enhancement Proposal: Track Head (for backtracking)

### DIFF
--- a/llm/migrations.py
+++ b/llm/migrations.py
@@ -204,8 +204,8 @@ def m011_fts_for_responses(db):
 
 
 @migration
-def m012_current_conversation(db):
-    """Add table to track current conversation"""
+def m012_track_current_conversation(db):
+    """Add table to track current conversation and parent id to responses table"""
     db["state"].create(
         {
             "key": str,
@@ -213,8 +213,4 @@ def m012_current_conversation(db):
         },
         pk="key"
     )
-
-
-@migration
-def m013_current_conversation(db):
     db["responses"].add_column("parent_id", str)

--- a/llm/migrations.py
+++ b/llm/migrations.py
@@ -201,3 +201,20 @@ def m010_create_new_log_tables(db):
 @migration
 def m011_fts_for_responses(db):
     db["responses"].enable_fts(["prompt", "response"], create_triggers=True)
+
+
+@migration
+def m012_current_conversation(db):
+    """Add table to track current conversation"""
+    db["state"].create(
+        {
+            "key": str,
+            "value": str,
+        },
+        pk="key"
+    )
+
+
+@migration
+def m013_current_conversation(db):
+    db["responses"].add_column("parent_id", str)


### PR DESCRIPTION
Sometimes it would be nice to step back a single generation. To fix a typo or redo a generation. This PR makes that possible. This is done by adding a parent ID to the responses and adding a table to track the HEAD ID.

I can clean it up and add some tests, but first I wanted to check if this was something you would be amenable to.

Here is a demonstration of what it allows for:
```
> llm 'Hello World. Reply with "hello".'
hello
> llm --continue 'Magic word is pineapple. Confirm with "okay".'
okay
> llm --continue 'What is the magic word?'
pineapple
> llm head back
Head moved back to response 01jctw7f1a2xv2n8ckjyhxr3k7
> llm head back
Head moved back to response 01jctw6rh9pd2kvphs0sdcjz8e
> llm --continue 'What is the magic word?'
please
> llm head set 01jctw7f1a2xv2n8ckjyhxr3k7
Head is now at response 01jctw7f1a2xv2n8ckjyhxr3k7
> llm --continue 'What is the magic word?'
pineapple
```

I think this is useful on its own and not too big of a change. However, this would also make it possible to explore many branches of a conversation in parallel, in a [loom](https://github.com/socketteer/loom)-like manner. I would make that as an additional module, but for that to be possible the responses need parent ids, so at least that much would have to be added to the db I believe.