### PR TITLE
Collections.exists now uses any

### DIFF
--- a/llm/embeddings.py
+++ b/llm/embeddings.py
@@ -332,8 +332,7 @@ class Collection:
         Args:
             name (str): Name of the collection
         """
-        rows = list(db["collections"].rows_where("name = ?", [name]))
-        return bool(rows)
+        return any(db["collections"].rows_where("name = ?", [name]))
 
     def delete(self):
         """


### PR DESCRIPTION
The `Collection.exists` classmethod in `llm.embedings` currently builds the entire list of results then applies `bool` to convert the result set to a boolean.

With this PR, the `Collection.exists` classmethod takes advantage of `any`'s early exiting to return `True` as soon as a result is found; otherwise, it will return `False`.