### PR TITLE
Add llm-azure to the plugins directory

### DIFF
--- a/docs/plugins/directory.md
+++ b/docs/plugins/directory.md
@@ -40,6 +40,7 @@ These plugins can be used to interact with remotely hosted models via their API:
 - **[llm-deepseek](https://github.com/abrasumente233/llm-deepseek)** adds support for the [DeepSeek](https://deepseek.com)'s DeepSeek-Chat and DeepSeek-Coder models.
 - **[llm-lambda-labs](https://github.com/simonw/llm-lambda-labs)** provides access to models hosted by [Lambda Labs](https://docs.lambdalabs.com/public-cloud/lambda-chat-api/), including the Nous Hermes 3 series.
 - **[llm-venice](https://github.com/ar-jan/llm-venice)** provides access to uncensored models hosted by privacy-focused [Venice AI](https://docs.venice.ai/), including Llama 3.1 405B.
+- **[llm-azure](https://github.com/fabge/llm-azure/)** adds support for OpenAI models hosted using [Azure OpenAI Service](https://azure.microsoft.com/en-us/products/ai-services/openai-service).
 
 If an API model host provides an OpenAI-compatible API you can also [configure LLM to talk to it](https://llm.datasette.io/en/stable/other-models.html#openai-compatible-models) without needing an extra plugin.
 


### PR DESCRIPTION
[`llm-azure`](https://github.com/fabge/llm-azure/) by fabge is missing from the plugins directory. My understanding is that this plugin is currently the best way to use `llm` with Azure deployed OpenAI endpoints.