### PR TITLE
Fix windows bug where llm doesn't run <<llm chat>> on Windows issue #495

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -499,8 +499,12 @@ def chat(
     Hold an ongoing chat with a model.
     """
     # Left and right arrow keys to move cursor:
-    readline.parse_and_bind("\\e[D: backward-char")
-    readline.parse_and_bind("\\e[C: forward-char")
+    if sys.platform !='win32':
+        readline.parse_and_bind("\\e[D: backward-char")
+        readline.parse_and_bind("\\e[C: forward-char")
+    else:
+        readline.parse_and_bind("bind -x '\\e[D: backward-char'")
+        readline.parse_and_bind("bind -x '\\e[C: forward-char'")
     log_path = logs_db_path()
     (log_path.parent).mkdir(parents=True, exist_ok=True)
     db = sqlite_utils.Database(log_path)

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -499,7 +499,7 @@ def chat(
     Hold an ongoing chat with a model.
     """
     # Left and right arrow keys to move cursor:
-    if sys.platform !='win32':
+    if sys.platform != "win32":
         readline.parse_and_bind("\\e[D: backward-char")
         readline.parse_and_bind("\\e[C: forward-char")
     else:


### PR DESCRIPTION
This is the issue

On a windows system, llm chat throws an error.

```cmd
llm chat -m l32

```
![388874920-448c5100-831a-4911-83e0-71f6e685d62a](https://github.com/user-attachments/assets/f89baff0-86c7-4290-aef1-d64afcaad016)


Fixed. Demo of it working

![388874941-e9d75738-ec69-4ce5-86eb-fb629f7ab604](https://github.com/user-attachments/assets/802b1271-6fd5-47cf-ba34-866b2c74bcbb)
