### PR TITLE
WIP: Fragments

### DIFF
--- a/docs/help.md
+++ b/docs/help.md
@@ -118,7 +118,8 @@ Options:
   --at, --attachment-type <TEXT TEXT>...
                                   Attachment with explicit mimetype
   -o, --option <TEXT TEXT>...     key/value options for the model
-  -f, --fragment TEXT             Fragment to add to prompt
+  -f, --fragment TEXT             Fragment (alias, URL or file path) to add to
+                                  the prompt
   --sf, --system-fragment TEXT    Fragment to add to system prompt
   -t, --template TEXT             Template to use
   -p, --param <TEXT TEXT>...      Parameters for template

--- a/docs/help.md
+++ b/docs/help.md
@@ -118,8 +118,8 @@ Options:
   --at, --attachment-type <TEXT TEXT>...
                                   Attachment with explicit mimetype
   -o, --option <TEXT TEXT>...     key/value options for the model
-  -f, --fragment TEXT             Fragment (alias, URL or file path) to add to
-                                  the prompt
+  -f, --fragment TEXT             Fragment (alias, URL, hash or file path) to
+                                  add to the prompt
   --sf, --system-fragment TEXT    Fragment to add to system prompt
   -t, --template TEXT             Template to use
   -p, --param <TEXT TEXT>...      Parameters for template
@@ -527,7 +527,7 @@ Usage: llm fragments set [OPTIONS] ALIAS FRAGMENT
 
   Set an alias for a fragment
 
-  Accepts an alias and a file path, URL or '-' for stdin
+  Accepts an alias and a file path, URL, hash or '-' for stdin
 
   Example usage:
 

--- a/docs/help.md
+++ b/docs/help.md
@@ -516,8 +516,9 @@ Usage: llm fragments list [OPTIONS]
   List current fragments
 
 Options:
-  --json  Output as JSON
-  --help  Show this message and exit.
+  -q, --query TEXT  Search for fragments matching these strings
+  --json            Output as JSON
+  --help            Show this message and exit.
 ```
 
 (help-fragments-set)=

--- a/docs/help.md
+++ b/docs/help.md
@@ -71,6 +71,7 @@ Commands:
   embed         Embed text and store or return the result
   embed-models  Manage available embedding models
   embed-multi   Store embeddings for multiple strings at once
+  fragments     Manage fragments
   install       Install packages from PyPI into the same environment as LLM
   keys          Manage stored API keys for different models
   logs          Tools for exploring logged prompts and responses
@@ -117,6 +118,8 @@ Options:
   --at, --attachment-type <TEXT TEXT>...
                                   Attachment with explicit mimetype
   -o, --option <TEXT TEXT>...     key/value options for the model
+  -f, --fragment TEXT             Fragment to add to prompt
+  --sf, --system-fragment TEXT    Fragment to add to system prompt
   -t, --template TEXT             Template to use
   -p, --param <TEXT TEXT>...      Parameters for template
   --no-stream                     Do not stream output
@@ -483,6 +486,66 @@ Options:
 Usage: llm aliases path [OPTIONS]
 
   Output the path to the aliases.json file
+
+Options:
+  --help  Show this message and exit.
+```
+
+(help-fragments)=
+### llm fragments --help
+```
+Usage: llm fragments [OPTIONS] COMMAND [ARGS]...
+
+  Manage fragments
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  list*   List current fragments
+  remove  Remove a fragment alias
+  set     Set an alias for a fragment
+```
+
+(help-fragments-list)=
+#### llm fragments list --help
+```
+Usage: llm fragments list [OPTIONS]
+
+  List current fragments
+
+Options:
+  --json  Output as JSON
+  --help  Show this message and exit.
+```
+
+(help-fragments-set)=
+#### llm fragments set --help
+```
+Usage: llm fragments set [OPTIONS] ALIAS FRAGMENT
+
+  Set an alias for a fragment
+
+  Accepts an alias and a file path, URL or '-' for stdin
+
+  Example usage:
+
+      llm fragments set docs ./docs.md
+
+Options:
+  --help  Show this message and exit.
+```
+
+(help-fragments-remove)=
+#### llm fragments remove --help
+```
+Usage: llm fragments remove [OPTIONS] ALIAS
+
+  Remove a fragment alias
+
+  Example usage:
+
+      llm fragments remove docs
 
 Options:
   --help  Show this message and exit.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -127,6 +127,45 @@ See {ref}`prompt templates <prompt-templates>` for more.
 
 You can use the `-f/--fragment` option to reference fragments of context that you would like to load into your prompt. Fragments can be specified as URLs, file paths or as aliases to previously saved fragments.
 
+Fragments are designed for running longer prompts. LLM {ref}`stores prompts in a database <logging>`, and the same prompt repeated many times can end up stored as multiple copies, wasting disk space. A fragment will be stored just once and referenced by all of the prompts that use it.
+
+The `-f` option can accept a path to a file on disk, a URL or the hash or alias of a previous fragment.
+
+For example, to ask a question about the `robots.txt` file on `llm.datasette.io`:
+```bash
+llm -f https://llm.datasette.io/robots.txt 'explain this'
+```
+For a poem inspired by some Python code on disk:
+```bash
+llm -f cli.py 'a short snappy poem inspired by this code'
+```
+You can use as many `-f` options as you like - the fragments will be concatenated together in the order you provided, with any additional prompt added at the end.
+
+Fragments can also be used for the system prompt using the `--sf/--system-fragment` option. If you have a file called `explain_code.txt` containing this:
+
+```
+Explain this code in detail. Include copies of the code quoted in the explanation.
+```
+You can run it as the system prompt like this:
+```bash
+llm -f cli.py --sf explain_code.txt
+```
+
+You can use the `llm fragments set` command to load a fragment and give it an alias for use in future queries:
+```bash
+llm fragments set cli cli.py
+# Then
+llm -f cli 'explain this code'
+```
+Use `llm fragments` to list all fragments that have been stored:
+```bash
+llm fragments
+```
+The `llm fragments remove` command removes an alias. It does not delete the fragment record itself as those are linked to previous prompts and responses and cannot be deleted independently of them.
+```bash
+llm fragments remove cli
+```
+
 (conversation)=
 ### Continuing a conversation
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -161,6 +161,11 @@ Use `llm fragments` to list all fragments that have been stored:
 ```bash
 llm fragments
 ```
+You can search by passing one or more `-q X` search strings. This will return results matching all of those strings, across the source, hash, aliases and content:
+```bash
+llm fragments -q pytest -q asyncio
+```
+
 The `llm fragments remove` command removes an alias. It does not delete the fragment record itself as those are linked to previous prompts and responses and cannot be deleted independently of them.
 ```bash
 llm fragments remove cli

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -122,6 +122,11 @@ cat llm/utils.py | llm -t pytest
 ```
 See {ref}`prompt templates <prompt-templates>` for more.
 
+(fragments)=
+### Fragments
+
+You can use the `-f/--fragment` option to reference fragments of context that you would like to load into your prompt. Fragments can be specified as URLs, file paths or as aliases to previously saved fragments.
+
 (conversation)=
 ### Continuing a conversation
 

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -38,10 +38,12 @@ from llm.models import _BaseConversation
 from .migrations import migrate
 from .plugins import pm, load_plugins
 from .utils import (
-    mimetype_from_path,
-    mimetype_from_string,
     token_usage_string,
     extract_fenced_code_block,
+    FragmentString,
+    ensure_fragment,
+    mimetype_from_path,
+    mimetype_from_string,
 )
 import base64
 import httpx
@@ -54,7 +56,7 @@ import sqlite_utils
 from sqlite_utils.utils import rows_from_file, Format
 import sys
 import textwrap
-from typing import cast, Optional, Iterable, Union, Tuple
+from typing import cast, Optional, Iterable, List, Union, Tuple
 import warnings
 import yaml
 
@@ -63,18 +65,22 @@ warnings.simplefilter("ignore", ResourceWarning)
 DEFAULT_TEMPLATE = "prompt: "
 
 
-def resolve_fragments(fragments):
+def resolve_fragments(fragments: Iterable[str]) -> List[Tuple[str, str]]:
+    """
+    Resolve fragments into a list of (content, source) tuples
+    """
     # These can be URLs or paths
     resolved = []
     for fragment in fragments:
         if fragment.startswith("http://") or fragment.startswith("https://"):
             response = httpx.get(fragment, follow_redirects=True)
             response.raise_for_status()
-            resolved.append(response.text)
+            resolved.append(FragmentString(response.text, fragment))
         elif fragment == "-":
-            resolved.append(sys.stdin.read())
+            resolved.append(FragmentString(sys.stdin.read(), "-"))
         elif pathlib.Path(fragment).exists():
-            resolved.append(pathlib.Path(fragment).read_text())
+            path = pathlib.Path(fragment)
+            resolved.append(FragmentString(path.read_text(), str(path.resolve())))
         else:
             raise click.ClickException(f"Fragment {fragment} not found")
     return resolved
@@ -1428,6 +1434,92 @@ def aliases_remove(alias):
 def aliases_path():
     "Output the path to the aliases.json file"
     click.echo(user_dir() / "aliases.json")
+
+
+@cli.group(
+    cls=DefaultGroup,
+    default="list",
+    default_if_no_args=True,
+)
+def fragments():
+    "Manage fragments"
+
+
+@fragments.command(name="list")
+@click.option("json_", "--json", is_flag=True, help="Output as JSON")
+def fragments_list(json_):
+    "List current fragments"
+    db = sqlite_utils.Database(logs_db_path())
+    migrate(db)
+    sql = """
+    select
+        fragments.id,
+        fragments.hash,
+        fragments.content,
+        fragments.datetime_utc,
+        fragments.source,
+        json_group_array(fragment_aliases.alias) filter (
+            where
+            fragment_aliases.alias is not null
+        ) as aliases
+    from
+        fragments
+    left join
+        fragment_aliases on fragment_aliases.fragment_id = fragments.id
+    group by
+        fragments.id, fragments.hash, fragments.content, fragments.datetime_utc, fragments.source;
+    """
+    results = list(db.query(sql))
+    for result in results:
+        result["aliases"] = json.loads(result["aliases"])
+    click.echo(json.dumps(results, indent=4))
+
+
+@fragments.command(name="set")
+@click.argument("alias")
+@click.argument("fragment")
+def fragments_set(alias, fragment):
+    """
+    Set an alias for a fragment
+
+    Accepts an alias and a file path, URL or '-' for stdin
+
+    Example usage:
+
+    \b
+        llm fragments set docs ./docs.md
+    """
+    resolved = resolve_fragments([fragment])[0]
+    db = sqlite_utils.Database(logs_db_path())
+    migrate(db)
+    alias_sql = """
+    insert into fragment_aliases (alias, fragment_id)
+    values (:alias, :fragment_id)
+    on conflict(alias) do update set
+        fragment_id = excluded.fragment_id;
+    """
+    with db.conn:
+        fragment_id = ensure_fragment(db, resolved)
+        db.conn.execute(alias_sql, {"alias": alias, "fragment_id": fragment_id})
+
+
+@fragments.command(name="remove")
+@click.argument("alias")
+def fragments_remove(alias):
+    """
+    Remove a fragment alias
+
+    Example usage:
+
+    \b
+        llm fragments remove docs
+    """
+    db = sqlite_utils.Database(logs_db_path())
+    migrate(db)
+    with db.conn:
+        db.conn.execute(
+            "delete from fragment_aliases where alias = :alias", {"alias": alias}
+        )
 
 
 @cli.command(name="plugins")

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1497,13 +1497,12 @@ def fragments_list(json_):
     migrate(db)
     sql = """
     select
-        fragments.id,
+        fragments.hash,
         json_group_array(fragment_aliases.alias) filter (
             where
             fragment_aliases.alias is not null
         ) as aliases,
         fragments.datetime_utc,
-        fragments.hash,
         fragments.source,
         fragments.content
     from
@@ -1519,14 +1518,14 @@ def fragments_list(json_):
     if json_:
         click.echo(json.dumps(results, indent=4))
     else:
-
-        def selective_representer(dumper, data):
-            return dumper.represent_scalar(
+        yaml.add_representer(
+            str,
+            lambda dumper, data: dumper.represent_scalar(
                 "tag:yaml.org,2002:str", data, style="|" if "\n" in data else None
-            )
-
-        yaml.add_representer(str, selective_representer)
+            ),
+        )
         for result in results:
+            result["content"] = _truncate_string(result["content"])
             click.echo(yaml.dump([result], sort_keys=False, width=sys.maxsize).strip())
 
 

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -65,7 +65,7 @@ warnings.simplefilter("ignore", ResourceWarning)
 DEFAULT_TEMPLATE = "prompt: "
 
 
-def resolve_fragments(fragments: Iterable[str]) -> List[Tuple[str, str]]:
+def resolve_fragments(fragments: Iterable[str]) -> List[FragmentString]:
     """
     Resolve fragments into a list of (content, source) tuples
     """

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -82,7 +82,7 @@ def resolve_fragments(
                 """
                 select content, source from fragments
                 join fragment_aliases on fragments.id = fragment_aliases.fragment_id
-                where alias = :alias
+                where alias = :alias or hash = :alias limit 1
                 """,
                 {"alias": fragment},
             )
@@ -244,7 +244,7 @@ def cli():
     "-f",
     "--fragment",
     multiple=True,
-    help="Fragment (alias, URL or file path) to add to the prompt",
+    help="Fragment (alias, URL, hash or file path) to add to the prompt",
 )
 @click.option(
     "system_fragments",
@@ -1537,7 +1537,7 @@ def fragments_set(alias, fragment):
     """
     Set an alias for a fragment
 
-    Accepts an alias and a file path, URL or '-' for stdin
+    Accepts an alias and a file path, URL, hash or '-' for stdin
 
     Example usage:
 

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -240,7 +240,11 @@ def cli():
     help="key/value options for the model",
 )
 @click.option(
-    "fragments", "-f", "--fragment", multiple=True, help="Fragment to add to prompt"
+    "fragments",
+    "-f",
+    "--fragment",
+    multiple=True,
+    help="Fragment (alias, URL or file path) to add to the prompt",
 )
 @click.option(
     "system_fragments",
@@ -1512,7 +1516,18 @@ def fragments_list(json_):
     results = list(db.query(sql))
     for result in results:
         result["aliases"] = json.loads(result["aliases"])
-    click.echo(json.dumps(results, indent=4))
+    if json_:
+        click.echo(json.dumps(results, indent=4))
+    else:
+
+        def selective_representer(dumper, data):
+            return dumper.represent_scalar(
+                "tag:yaml.org,2002:str", data, style="|" if "\n" in data else None
+            )
+
+        yaml.add_representer(str, selective_representer)
+        for result in results:
+            click.echo(yaml.dump([result], sort_keys=False, width=sys.maxsize).strip())
 
 
 @fragments.command(name="set")

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1498,14 +1498,14 @@ def fragments_list(json_):
     sql = """
     select
         fragments.id,
-        fragments.hash,
-        fragments.content,
-        fragments.datetime_utc,
-        fragments.source,
         json_group_array(fragment_aliases.alias) filter (
             where
             fragment_aliases.alias is not null
-        ) as aliases
+        ) as aliases,
+        fragments.datetime_utc,
+        fragments.hash,
+        fragments.source,
+        fragments.content
     from
         fragments
     left join

--- a/llm/migrations.py
+++ b/llm/migrations.py
@@ -251,6 +251,7 @@ def m014_fragments_tables(db):
         },
         pk="id",
     )
+    db["fragments"].create_index(["alias"], unique=True)
     db["prompt_fragments"].create(
         {
             "response_id": str,

--- a/llm/migrations.py
+++ b/llm/migrations.py
@@ -245,17 +245,24 @@ def m014_fragments_tables(db):
             "id": int,
             "hash": str,
             "content": str,
-            "alias": str,
             "datetime_utc": str,
             "source": str,
         },
         pk="id",
     )
-    db["fragments"].create_index(["alias"], unique=True)
+    db["fragments"].create_index(["hash"], unique=True)
+    db["fragment_aliases"].create(
+        {
+            "alias": str,
+            "fragment_id": int,
+        },
+        foreign_keys=(("fragment_id", "fragments", "id"),),
+        pk="alias",
+    )
     db["prompt_fragments"].create(
         {
             "response_id": str,
-            "fragment_id": str,
+            "fragment_id": int,
             "order": int,
         },
         foreign_keys=(
@@ -267,7 +274,7 @@ def m014_fragments_tables(db):
     db["system_fragments"].create(
         {
             "response_id": str,
-            "fragment_id": str,
+            "fragment_id": int,
             "order": int,
         },
         foreign_keys=(

--- a/llm/migrations.py
+++ b/llm/migrations.py
@@ -237,3 +237,41 @@ def m013_usage(db):
     db["responses"].add_column("input_tokens", int)
     db["responses"].add_column("output_tokens", int)
     db["responses"].add_column("token_details", str)
+
+
+def m014_fragments_tables(db):
+    db["fragments"].create(
+        {
+            "id": int,
+            "hash": str,
+            "content": str,
+            "alias": str,
+            "datetime_utc": str,
+            "source": str,
+        },
+        pk="id",
+    )
+    db["prompt_fragments"].create(
+        {
+            "response_id": str,
+            "fragment_id": str,
+            "order": int,
+        },
+        foreign_keys=(
+            ("response_id", "responses", "id"),
+            ("fragment_id", "fragments", "id"),
+        ),
+        pk=("response_id", "fragment_id"),
+    )
+    db["system_fragments"].create(
+        {
+            "response_id": str,
+            "fragment_id": str,
+            "order": int,
+        },
+        foreign_keys=(
+            ("response_id", "responses", "id"),
+            ("fragment_id", "fragments", "id"),
+        ),
+        pk=("response_id", "fragment_id"),
+    )

--- a/llm/models.py
+++ b/llm/models.py
@@ -150,7 +150,6 @@ class Prompt:
         system_fragments = [
             row["content"] for row in all_fragments if row["fragment_type"] == "system"
         ]
-        breakpoint()
         return cls(
             prompt=row["prompt"],
             model=model,

--- a/llm/models.py
+++ b/llm/models.py
@@ -130,7 +130,7 @@ class Prompt:
 
     @property
     def prompt(self):
-        return "\n".join(self.fragments + [self._prompt])
+        return "\n".join(self.fragments + ([self._prompt] if self._prompt else []))
 
     @property
     def system(self):

--- a/llm/models.py
+++ b/llm/models.py
@@ -20,7 +20,12 @@ from typing import (
     Set,
     Union,
 )
-from .utils import ensure_fragment, mimetype_from_path, mimetype_from_string, token_usage_string
+from .utils import (
+    ensure_fragment,
+    mimetype_from_path,
+    mimetype_from_string,
+    token_usage_string,
+)
 from abc import ABC, abstractmethod
 import json
 from pydantic import BaseModel

--- a/llm/models.py
+++ b/llm/models.py
@@ -98,10 +98,12 @@ class Attachment:
 
 @dataclass
 class Prompt:
-    prompt: str
+    _prompt: str
     model: "Model"
+    fragments: Optional[List[str]]
     attachments: Optional[List[Attachment]]
-    system: Optional[str]
+    _system: Optional[str]
+    system_fragments: Optional[List[str]]
     prompt_json: Optional[str]
     options: "Options"
 
@@ -110,17 +112,54 @@ class Prompt:
         prompt,
         model,
         *,
+        fragments=None,
         attachments=None,
         system=None,
+        system_fragments=None,
         prompt_json=None,
         options=None,
     ):
-        self.prompt = prompt
+        self._prompt = prompt
         self.model = model
         self.attachments = list(attachments or [])
-        self.system = system
+        self.fragments = fragments or []
+        self._system = system
+        self.system_fragments = system_fragments or []
         self.prompt_json = prompt_json
         self.options = options or {}
+
+    @property
+    def prompt(self):
+        return "\n".join(self.fragments + [self._prompt])
+
+    @property
+    def system(self):
+        bits = [
+            bit.strip()
+            for bit in (self.system_fragments + [self._system or ""])
+            if bit.strip()
+        ]
+        return "\n\n".join(bits)
+
+    @classmethod
+    def from_row(cls, db, row, model):
+        all_fragments = list(db.query(FRAGMENT_SQL, {"response_id": row["id"]}))
+        fragments = [
+            row["content"] for row in all_fragments if row["fragment_type"] == "prompt"
+        ]
+        system_fragments = [
+            row["content"] for row in all_fragments if row["fragment_type"] == "system"
+        ]
+        breakpoint()
+        return cls(
+            prompt=row["prompt"],
+            model=model,
+            fragments=fragments,
+            attachments=[],
+            system=row["system"],
+            system_fragments=system_fragments,
+            options=model.Options(**json.loads(row["options_json"])),
+        )
 
 
 @dataclass
@@ -142,8 +181,10 @@ class Conversation(_BaseConversation):
         self,
         prompt: Optional[str],
         *,
+        fragments: Optional[List[str]] = None,
         attachments: Optional[List[Attachment]] = None,
         system: Optional[str] = None,
+        system_fragments: Optional[List[str]] = None,
         stream: bool = True,
         key: Optional[str] = None,
         **options,
@@ -152,8 +193,10 @@ class Conversation(_BaseConversation):
             Prompt(
                 prompt,
                 model=self.model,
+                fragments=fragments,
                 attachments=attachments,
                 system=system,
+                system_fragments=system_fragments,
                 options=self.model.Options(**options),
             ),
             self.model,
@@ -184,8 +227,10 @@ class AsyncConversation(_BaseConversation):
         self,
         prompt: Optional[str],
         *,
+        fragments: Optional[List[str]] = None,
         attachments: Optional[List[Attachment]] = None,
         system: Optional[str] = None,
+        system_fragments: Optional[List[str]] = None,
         stream: bool = True,
         key: Optional[str] = None,
         **options,
@@ -194,8 +239,10 @@ class AsyncConversation(_BaseConversation):
             Prompt(
                 prompt,
                 model=self.model,
+                fragments=fragments,
                 attachments=attachments,
                 system=system,
+                system_fragments=system_fragments,
                 options=self.model.Options(**options),
             ),
             self.model,
@@ -218,6 +265,26 @@ class AsyncConversation(_BaseConversation):
         count = len(self.responses)
         s = "s" if count == 1 else ""
         return f"<{self.__class__.__name__}: {self.id} - {count} response{s}"
+
+
+FRAGMENT_SQL = """
+select
+    'prompt' as fragment_type,
+    f.content,
+    pf."order" as ord
+from prompt_fragments pf
+join fragments f on pf.fragment_id = f.id
+where pf.response_id = :response_id
+union all
+select
+    'system' as fragment_type,
+    f.content,
+    sf."order" as ord
+from system_fragments sf
+join fragments f on sf.fragment_id = f.id
+where sf.response_id = :response_id
+order by fragment_type desc, ord asc;
+"""
 
 
 class _BaseResponse:
@@ -276,13 +343,7 @@ class _BaseResponse:
 
         response = cls(
             model=model,
-            prompt=Prompt(
-                prompt=row["prompt"],
-                model=model,
-                attachments=[],
-                system=row["system"],
-                options=model.Options(**json.loads(row["options_json"])),
-            ),
+            prompt=Prompt.from_row(db, row, model),
             stream=False,
         )
         response.id = row["id"]
@@ -292,8 +353,8 @@ class _BaseResponse:
         response._chunks = [row["response"]]
         # Attachments
         response.attachments = [
-            Attachment.from_row(arow)
-            for arow in db.query(
+            Attachment.from_row(attachment_row)
+            for attachment_row in db.query(
                 """
                 select attachments.* from attachments
                 join prompt_attachments on attachments.id = prompt_attachments.attachment_id
@@ -701,8 +762,10 @@ class _Model(_BaseModel):
         self,
         prompt: str,
         *,
+        fragments: Optional[List[str]] = None,
         attachments: Optional[List[Attachment]] = None,
         system: Optional[str] = None,
+        system_fragments: Optional[List[str]] = None,
         stream: bool = True,
         **options,
     ) -> Response:
@@ -711,8 +774,10 @@ class _Model(_BaseModel):
         return Response(
             Prompt(
                 prompt,
+                fragments=fragments,
                 attachments=attachments,
                 system=system,
+                system_fragments=system_fragments,
                 model=self,
                 options=self.Options(**options),
             ),
@@ -755,8 +820,10 @@ class _AsyncModel(_BaseModel):
         self,
         prompt: str,
         *,
+        fragments: Optional[List[str]] = None,
         attachments: Optional[List[Attachment]] = None,
         system: Optional[str] = None,
+        system_fragments: Optional[List[str]] = None,
         stream: bool = True,
         **options,
     ) -> AsyncResponse:
@@ -765,8 +832,10 @@ class _AsyncModel(_BaseModel):
         return AsyncResponse(
             Prompt(
                 prompt,
+                fragments=fragments,
                 attachments=attachments,
                 system=system,
+                system_fragments=system_fragments,
                 model=self,
                 options=self.Options(**options),
             ),

--- a/tests/test_cli_openai_models.py
+++ b/tests/test_cli_openai_models.py
@@ -141,8 +141,8 @@ def test_only_gpt4_audio_preview_allows_mp3_or_wav(httpx_mock, model, filetype):
     else:
         assert result.exit_code == 1
         long = "audio/mpeg" if filetype == "mp3" else "audio/wav"
-        assert (
-            f"This model does not support attachments of type '{long}'" in result.output
+        assert f"This model does not support attachments of type '{long}'" in str(
+            result
         )
 
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -529,25 +529,24 @@ def test_openai_completion(mocked_openai_completion, user_path):
 
 def test_openai_completion_system_prompt_error():
     runner = CliRunner()
-    result = runner.invoke(
-        cli,
-        [
-            "-m",
-            "gpt-3.5-turbo-instruct",
-            "Say this is a test",
-            "--no-stream",
-            "--key",
-            "x",
-            "--system",
-            "system prompts not allowed",
-        ],
-        catch_exceptions=False,
-    )
-    assert result.exit_code == 1
-    assert (
-        result.output
-        == "Error: System prompts are not supported for OpenAI completion models\n"
-    )
+    with pytest.raises(NotImplementedError) as ex:
+        runner.invoke(
+            cli,
+            [
+                "-m",
+                "gpt-3.5-turbo-instruct",
+                "Say this is a test",
+                "--no-stream",
+                "--key",
+                "x",
+                "--system",
+                "system prompts not allowed",
+            ],
+            catch_exceptions=False,
+        )
+        assert "System prompts are not supported for OpenAI completion models" in str(
+            ex
+        )
 
 
 def test_openai_completion_logprobs_stream(


### PR DESCRIPTION
Refs:
- #617

TODO:

- [x] Make aliases such as `llm prompt -f alias` work
- [x] Document how to use `-f` option
- [x] `llm fragments list` needs non-JSON output (that truncates) - this should work similar to the new `llm logs --short` mode.
- [x] `llm fragments -q one -q two`
- [x] Make `-f fragment-hash` work in addition to `-f fragment-alias`
- [x] Documentation for the `llm fragments` family of commands
- [ ] Make sure `-f $URL` follows up to three redirects
- [ ] Fix the problem where `prompt_json` still duplicates the prompt - I can use https://pypi.org/project/condense-json/ for that
- [ ] Update `llm logs` to correctly display prompts using this new mechanism
  - [ ] Consider hiding fragments in a `<details><summary>` by default in log output
  - [ ] ... or maybe just show fragment IDs but not fragments? Would make `llm logs` output easier to visually scan. Could have a `-e/--expand` option to expand those fragments.
  - [ ] Tempted to add magic that says if the source ended in `.py` or `.js` then it gets wrapped in a syntax highlight block with the correct language tag - bit of a weird feature, maybe have this turned on by `llm logs --syntax` or similar? Might be easier to ignore programming languages but still wrap in triple backticks if it looks like code - if most of the lines are less than 120 chars for example.
- [ ] `llm fragments show hash-or-alias` - to show the full fragment based on the hash from the previous command
- [ ] Comprehensive tests

## Stretch goals

- [ ] Add this to `llm chat` - so you can do `llm chat -f docs`
- [ ] Does this need documentation in the Python docs?
- [ ] Consider if this should be added to templates (maybe not?)
- [ ] Consider how this design might be used to implement prompt caching in Claude