### PR TITLE
KeyModel and AsyncKeyModel classes for models that taken keys

### DIFF
--- a/docs/plugins/advanced-model-plugins.md
+++ b/docs/plugins/advanced-model-plugins.md
@@ -5,6 +5,33 @@ The {ref}`model plugin tutorial <tutorial-model-plugin>` covers the basics of de
 
 This document covers more advanced topics.
 
+(advanced-model-plugins-api-keys)=
+
+## Models that accept API keys
+
+Models that call out to API providers such as OpenAI, Anthropic or Google Gemini usually require an API key.
+
+LLM's API key management mechanism {ref}`is described here <api-keys>`.
+
+If your plugin requires an API key you should subclass the `llm.KeyModel` class instead of the `llm.Model` class. Start your model definition like this:
+
+```python
+import llm
+
+class HostedModel(llm.KeyModel):
+    needs_key = "hosted" # Required
+    key_env_var = "HOSTED_API_KEY" # Optional
+```
+This tells LLM that your model requires an API key, which may be saved in the key registry under the key name `hosted` or might also be provided as the `HOSTED_API_KEY` environment variable.
+
+Then when you define your `execute()` method it should take an extra `key=` parameter like this:
+
+```python
+    def execute(self, prompt, stream, response, conversation, key=None):
+        # key= here will be the API key to use
+```
+LLM will pass in the key from the environment variable, key registry or that has been passed to LLM as the `--key` command-line option or the `model.prompt(..., key=)` parameter.
+
 (advanced-model-plugins-async)=
 
 ## Async models
@@ -15,13 +42,12 @@ The async version of a model subclasses `llm.AsyncModel` instead of `llm.Model`.
 
 This example shows a subset of the OpenAI default plugin illustrating how this method might work:
 
-
 ```python
 from typing import AsyncGenerator
 import llm
 
 class MyAsyncModel(llm.AsyncModel):
-    # This cn duplicate the model_id of the sync model:
+    # This can duplicate the model_id of the sync model:
     model_id = "my-model-id"
 
     async def execute(
@@ -43,6 +69,17 @@ class MyAsyncModel(llm.AsyncModel):
             )
             yield completion.choices[0].message.content
 ```
+If your model takes an API key you should instead subclass `llm.AsyncKeyModel` and have a `key=` parameter on your `.execute()` method:
+
+```python
+class MyAsyncModel(llm.AsyncKeyModel):
+    ...
+    async def execute(
+        self, prompt, stream, response, conversation=None, key=None
+    ) -> AsyncGenerator[str, None]:
+```
+
+
 This async model instance should then be passed to the `register()` method in the `register_models()` plugin hook:
 
 ```python

--- a/docs/plugins/tutorial-model-plugin.md
+++ b/docs/plugins/tutorial-model-plugin.md
@@ -1,5 +1,6 @@
 (tutorial-model-plugin)=
-# Model plugin tutorial
+
+# Developing a model plugin
 
 This tutorial will walk you through developing a new plugin for LLM that adds support for a new Large Language Model.
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -94,6 +94,21 @@ model = llm.get_model()
 print(model.prompt("Names for otters", temperature=0.2))
 ```
 
+(python-api-models-api-keys)=
+
+### Passing an API key
+
+Models that accept API keys should take an additional `key=` parameter to their `model.prompt()` method:
+
+```python
+model = llm.get_model("gpt-4o-mini")
+print(model.prompt("Names for beavers", key="sk-..."))
+```
+
+If you don't provide this argument LLM will attempt to find it from an environment variable (`OPENAI_API_KEY` for OpenAI, others for different plugins) or from keys that have been saved using the {ref}`llm keys set <api-keys>` command.
+
+Some model plugins may not yet have been upgraded to handle the `key=` parameter, in which case you will need to use one of the other mechanisms.
+
 (python-api-models-from-plugins)=
 
 ### Models from plugins

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -207,26 +207,6 @@ The `response.text()` method described earlier does this for you - it runs throu
 
 If a response has been evaluated, `response.text()` will continue to return the same string.
 
-(python-api-listing-models)=
-
-## Listing models
-
-The `llm.get_models()` list returns a list of all available models, including those from plugins.
-
-```python
-import llm
-
-for model in llm.get_models():
-    print(model.model_id)
-```
-
-Use `llm.get_async_models()` to list async models:
-
-```python
-for model in llm.get_async_models():
-    print(model.model_id)
-```
-
 (python-api-async)=
 
 ## Async models
@@ -254,6 +234,7 @@ async for chunk in model.prompt(
 ):
     print(chunk, end="", flush=True)
 ```
+This `await model.prompt()` method takes the same arguments as the synchronous `model.prompt()` method, for options and attachments and `key=` and suchlike.
 
 (python-api-conversations)=
 
@@ -291,6 +272,26 @@ response = conversation.prompt(
 ```
 
 Access `conversation.responses` for a list of all of the responses that have so far been returned during the conversation.
+
+(python-api-listing-models)=
+
+## Listing models
+
+The `llm.get_models()` list returns a list of all available models, including those from plugins.
+
+```python
+import llm
+
+for model in llm.get_models():
+    print(model.model_id)
+```
+
+Use `llm.get_async_models()` to list async models:
+
+```python
+for model in llm.get_async_models():
+    print(model.model_id)
+```
 
 (python-api-response-on-done)=
 

--- a/llm/__init__.py
+++ b/llm/__init__.py
@@ -4,14 +4,16 @@ from .errors import (
     NeedsKeyException,
 )
 from .models import (
+    AsyncKeyModel,
     AsyncModel,
     AsyncResponse,
     Attachment,
     Conversation,
-    Model,
-    ModelWithAliases,
     EmbeddingModel,
     EmbeddingModelWithAliases,
+    KeyModel,
+    Model,
+    ModelWithAliases,
     Options,
     Prompt,
     Response,
@@ -27,22 +29,24 @@ import pathlib
 import struct
 
 __all__ = [
-    "hookimpl",
-    "get_async_model",
-    "get_model",
-    "get_key",
-    "user_dir",
+    "AsyncKeyModel",
     "AsyncResponse",
     "Attachment",
     "Collection",
     "Conversation",
+    "get_async_model",
+    "get_key",
+    "get_model",
+    "hookimpl",
+    "KeyModel",
     "Model",
+    "ModelError",
+    "NeedsKeyException",
     "Options",
     "Prompt",
     "Response",
     "Template",
-    "ModelError",
-    "NeedsKeyException",
+    "user_dir",
 ]
 DEFAULT_MODEL = "gpt-4o-mini"
 

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -7,12 +7,14 @@ import json
 import re
 from llm import (
     Attachment,
+    AsyncKeyModel,
     AsyncResponse,
     Collection,
     Conversation,
     Response,
     Template,
     UnknownModelError,
+    KeyModel,
     encode,
     get_async_model,
     get_default_model,
@@ -382,10 +384,6 @@ def prompt(
     except UnknownModelError as ex:
         raise click.ClickException(ex)
 
-    # Provide the API key, if one is needed and has been provided
-    if model.needs_key:
-        model.key = get_key(key, model.needs_key, model.key_env_var)
-
     if conversation:
         # To ensure it can see the key
         conversation.model = model
@@ -403,11 +401,16 @@ def prompt(
         except pydantic.ValidationError as ex:
             raise click.ClickException(render_errors(ex.errors()))
 
+    kwargs = {**validated_options}
+
     resolved_attachments = [*attachments, *attachment_types]
 
     should_stream = model.can_stream and not no_stream
     if not should_stream:
-        validated_options["stream"] = False
+        kwargs["stream"] = False
+
+    if isinstance(model, (KeyModel, AsyncKeyModel)):
+        kwargs["key"] = key
 
     prompt = read_prompt()
     response = None
@@ -425,7 +428,7 @@ def prompt(
                         prompt,
                         attachments=resolved_attachments,
                         system=system,
-                        **validated_options,
+                        **kwargs,
                     )
                     async for chunk in response:
                         print(chunk, end="")
@@ -436,7 +439,7 @@ def prompt(
                         prompt,
                         attachments=resolved_attachments,
                         system=system,
-                        **validated_options,
+                        **kwargs,
                     )
                     text = await response.text()
                     if extract or extract_last:
@@ -452,7 +455,7 @@ def prompt(
                 prompt,
                 attachments=resolved_attachments,
                 system=system,
-                **validated_options,
+                **kwargs,
             )
             if should_stream:
                 for chunk in response:

--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -1,4 +1,4 @@
-from llm import AsyncModel, EmbeddingModel, KeyModel, hookimpl
+from llm import AsyncKeyModel, EmbeddingModel, KeyModel, hookimpl
 import llm
 from llm.utils import (
     dicts_to_table_string,
@@ -567,7 +567,7 @@ class Chat(_Shared, KeyModel):
         response._prompt_json = redact_data({"messages": messages})
 
 
-class AsyncChat(_Shared, AsyncModel):
+class AsyncChat(_Shared, AsyncKeyModel):
     needs_key = "openai"
     key_env_var = "OPENAI_API_KEY"
     default_max_tokens = None

--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -1,4 +1,4 @@
-from llm import AsyncModel, EmbeddingModel, Model, hookimpl
+from llm import AsyncModel, EmbeddingModel, KeyModel, hookimpl
 import llm
 from llm.utils import (
     dicts_to_table_string,
@@ -479,7 +479,7 @@ class _Shared:
             input=input_tokens, output=output_tokens, details=simplify_usage_dict(usage)
         )
 
-    def get_client(self, async_=False):
+    def get_client(self, key, *, async_=False):
         kwargs = {}
         if self.api_base:
             kwargs["base_url"] = self.api_base
@@ -490,7 +490,7 @@ class _Shared:
         if self.api_engine:
             kwargs["engine"] = self.api_engine
         if self.needs_key:
-            kwargs["api_key"] = self.get_key()
+            kwargs["api_key"] = self.get_key(key)
         else:
             # OpenAI-compatible models don't need a key, but the
             # openai client library requires one
@@ -516,7 +516,7 @@ class _Shared:
         return kwargs
 
 
-class Chat(_Shared, Model):
+class Chat(_Shared, KeyModel):
     needs_key = "openai"
     key_env_var = "OPENAI_API_KEY"
     default_max_tokens = None
@@ -527,12 +527,12 @@ class Chat(_Shared, Model):
             default=None,
         )
 
-    def execute(self, prompt, stream, response, conversation=None):
+    def execute(self, prompt, stream, response, conversation=None, key=None):
         if prompt.system and not self.allows_system_prompt:
             raise NotImplementedError("Model does not support system prompts")
         messages = self.build_messages(prompt, conversation)
         kwargs = self.build_kwargs(prompt, stream)
-        client = self.get_client()
+        client = self.get_client(key)
         usage = None
         if stream:
             completion = client.chat.completions.create(
@@ -579,13 +579,13 @@ class AsyncChat(_Shared, AsyncModel):
         )
 
     async def execute(
-        self, prompt, stream, response, conversation=None
+        self, prompt, stream, response, conversation=None, key=None
     ) -> AsyncGenerator[str, None]:
         if prompt.system and not self.allows_system_prompt:
             raise NotImplementedError("Model does not support system prompts")
         messages = self.build_messages(prompt, conversation)
         kwargs = self.build_kwargs(prompt, stream)
-        client = self.get_client(async_=True)
+        client = self.get_client(key, async_=True)
         usage = None
         if stream:
             completion = await client.chat.completions.create(
@@ -635,7 +635,7 @@ class Completion(Chat):
     def __str__(self):
         return "OpenAI Completion: {}".format(self.model_id)
 
-    def execute(self, prompt, stream, response, conversation=None):
+    def execute(self, prompt, stream, response, conversation=None, key=None):
         if prompt.system:
             raise NotImplementedError(
                 "System prompts are not supported for OpenAI completion models"
@@ -647,7 +647,7 @@ class Completion(Chat):
                 messages.append(prev_response.text())
         messages.append(prompt.prompt)
         kwargs = self.build_kwargs(prompt, stream)
-        client = self.get_client()
+        client = self.get_client(key)
         if stream:
             completion = client.completions.create(
                 model=self.model_name or self.model_id,

--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -212,7 +212,7 @@ def register_commands(cli):
     @click.option("--key", help="OpenAI API key")
     def models(json_, key):
         "List models available to you from the OpenAI API"
-        from llm.cli import get_key
+        from llm import get_key
 
         api_key = get_key(key, "openai", "OPENAI_API_KEY")
         response = httpx.get(

--- a/llm/models.py
+++ b/llm/models.py
@@ -699,6 +699,8 @@ class Model(_Model):
 
 
 class KeyModel(_Model):
+    needs_key = True
+
     @abstractmethod
     def execute(
         self,
@@ -753,6 +755,8 @@ class AsyncModel(_AsyncModel):
 
 
 class AsyncKeyModel(_AsyncModel):
+    needs_key = True
+
     @abstractmethod
     async def execute(
         self,

--- a/llm/models.py
+++ b/llm/models.py
@@ -150,6 +150,7 @@ class Conversation(_BaseConversation):
         attachments: Optional[List[Attachment]] = None,
         system: Optional[str] = None,
         stream: bool = True,
+        key: Optional[str] = None,
         **options,
     ) -> "Response":
         return Response(
@@ -163,6 +164,7 @@ class Conversation(_BaseConversation):
             self.model,
             stream,
             conversation=self,
+            key=key,
         )
 
 
@@ -175,6 +177,7 @@ class AsyncConversation(_BaseConversation):
         attachments: Optional[List[Attachment]] = None,
         system: Optional[str] = None,
         stream: bool = True,
+        key: Optional[str] = None,
         **options,
     ) -> "AsyncResponse":
         return AsyncResponse(
@@ -188,6 +191,7 @@ class AsyncConversation(_BaseConversation):
             self.model,
             stream,
             conversation=self,
+            key=key,
         )
 
 
@@ -666,6 +670,7 @@ class _Model(_BaseModel):
         stream: bool = True,
         **options,
     ) -> Response:
+        key = options.pop("key", None)
         self._validate_attachments(attachments)
         return Response(
             Prompt(
@@ -677,6 +682,7 @@ class _Model(_BaseModel):
             ),
             self,
             stream,
+            key=key,
         )
 
 
@@ -718,6 +724,7 @@ class _AsyncModel(_BaseModel):
         stream: bool = True,
         **options,
     ) -> AsyncResponse:
+        key = options.pop("key", None)
         self._validate_attachments(attachments)
         return AsyncResponse(
             Prompt(
@@ -729,6 +736,7 @@ class _AsyncModel(_BaseModel):
             ),
             self,
             stream,
+            key=key,
         )
 
 
@@ -753,8 +761,8 @@ class AsyncKeyModel(_AsyncModel):
         response: AsyncResponse,
         conversation: Optional[AsyncConversation],
         key: Optional[str],
-    ) -> Iterator[str]:
-        pass
+    ) -> AsyncGenerator[str, None]:
+        yield ""
 
 
 class EmbeddingModel(ABC, _get_key_mixin):

--- a/llm/models.py
+++ b/llm/models.py
@@ -699,8 +699,6 @@ class Model(_Model):
 
 
 class KeyModel(_Model):
-    needs_key = True
-
     @abstractmethod
     def execute(
         self,
@@ -755,8 +753,6 @@ class AsyncModel(_AsyncModel):
 
 
 class AsyncKeyModel(_AsyncModel):
-    needs_key = True
-
     @abstractmethod
     async def execute(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,6 +81,7 @@ class MockModel(llm.Model):
 
 class MockKeyModel(llm.KeyModel):
     model_id = "mock_key"
+    needs_key = "mock"
 
     def execute(self, prompt, stream, response, conversation, key):
         return [f"key: {key}"]
@@ -88,6 +89,7 @@ class MockKeyModel(llm.KeyModel):
 
 class MockAsyncKeyModel(llm.AsyncKeyModel):
     model_id = "mock_key"
+    needs_key = "mock"
 
     async def execute(self, prompt, stream, response, conversation, key):
         yield f"async, key: {key}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,6 +79,20 @@ class MockModel(llm.Model):
         response.set_usage(input=len(prompt.prompt.split()), output=len(gathered))
 
 
+class MockKeyModel(llm.KeyModel):
+    model_id = "mock_key"
+
+    def execute(self, prompt, stream, response, conversation, key):
+        return [f"key: {key}"]
+
+
+class MockAsyncKeyModel(llm.AsyncKeyModel):
+    model_id = "mock_key"
+
+    async def execute(self, prompt, stream, response, conversation, key):
+        yield f"async, key: {key}"
+
+
 class AsyncMockModel(llm.AsyncModel):
     model_id = "mock"
 
@@ -151,6 +165,16 @@ def mock_model():
 @pytest.fixture
 def async_mock_model():
     return AsyncMockModel()
+
+
+@pytest.fixture
+def mock_key_model():
+    return MockKeyModel()
+
+
+@pytest.fixture
+def mock_async_key_model():
+    return MockAsyncKeyModel()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -749,6 +749,18 @@ def test_mock_model(mock_model):
     assert response2.usage() == Usage(input=2, output=1, details=None)
 
 
+def test_mock_key_model(mock_key_model):
+    response = mock_key_model.prompt(prompt="hello", key="hi")
+    assert response.text() == "key: hi"
+
+
+@pytest.mark.asyncio
+async def test_mock_async_key_model(mock_async_key_model):
+    response = mock_async_key_model.prompt(prompt="hello", key="hi")
+    output = await response.text()
+    assert output == "async, key: hi"
+
+
 def test_sync_on_done(mock_model):
     mock_model.enqueue(["hello world"])
     model = llm.get_model("mock")

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -718,7 +718,7 @@ def test_model_defaults(tmpdir, monkeypatch):
 
 def test_get_models():
     models = llm.get_models()
-    assert all(isinstance(model, llm.Model) for model in models)
+    assert all(isinstance(model, (llm.Model, llm.KeyModel)) for model in models)
     model_ids = [model.model_id for model in models]
     assert "gpt-4o-mini" in model_ids
     # Ensure no model_ids are duplicated

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -728,7 +728,9 @@ def test_get_models():
 
 def test_get_async_models():
     models = llm.get_async_models()
-    assert all(isinstance(model, llm.AsyncModel) for model in models)
+    assert all(
+        isinstance(model, (llm.AsyncModel, llm.AsyncKeyModel)) for model in models
+    )
     model_ids = [model.model_id for model in models]
     assert "gpt-4o-mini" in model_ids
 


### PR DESCRIPTION
Refs:
- #744

Still needs:
- [x] CLI should use the new mechanism for the `--key` option
  - [x] For `llm prompt`
  - [x] For `llm chat`
  - (I just noticed that `llm embed` doesn't take a `--key` option - think about that) - #757 
- [x] Automated test that checks the new `key=` parameter works correctly
- [x] More manual testing
- [x] Updated Python API documentation
- [x] Updated plugin author documentation
- [x] At least one other plugin ported to it in order to check the design is good
- [x] ~Build a Datasette plugin demo showing that it can run prompts with different API keys (this was the end goal)~ will do this later, I'm confident it works.