### PR TITLE
Add `extra_body` option to SharedOptions for OpenAI

### DIFF
--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -257,6 +257,29 @@ class SharedOptions(llm.Options):
         description="Integer seed to attempt to sample deterministically",
         default=None,
     )
+    extra_body: Optional[Union[dict, str]] = Field(
+        description=(
+            "Additional JSON properties to include in the request body. "
+            "When provided via CLI, must be a valid JSON string."
+        ),
+        default=None,
+    )
+
+    @field_validator("extra_body")
+    def validate_extra_body(cls, extra_body):
+        if extra_body is None:
+            return None
+
+        if isinstance(extra_body, str):
+            try:
+                return json.loads(extra_body)
+            except json.JSONDecodeError:
+                raise ValueError("Invalid JSON in extra_body string")
+
+        if not isinstance(extra_body, dict):
+            raise ValueError("extra_body must be a dictionary")
+
+        return extra_body
 
     @field_validator("logit_bias")
     def validate_logit_bias(cls, logit_bias):


### PR DESCRIPTION
The OpenAI classes all have an `extra_body` parameter:

> extra_body: Add additional JSON properties to the request

It would be helpful to support this for providers compatible with the OpenAI API who use additional properties.

With this I can use for example `venice_parameters` with [llm-venice](https://github.com/ar-jan/llm-venice):

> llm -m venice/llama-3.1-405b -o extra_body '{"venice_parameters": { "include_venice_system_prompt": true }}' "Repeat the above prompt"