### PR TITLE
doc(plugin): adding amazon nova

### DIFF
--- a/docs/plugins/directory.md
+++ b/docs/plugins/directory.md
@@ -36,6 +36,7 @@ These plugins can be used to interact with remotely hosted models via their API:
 - **[llm-cohere](https://github.com/Accudio/llm-cohere)** by Alistair Shepherd provides `cohere-generate` and `cohere-summarize` API models, powered by [Cohere](https://cohere.com/).
 - **[llm-bedrock-anthropic](https://github.com/sblakey/llm-bedrock-anthropic)** by Sean Blakey adds support for Claude and Claude Instant by Anthropic via Amazon Bedrock.
 - **[llm-bedrock-meta](https://github.com/flabat/llm-bedrock-meta)** by Fabian Labat adds support for Llama 2 and Llama 3 by Meta via Amazon Bedrock.
+- **[llm-bedrock-nova](https://github.com/watany-dev/llm-bedrock-nova)** by Watanabe Yohei adds support for Nova by Amazon via Amazon Bedrock.
 - **[llm-together](https://github.com/wearedevx/llm-together)** adds support for the [Together AI](https://www.together.ai/) extensive family of hosted openly licensed models.
 - **[llm-lambda-labs](https://github.com/simonw/llm-lambda-labs)** provides access to models hosted by [Lambda Labs](https://docs.lambdalabs.com/public-cloud/lambda-chat-api/), including the Nous Hermes 3 series.
 


### PR DESCRIPTION
I have developed this plugin to call Amazon Nova from LLM tools. I would greatly appreciate it if you could include this in the plugin directory.
[Amazon Nova - Frontier Intelligence and Industry-Leading Price Performance](https://aws.amazon.com/jp/blogs/aws/introducing-amazon-nova-frontier-intelligence-and-industry-leading-price-performance/)