### PR TITLE
Add support for multiple template directories with LLM_TEMPLATE_PATH

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -213,3 +213,20 @@ Example:
 llm -t roast 'How are you today?'
 ```
 > I'm doing great but with your boring questions, I must admit, I've seen more life in a cemetery.
+
+## Template directories
+
+By default, templates are stored in the user's template directory, which can be found by running:
+
+```bash
+$ llm templates path
+/Users/simon/Library/Application Support/io.datasette.llm/templates
+```
+
+You can also specify additional directories to search for templates using the `LLM_TEMPLATE_PATH` environment variable. This is a comma-separated list of directories:
+
+```bash
+export LLM_TEMPLATE_PATH="/path/to/templates,/another/path/to/templates"
+```
+
+When searching for templates, LLM will look in the user's template directory first, followed by any additional directories specified in `LLM_TEMPLATE_PATH`. If a template with the same name exists in multiple directories, the one in the directory that appears first in the search path will be used.

--- a/llm/errors.py
+++ b/llm/errors.py
@@ -1,8 +1,10 @@
 class ModelError(Exception):
     "Models can raise this error, which will be displayed to the user"
+
     pass
 
 
 class NeedsKeyException(ModelError):
     "Model needs an API key which has not been provided"
+
     pass


### PR DESCRIPTION
**Changes in this PR:**
- Updates template loading and listing to work with multiple directories
- Adds LLM_TEMPLATE_PATH environment variable support

**Reasoning behind this change:** In a company setting, it's nice to be able to have a repo of shared prompts, in addition to the prompts that are in your user directory. By allowing a PATH-type env variable for multiple template directories, you can clone a repo of shared prompts and add that to your LLM_TEMPLATE_PATH. This lets you use version controlled shared prompts along with your personal user prompts.

Please let me know if this goes against the conventions for `llm`, or if there's any changes that would make this more merge-ready. Thanks! 😄 