### PR TITLE
Add `llm-edit` to plugin directory

### DIFF
--- a/docs/plugins/directory.md
+++ b/docs/plugins/directory.md
@@ -1,4 +1,5 @@
 (plugin-directory)=
+
 # Plugin directory
 
 The following plugins are available for LLM. Here's {ref}`how to install them <installing-plugins>`.
@@ -6,7 +7,6 @@ The following plugins are available for LLM. Here's {ref}`how to install them <i
 ## Local models
 
 These plugins all help you run LLMs directly on your own computer:
-
 
 - **[llm-gguf](https://github.com/simonw/llm-gguf)** uses [llama.cpp](https://github.com/ggerganov/llama.cpp) to run models published in the GGUF format.
 - **[llm-mlc](https://github.com/simonw/llm-mlc)** can run local models released by the [MLC project](https://mlc.ai/mlc-llm/), including models that can take advantage of the GPU on Apple Silicon M1/M2 devices.
@@ -60,6 +60,7 @@ If an API model host provides an OpenAI-compatible API you can also [configure L
 - **[llm-python](https://github.com/simonw/llm-python)** adds a `llm python` command for running a Python interpreter in the same virtual environment as LLM. This is useful for debugging, and also provides a convenient way to interact with the LLM {ref}`python-api` if you installed LLM using Homebrew or `pipx`.
 - **[llm-cluster](https://github.com/simonw/llm-cluster)** adds a `llm cluster` command for calculating clusters for a collection of embeddings. Calculated clusters can then be passed to a Large Language Model to generate a summary description.
 - **[llm-jq](https://github.com/simonw/llm-jq)** lets you pipe in JSON data and a prompt describing a `jq` program, then executes the generated program against the JSON.
+- **[llm-edit](https://github.com/ajac-zero/llm-edit)** adds a `llm edit` command that allows LLM to quickly edit existing files or generate new files. The command can be passed additional context files to improve the model response.
 
 ## Just for fun
 


### PR DESCRIPTION
# LLM Edit

Hi! I've created a small plugin that makes generating or editing files with LLM super simple and fun, and I think some other users of LLM might find it useful.

The **reasoning** behind it is that I wanted a more convenient way to integrate LLM into my development workflow, taking advantage of the quick and easy access to so many models/providers from my terminal.

The **objective** of this plugin is to become a more lightweight version of aider, for those of us who prefer to use AI in a more targeted, efficient manner and in a terminal-native way, as opposed to other AI coding tools.

You can check out the repo [here](https://github.com/ajac-zero/llm-edit/)

Here's a little gif of llama 8b solving 'fizzbuzz' through the plugin:

![demo](https://github.com/user-attachments/assets/60905780-4531-4a6a-ba9c-c3780aa83245)
 