### PR TITLE
Add support for plugins to define custom template types

### DIFF
--- a/docs/plugins/plugin-hooks.md
+++ b/docs/plugins/plugin-hooks.md
@@ -59,3 +59,32 @@ This demonstrates how to register a model with both sync and async versions, and
 
 The {ref}`model plugin tutorial <tutorial-model-plugin>` describes how to use this hook in detail. Asynchronous models {ref}`are described here <advanced-model-plugins-async>`.
 
+(register-template-types)=
+## register_template_types()
+
+This hook allows plugins to register custom template types that can be used in prompt templates.
+
+```python
+from llm import Template, hookimpl
+
+class CustomTemplate(Template):
+    type: str = "custom"
+    
+    def evaluate(self, input: str, params=None):
+        # Custom processing here
+        prompt, system = super().evaluate(input, params)
+        return f"CUSTOM: {prompt}", system
+    
+    def stringify(self):
+        # Custom string representation for llm templates list
+        return f"custom template: {self.prompt}"
+
+@hookimpl
+def register_template_types():
+    return {
+        "custom": CustomTemplate
+    }
+```
+
+Custom template types can modify how prompts are processed and how they appear in template listings. See {ref}`templates <custom-template-types>` for more details.
+

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -213,3 +213,52 @@ Example:
 llm -t roast 'How are you today?'
 ```
 > I'm doing great but with your boring questions, I must admit, I've seen more life in a cemetery.
+
+(custom-template-types)=
+### Custom template types
+
+Plugins can register custom template types that provide additional functionality. These templates are identified by a `type:` key in their YAML configuration.
+
+For example, a plugin might provide a custom template type that adds special formatting or processing to the prompts:
+
+```yaml
+type: custom
+prompt: Hello $input
+system: Be helpful
+```
+
+Custom template types can customize how they appear in the template list by implementing a `stringify` method. This allows them to provide a more descriptive or formatted representation of their configuration when users run `llm templates list`.
+
+To create a custom template type in a plugin:
+
+1. Create a class that inherits from `Template`
+2. Set a `type` attribute to identify your template type
+3. Override methods like `evaluate` to customize behavior
+4. Optionally implement `stringify` to control how the template appears in listings
+5. Register your template type using the `register_template_types` hook
+
+For details on implementing the plugin hook, see {ref}`register_template_types() <register-template-types>`.
+
+Example plugin implementation:
+
+```python
+from llm import Template, hookimpl
+
+class CustomTemplate(Template):
+    type: str = "custom"
+    
+    def evaluate(self, input: str, params=None):
+        # Custom processing here
+        prompt, system = super().evaluate(input, params)
+        return f"CUSTOM: {prompt}", system
+    
+    def stringify(self):
+        # Custom string representation
+        return f"custom template: {self.prompt}"
+
+@hookimpl
+def register_template_types():
+    return {
+        "custom": CustomTemplate
+    }
+```

--- a/llm/hookspecs.py
+++ b/llm/hookspecs.py
@@ -18,3 +18,12 @@ def register_models(register):
 @hookspec
 def register_embedding_models(register):
     "Register additional model instances that can be used for embedding"
+
+
+@hookspec
+def register_template_types():
+    """Register additional template types that can be used for prompt templates.
+    
+    Returns:
+        dict: A dictionary mapping template type names to template classes
+    """

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,11 +1,53 @@
 from click.testing import CliRunner
+import click
 import json
-from llm import Template
-from llm.cli import cli
+from llm import Template, hookimpl
+from llm.cli import cli, load_template
+from llm.plugins import pm
 import os
 from unittest import mock
 import pytest
 import yaml
+
+
+class CustomTemplate(Template):
+    """A custom template type for testing."""
+    type: str = "custom"
+
+    def evaluate(self, input: str, params=None):
+        prompt, system = super().evaluate(input, params)
+        if prompt:
+            prompt = f"CUSTOM: {prompt}"
+        if system:
+            system = f"CUSTOM: {system}"
+        return prompt, system
+
+    def stringify(self):
+        parts = []
+        if self.prompt:
+            parts.append(f"custom prompt: {self.prompt}")
+        if self.system:
+            parts.append(f"custom system: {self.system}")
+        return " ".join(parts)
+
+
+class MockPlugin:
+    __name__ = "MockPlugin"
+
+    @hookimpl
+    def register_template_types(self):
+        return {
+            "custom": CustomTemplate
+        }
+
+
+@pytest.fixture
+def register_custom_template(monkeypatch):
+    pm.register(MockPlugin(), name="mock-plugin")
+    try:
+        yield
+    finally:
+        pm.unregister(name="mock-plugin")
 
 
 @pytest.mark.parametrize(
@@ -42,6 +84,72 @@ def test_template_evaluate(
         assert system == expected_system
 
 
+@pytest.mark.parametrize(
+    "template_yaml,expected_type,expected_prompt,expected_system,expected_error",
+    (
+        (
+            """
+            type: custom
+            prompt: Hello $input
+            system: Be helpful
+            """,
+            CustomTemplate,
+            "CUSTOM: Hello world",
+            "CUSTOM: Be helpful",
+            None,
+        ),
+        (
+            """
+            type: unknown
+            prompt: Hello $input
+            """,
+            None,
+            None,
+            None,
+            "Unknown template type: unknown",
+        ),
+        (
+            "Hello $input",
+            Template,
+            "Hello world",
+            None,
+            None,
+        ),
+        (
+            """
+            prompt: Hello $input
+            system: Be helpful
+            """,
+            Template,
+            "Hello world",
+            "Be helpful",
+            None,
+        ),
+    ),
+)
+def test_template_types(
+    register_custom_template,
+    templates_path,
+    template_yaml,
+    expected_type,
+    expected_prompt,
+    expected_system,
+    expected_error,
+):
+    (templates_path / "test.yaml").write_text(template_yaml, "utf-8")
+    if expected_error:
+        with pytest.raises(click.ClickException, match=expected_error):
+            load_template("test")
+    else:
+        template = load_template("test")
+        assert isinstance(template, expected_type)
+        if expected_type == CustomTemplate:
+            assert template.type == "custom"
+        prompt, system = template.evaluate("world")
+        assert prompt == expected_prompt
+        assert system == expected_system
+
+
 def test_templates_list_no_templates_found():
     runner = CliRunner()
     result = runner.invoke(cli, ["templates", "list"])
@@ -50,6 +158,7 @@ def test_templates_list_no_templates_found():
 
 
 @pytest.mark.parametrize("args", (["templates", "list"], ["templates"]))
+@pytest.mark.usefixtures("register_custom_template")
 def test_templates_list(templates_path, args):
     (templates_path / "one.yaml").write_text("template one", "utf-8")
     (templates_path / "two.yaml").write_text("template two", "utf-8")
@@ -63,17 +172,22 @@ def test_templates_list(templates_path, args):
         "system: summarize this\nprompt: $input", "utf-8"
     )
     (templates_path / "sys.yaml").write_text("system: Summarize this", "utf-8")
+    (templates_path / "custom.yaml").write_text(
+        "type: custom\nprompt: Hello $input", "utf-8"
+    )
     runner = CliRunner()
     result = runner.invoke(cli, args)
     assert result.exit_code == 0
-    assert result.output == (
-        "both  : system: summarize this prompt: $input\n"
-        "four  : this one has newlines in it\n"
-        "one   : template one\n"
-        "sys   : system: Summarize this\n"
-        "three : template three is very long template three is very long template thre...\n"
-        "two   : template two\n"
-    )
+    lines = result.output.strip().split("\n")
+    assert len(lines) == 7
+    assert lines[0] == "both   : system: summarize this prompt: $input"
+    assert lines[1] == "custom : custom prompt: Hello $input"
+    assert lines[2] == "four   : this one has newlines in it"
+    assert lines[3] == "one    : template one"
+    assert lines[4] == "sys    : system: Summarize this"
+    assert lines[5].startswith("three  : template three is very long template three is very long template")
+    assert lines[5].endswith("...")
+    assert lines[6] == "two    : template two"
 
 
 @pytest.mark.parametrize(
@@ -165,6 +279,50 @@ def test_templates_prompt_save(templates_path, args, expected_prompt, expected_e
     ),
 )
 def test_template_basic(
+    templates_path,
+    mocked_openai_chat,
+    template,
+    extra_args,
+    expected_model,
+    expected_input,
+    expected_error,
+):
+    (templates_path / "template.yaml").write_text(template, "utf-8")
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["--no-stream", "-t", "template", "Input text"] + extra_args,
+        catch_exceptions=False,
+    )
+    if expected_error is None:
+        assert result.exit_code == 0
+        last_request = mocked_openai_chat.get_requests()[-1]
+        assert json.loads(last_request.content) == {
+            "model": expected_model,
+            "messages": [{"role": "user", "content": expected_input}],
+            "stream": False,
+        }
+    else:
+        assert result.exit_code == 1
+        assert result.output.strip() == expected_error
+        mocked_openai_chat.reset()
+
+
+@mock.patch.dict(os.environ, {"OPENAI_API_KEY": "X"})
+@pytest.mark.parametrize(
+    "template,extra_args,expected_model,expected_input,expected_error",
+    (
+        (
+            "type: custom\nprompt: 'Say $hello'",
+            ["-p", "hello", "Blah"],
+            "gpt-4o-mini",
+            "CUSTOM: Say Blah",
+            None,
+        ),
+    ),
+)
+def test_template_basic_custom(
+    register_custom_template,
     templates_path,
     mocked_openai_chat,
     template,


### PR DESCRIPTION
* Introduced a new hook for registering additional template types.
* Updated the load_template function to handle custom template types and raise appropriate errors for unknown types.

Why?
I wanted to make use of DSPy in templates. This allows for the creation of an `llm-dspy` plugin that can support that.
