### PR TITLE
Add `--input-style` feature for `prompt`

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -50,7 +50,8 @@ Will run a prompt of:
 ```
 
 You can change this with the `--input-style` argument; it supports the values `prepend` (the default), `append` (the opposite of `prepend`),
-and `fence-prepend` and `fence-append`, which will fence the standard input content with triple backticks before prepending or appending it.
+`fence-prepend` and `fence-append`, which will fence the standard input content with triple backticks before prepending or appending it, and
+finally `both` and `fence-both`, which could be useful with certain long-context models like GPT-4.1.
 
 For models that support them, {ref}`system prompts <usage-system-prompts>` are a better tool for this kind of prompting.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -48,6 +48,10 @@ Will run a prompt of:
 ```
 <contents of myscript.py> explain this code
 ```
+
+You can change this with the `--input-style` argument; it supports the values `prepend` (the default), `append` (the opposite of `prepend`),
+and `fence-prepend` and `fence-append`, which will fence the standard input content with triple backticks before prepending or appending it.
+
 For models that support them, {ref}`system prompts <usage-system-prompts>` are a better tool for this kind of prompting.
 
 (usage-model-options)=

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -446,6 +446,15 @@ def cli():
     help="How many chained tool responses to allow, default 5, set 0 for unlimited",
 )
 @click.option(
+    "--input-style",
+    type=click.Choice(["prepend", "append", "fence-prepend", "fence-append"]),
+    default="prepend",
+    help=(
+       "How to combine input given on the standard input, if any, with the prompt on the command line. "
+       "The default is 'prepend', i.e. the standard input is prepended to the command line prompt."
+    ),
+)
+@click.option(
     "options",
     "-o",
     "--option",
@@ -529,6 +538,7 @@ def prompt(
     tools_debug,
     tools_approve,
     chain_limit,
+    input_style,
     options,
     show_model_options,
     schema_input,
@@ -627,10 +637,16 @@ def prompt(
             stdin_prompt = sys.stdin.read()
 
         if stdin_prompt:
+            if "fence" in input_style:
+                stdin_prompt = stdin_prompt.strip('\n')
+                stdin_prompt = f"```\n{stdin_prompt}\n```"
+                sep = "\n\n"
+            else:
+                sep = " "
             bits = [stdin_prompt]
             if prompt:
-                bits.append(prompt)
-            prompt = " ".join(bits)
+                bits.insert(0 if "prepend" in input_style else 1, prompt)
+            prompt = sep.join(bits)
 
         if (
             prompt is None

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -447,7 +447,7 @@ def cli():
 )
 @click.option(
     "--input-style",
-    type=click.Choice(["prepend", "append", "fence-prepend", "fence-append"]),
+    type=click.Choice(["prepend", "append", "both", "fence-prepend", "fence-append", "fence-both"]),
     default="prepend",
     help=(
        "How to combine input given on the standard input, if any, with the prompt on the command line. "
@@ -645,7 +645,10 @@ def prompt(
                 sep = " "
             bits = [stdin_prompt]
             if prompt:
-                bits.insert(0 if "prepend" in input_style else 1, prompt)
+                if "prepend" in input_style or "both" in input_style:
+                    bits.insert(0, prompt)
+                if "append" in input_style or "both" in input_style:
+                    bits.append(prompt)
             prompt = sep.join(bits)
 
         if (

--- a/tests/test_prompt_style.py
+++ b/tests/test_prompt_style.py
@@ -1,0 +1,21 @@
+from click.testing import CliRunner
+from llm import cli
+import pytest
+
+
+@pytest.mark.parametrize(("style", "expected"), [
+    (None, "describe this input from stdin"),  # same as `prepend` (default)
+    ("append", "input from stdin describe this"),
+    ("fence-prepend", "describe this\n\n```\ninput from stdin\n```"),
+    ("fence-append", "```\ninput from stdin\n```\n\ndescribe this"),
+])
+def test_prompt_input_style(mock_model, logs_db, style, expected):
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.cli,
+        ["prompt", "-m", "mock", "describe this", *(["--input-style", style] if style else [])],
+        input="input from stdin",
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    assert mock_model.history[0][0].prompt == expected

--- a/tests/test_prompt_style.py
+++ b/tests/test_prompt_style.py
@@ -8,6 +8,8 @@ import pytest
     ("append", "input from stdin describe this"),
     ("fence-prepend", "describe this\n\n```\ninput from stdin\n```"),
     ("fence-append", "```\ninput from stdin\n```\n\ndescribe this"),
+    ("fence-both", "describe this\n\n```\ninput from stdin\n```\n\ndescribe this"),
+    ("both", "describe this input from stdin describe this"),
 ])
 def test_prompt_input_style(mock_model, logs_db, style, expected):
     runner = CliRunner()


### PR DESCRIPTION
This adds `--input-style` for `llm prompt`, which lets the operator choose how input from stdin is passed to the prompt.

For `llm prompt "describe this"` and `input from stdin` as the input, the final prompts would be:

### `--input-style=prepend` (the default, and the current behavior)

`input from stdin describe this`

### `--input-style=append`

`describe this input from stdin`

### `--input-style=fence-prepend`

````
```
input from stdin
```

describe this
````

### `--input-style=fence-append`

````
describe this

```
input from stdin
```
````
