### PR TITLE
Add note about similarity function in "similar" command's doc

### DIFF
--- a/docs/embeddings/cli.md
+++ b/docs/embeddings/cli.md
@@ -325,7 +325,7 @@ llm embed-multi photos \
 (embeddings-cli-similar)=
 ## llm similar
 
-The `llm similar` command searches a collection of embeddings for the items that are most similar to a given or item ID.
+The `llm similar` command searches a collection of embeddings for the items that are most similar to a given or item ID. Cosine similarity is used in similarity calculation.
 
 This currently uses a slow brute-force approach which does not scale well to large collections. See [issue 216](https://github.com/simonw/llm/issues/216) for plans to add a more scalable approach via vector indexes provided by plugins.
 

--- a/docs/embeddings/cli.md
+++ b/docs/embeddings/cli.md
@@ -325,7 +325,7 @@ llm embed-multi photos \
 (embeddings-cli-similar)=
 ## llm similar
 
-The `llm similar` command searches a collection of embeddings for the items that are most similar to a given or item ID. Cosine similarity is used in similarity calculation.
+The `llm similar` command searches a collection of embeddings for the items that are most similar to a given or item ID, based on [cosine similarity](https://en.wikipedia.org/wiki/Cosine_similarity).
 
 This currently uses a slow brute-force approach which does not scale well to large collections. See [issue 216](https://github.com/simonw/llm/issues/216) for plans to add a more scalable approach via vector indexes provided by plugins.
 

--- a/docs/help.md
+++ b/docs/help.md
@@ -77,7 +77,7 @@ Commands:
   models        Manage available models
   openai        Commands for working directly with the OpenAI API
   plugins       List installed plugins
-  similar       Return top N similar IDs from a collection
+  similar       Return top N similar IDs from a collection using cosine...
   templates     Manage stored prompt templates
   uninstall     Uninstall Python packages from the LLM environment
 ```
@@ -591,7 +591,7 @@ Options:
 ```
 Usage: llm similar [OPTIONS] COLLECTION [ID]
 
-  Return top N similar IDs from a collection
+  Return top N similar IDs from a collection using cosine similarity.
 
   Example usage:
 

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1820,7 +1820,7 @@ def embed_multi(
 )
 def similar(collection, id, input, content, binary, number, database):
     """
-    Return top N similar IDs from a collection
+    Return top N similar IDs from a collection. Cosine similarity is used in similarity calculation.
 
     Example usage:
 

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1820,7 +1820,7 @@ def embed_multi(
 )
 def similar(collection, id, input, content, binary, number, database):
     """
-    Return top N similar IDs from a collection. Cosine similarity is used in similarity calculation.
+    Return top N similar IDs from a collection using cosine similarity.
 
     Example usage:
 


### PR DESCRIPTION
Hi there! Thank you for sharing this great tool.

This is a minor documentation update.
Users like me might want to know what similarity function is used in `similar` commands since there are several similarity functions and modern Vector Search Engines usually support multiple similarity metrics (examples:  [Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/dense-vector.html#dense-vector-params), [Qdrant](https://qdrant.tech/documentation/concepts/search/#metrics)).
