### PR TITLE
Allow "reasoning" for extra-openai-models.yaml

### DIFF
--- a/docs/openai-models.md
+++ b/docs/openai-models.md
@@ -123,6 +123,8 @@ The `model_id` is the identifier that will be recorded in the LLM logs. You can 
 
 If the model is a completion model (such as `gpt-3.5-turbo-instruct`) add `completion: true` to the configuration.
 
+For reasoning models like `o1` or `o3-mini` add `reasoning: true`.
+
 With this configuration in place, the following command should run a prompt against the new model:
 
 ```bash

--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -114,6 +114,7 @@ def register_models(register):
         api_version = extra_model.get("api_version")
         api_engine = extra_model.get("api_engine")
         headers = extra_model.get("headers")
+        reasoning = extra_model.get("reasoning")
         kwargs = {}
         if extra_model.get("can_stream") is False:
             kwargs["can_stream"] = False
@@ -129,6 +130,7 @@ def register_models(register):
             api_version=api_version,
             api_engine=api_engine,
             headers=headers,
+            reasoning=reasoning,
             **kwargs,
         )
         if api_base:


### PR DESCRIPTION
Currently you get an error when trying to use `-o reasoning_effort high` with a model that has been defined in `extra-openai-models.yaml`.  This allows an optional `reasoning` field.