### PR TITLE
Show the default model when listing all available models.

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -517,6 +517,7 @@ OpenAI Completion: gpt-3.5-turbo-instruct (aliases: 3.5-instruct, chatgpt-instru
       Integer seed to attempt to sample deterministically
     logprobs: int
       Include the log probabilities of most likely N per token
+Default: gpt-4o-mini
 
 ```
 <!-- [[[end]]] -->

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1121,6 +1121,7 @@ def models_list(options, async_):
             )
             output += "\n  Attachment types:\n{}".format(wrapper.fill(attachment_types))
         click.echo(output)
+    click.echo(f"Default: {get_default_model()}")
 
 
 @models.command(name="default")


### PR DESCRIPTION
Show the current default model in the list of models in the list printed by `llm models`.