### PR TITLE
Enable optional experimental TUI via Trogon

### DIFF
--- a/.github/workflows/cog.yml
+++ b/.github/workflows/cog.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install dependencies
-        run: pip install -e '.[test]'
+        run: pip install -e '.[test,tui]'
 
       - name: Run cog
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,9 @@ jobs:
       run: |
         pip install -e '.[test]'
         pip install 'pydantic${{ matrix.pydantic }}'
+    - name: Optionally install tui dependencies
+      run: |
+        pip install -e '.[tui]'
     - name: Run tests
       run: |
         pytest

--- a/Justfile
+++ b/Justfile
@@ -3,7 +3,7 @@
 
 # Install dependencies and test dependencies
 @init:
-  pipenv run pip install -e '.[test]'
+  pipenv run pip install -e '.[test, tui]'
 
 # Run pytest with supplied options
 @test *options:

--- a/docs/help.md
+++ b/docs/help.md
@@ -79,7 +79,19 @@ Commands:
   plugins       List installed plugins
   similar       Return top N similar IDs from a collection
   templates     Manage stored prompt templates
+  tui           Open Textual TUI.
   uninstall     Uninstall Python packages from the LLM environment
+```
+
+(help-tui)=
+### llm tui --help
+```
+Usage: llm tui [OPTIONS]
+
+  Open Textual TUI.
+
+Options:
+  --help  Show this message and exit.
 ```
 
 (help-prompt)=

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -526,3 +526,23 @@ When running a prompt you can pass the full model name or any of the aliases to 
 llm -m 4o \
   'As many names for cheesecakes as you can think of, with detailed descriptions'
 ```
+
+## Experimental TUI
+
+A TUI is a "text user interface" (or "terminal user interface") - a keyboard and mouse driven graphical interface running in your terminal.
+
+``llm`` has experimental support for a TUI for building command-line invocations, built on top of the [Trogon](https://github.com/Textualize/trogon) TUI library.
+
+To enable this feature you will need to install the ``trogon`` dependency. You can do that like so:
+
+```bash
+llm install trogon
+```
+
+Once installed, running the ``llm tui`` command will launch the TUI interface:
+
+```bash
+llm tui
+```
+
+You can then construct a command by selecting options from the menus, and execute it using ``Ctrl+R``.

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -54,6 +54,11 @@ from typing import cast, Optional, Iterable, Union, Tuple
 import warnings
 import yaml
 
+try:
+    import trogon  # type: ignore
+except ImportError:
+    trogon = None
+
 warnings.simplefilter("ignore", ResourceWarning)
 
 DEFAULT_TEMPLATE = "prompt: "
@@ -149,6 +154,10 @@ def cli():
 
         llm 'Five outrageous names for a pet pelican'
     """
+
+
+if trogon is not None:
+    cli = trogon.tui()(cli)
 
 
 @cli.command(name="prompt")

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,8 @@ setup(
             "types-click",
             "types-PyYAML",
             "types-setuptools",
-        ]
+        ],
+        "tui": ["trogon"],
     },
     python_requires=">=3.9",
 )


### PR DESCRIPTION
This PR adds the optional ability use a TUI via the [Trogon project](https://github.com/Textualize/trogon).  It follows the same pattern as [`sqlite_utils`](https://sqlite-utils.datasette.io/en/stable/index.html) by making it an optional dependency.

* `trogon` can be installed either via `llm install trogon` or during the installation of llm itself as in `pipx install 'llm[tui]'`.

* Using `cog` automatically adds the `tui` subcommand to the documentation.  An additional section is added to `usage.md` mimicking the language used in `sqlite_utils`.  There isn't currently any screen shot as part of the documentation like there is with `sqlite_utils`.

* The `cog.yml` and `test.yml` github action workflows now both also install `trogon` as well.


### Sample Screenshot
![Screenshot 2025-01-01 at 8 21 13 PM](https://github.com/user-attachments/assets/3f6183f9-4ace-4854-b98b-029e327d53fc)
