### PR TITLE
llm prompt --schema X option and model.prompt(..., schema=) parameter

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -411,7 +411,7 @@ There's also a new {ref}`llm.Collection <embeddings-python-collections>` class f
 - The output format for `llm logs` has changed. Previously it was JSON - it's now a much more readable Markdown format suitable for pasting into other documents. [#160](https://github.com/simonw/llm/issues/160)
   - The new `llm logs --json` option can be used to get the old JSON format.
   - Pass `llm logs --conversation ID` or `--cid ID` to see the full logs for a specific conversation.
-- You can now combine piped input and a prompt in a single command: `cat script.py | llm 'explain this code'`. This works even for models that do not support {ref}`system prompts <system-prompts>`. [#153](https://github.com/simonw/llm/issues/153)
+- You can now combine piped input and a prompt in a single command: `cat script.py | llm 'explain this code'`. This works even for models that do not support {ref}`system prompts <usage-system-prompts>`. [#153](https://github.com/simonw/llm/issues/153)
 - Additional {ref}`openai-compatible-models` can now be configured with custom HTTP headers. This enables platforms such as [openrouter.ai](https://openrouter.ai/) to be used with LLM, which can provide Claude access even without an Anthropic API key.
 - Keys set in `keys.json` are now used in preference to environment variables. [#158](https://github.com/simonw/llm/issues/158)
 - The documentation now includes a {ref}`plugin directory <plugin-directory>` listing all available plugins for LLM. [#173](https://github.com/simonw/llm/issues/173)

--- a/docs/help.md
+++ b/docs/help.md
@@ -117,6 +117,7 @@ Options:
   --at, --attachment-type <TEXT TEXT>...
                                   Attachment with explicit mimetype
   -o, --option <TEXT TEXT>...     key/value options for the model
+  --schema TEXT                   JSON schema to use for output
   -t, --template TEXT             Template to use
   -p, --param <TEXT TEXT>...      Parameters for template
   --no-stream                     Do not stream output

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -157,7 +157,7 @@ Example output:
 (logs-conversation)=
 ### Logs for a conversation
 
-To view the logs for the most recent {ref}`conversation <conversation>` you have had with a model, use `-c`:
+To view the logs for the most recent {ref}`conversation <usage-conversation>` you have had with a model, use `-c`:
 
 ```bash
 llm logs -c

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -209,7 +209,7 @@ def cleanup_sql(sql):
     return first_line + '(\n  ' + ',\n  '.join(columns) + '\n);'
 
 cog.out("```sql\n")
-for table in ("conversations", "responses", "responses_fts", "attachments", "prompt_attachments"):
+for table in ("conversations", "schemas", "responses", "responses_fts", "attachments", "prompt_attachments"):
     schema = db[table].schema
     cog.out(format(cleanup_sql(schema)))
     cog.out("\n")
@@ -221,7 +221,11 @@ CREATE TABLE [conversations] (
   [name] TEXT,
   [model] TEXT
 );
-CREATE TABLE [responses] (
+CREATE TABLE [schemas] (
+  [id] TEXT PRIMARY KEY,
+  [content] TEXT
+);
+CREATE TABLE "responses" (
   [id] TEXT PRIMARY KEY,
   [model] TEXT,
   [prompt] TEXT,
@@ -235,7 +239,8 @@ CREATE TABLE [responses] (
   [datetime_utc] TEXT,
   [input_tokens] INTEGER,
   [output_tokens] INTEGER,
-  [token_details] TEXT
+  [token_details] TEXT,
+  [schema_id] TEXT REFERENCES [schemas]([id])
 );
 CREATE VIRTUAL TABLE [responses_fts] USING FTS5 (
   [prompt],

--- a/docs/plugins/advanced-model-plugins.md
+++ b/docs/plugins/advanced-model-plugins.md
@@ -90,6 +90,21 @@ def register_models(register):
     )
 ```
 
+(advanced-model-plugins-schemas)=
+
+## Supporting schemas
+
+If your model supports {ref}`structured output <python-api-schemas>` against a defined JSON schema you can implement support by first adding `supports_schema = True` to the class:
+
+```python
+class MyModel(llm.KeyModel):
+    ...
+    support_schema = True
+```
+And then adding code to your `.execute()` method that checks for `prompt.schema` and, if it is present, uses that to prompt the model. `prompt.schema` will always be a Python dictionary, even if the user passed in a Pydantic model class.
+
+Check the [llm-gemini](https://github.com/simonw/llm-gemini) and [llm-anthropic](https://github.com/simonw/llm-anthropic) plugins for example of this pattern in action.
+
 (advanced-model-plugins-attachments)=
 
 ## Attachments for multi-modal models

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -83,6 +83,41 @@ if "image/jpeg" in model.attachment_types:
     ...
 ```
 
+(python-api-schemas)=
+
+### Schemas
+
+As with {ref}`the CLI tool <usage-schemas>` some models support passing a JSON schema should be used for the resulting response.
+
+You can pass this to the `prompt(schema=)` parameter as either a Python dictionary or a [Pydantic](https://docs.pydantic.dev/) `BaseModel` subclass:
+
+```python
+import llm, json
+from pydantic import BaseModel
+
+class Dog(BaseModel):
+    name: str
+    age: int
+
+model = llm.get_model("gpt-4o-mini")
+response = model.prompt("Describe a nice dog", schema=Dog)
+dog = json.loads(response.text())
+print(dog)
+# {"name":"Buddy","age":3}
+```
+You can also pass a schema directly, like this:
+```python
+response = model.prompt("Describe a nice dog", schema={
+    "properties": {
+        "name": {"title": "Name", "type": "string"},
+        "age": {"title": "Age", "type": "integer"},
+    },
+    "required": ["name", "age"],
+    "title": "Dog",
+    "type": "object",
+})
+```
+
 (python-api-model-options)=
 
 ### Model options

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -38,7 +38,7 @@ Will run a prompt of:
 ```
 <contents of myscript.py> explain this code
 ```
-For models that support them, {ref}`system prompts <system-prompts>` are a better tool for this kind of prompting.
+For models that support them, {ref}`system prompts <usage-system-prompts>` are a better tool for this kind of prompting.
 
 Some models support options. You can pass these using `-o/--option name value` - for example, to set the temperature to 1.5 run this:
 
@@ -88,7 +88,7 @@ LLM will attempt to automatically detect the content type of the image. If this 
 cat myfile | llm "describe this image" --at - image/jpeg
 ```
 
-(system-prompts)=
+(usage-system-prompts)=
 ### System prompts
 
 You can use `-s/--system '...'` to set a system prompt.
@@ -122,6 +122,7 @@ cat llm/utils.py | llm -t pytest
 ```
 See {ref}`prompt templates <prompt-templates>` for more.
 
+(usage-schemas)=
 ### Schemas
 
 Some models include the ability to return JSON that matches a provided [JSON schema](https://json-schema.org/). Models from OpenAI, Anthropic and Google Gemini all include this capability.
@@ -155,7 +156,7 @@ The JSON returned from the model should match that schema.
 
 Be warned that different models may support different dialects of the JSON schema specification.
 
-(conversation)=
+(usage-conversation)=
 ### Continuing a conversation
 
 By default, the tool will start a new conversation each time you run it.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -122,6 +122,39 @@ cat llm/utils.py | llm -t pytest
 ```
 See {ref}`prompt templates <prompt-templates>` for more.
 
+### Schemas
+
+Some models include the ability to return JSON that matches a provided [JSON schema](https://json-schema.org/). Models from OpenAI, Anthropic and Google Gemini all include this capability.
+
+LLM has alpha functionality for specifying a schema to use for the response to a prompt.
+
+Create the schema as a JSON string, then pass that to the `--schema` option. For example:
+
+```bash
+llm --schema '{
+  "type": "object",
+  "properties": {
+    "dogs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "bio": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}' -m gpt-4o-mini 'invent two dogs'
+```
+The JSON returned from the model should match that schema.
+
+Be warned that different models may support different dialects of the JSON schema specification.
+
 (conversation)=
 ### Continuing a conversation
 

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1138,6 +1138,12 @@ def logs_list(
                 if row["system"] is not None:
                     click.echo("\n## System:\n\n{}".format(row["system"]))
                 current_system = row["system"]
+            if row["schema_json"]:
+                click.echo(
+                    "\n## Schema:\n\n```json\n{}\n```".format(
+                        json.dumps(row["schema_json"], indent=2)
+                    )
+                )
             attachments = attachments_by_id.get(row["id"])
             if attachments:
                 click.echo("\n### Attachments\n")
@@ -1162,7 +1168,15 @@ def logs_list(
                             )
                         )
 
-            click.echo("\n## Response:\n\n{}\n".format(row["response"]))
+            # If a schema was provided and the row is valid JSON, pretty print and syntax highlight it
+            response = row["response"]
+            if row["schema_json"]:
+                try:
+                    parsed = json.loads(response)
+                    response = "```json\n{}\n```".format(json.dumps(parsed, indent=2))
+                except ValueError:
+                    pass
+            click.echo("\n## Response:\n\n{}\n".format(response))
             if usage:
                 token_usage = token_usage_string(
                     row["input_tokens"],

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -126,6 +126,18 @@ def _validate_metadata_json(ctx, param, value):
         raise click.BadParameter("Metadata must be valid JSON")
 
 
+def _validate_schema_json(ctx, param, value):
+    if value is None:
+        return value
+    try:
+        obj = json.loads(value)
+        if not isinstance(obj, dict):
+            raise click.BadParameter("Schema must be a JSON object")
+        return obj
+    except json.JSONDecodeError:
+        raise click.BadParameter("Schema must be valid JSON")
+
+
 @click.group(
     cls=DefaultGroup,
     default="prompt",
@@ -184,6 +196,9 @@ def cli():
     multiple=True,
     help="key/value options for the model",
 )
+@click.option(
+    "--schema", callback=_validate_schema_json, help="JSON schema to use for output"
+)
 @click.option("-t", "--template", help="Template to use")
 @click.option(
     "-p",
@@ -228,6 +243,7 @@ def prompt(
     attachments,
     attachment_types,
     options,
+    schema,
     template,
     param,
     no_stream,
@@ -429,6 +445,7 @@ def prompt(
                         prompt,
                         attachments=resolved_attachments,
                         system=system,
+                        schema=schema,
                         **kwargs,
                     )
                     async for chunk in response:
@@ -440,6 +457,7 @@ def prompt(
                         prompt,
                         attachments=resolved_attachments,
                         system=system,
+                        schema=schema,
                         **kwargs,
                     )
                     text = await response.text()
@@ -456,6 +474,7 @@ def prompt(
                 prompt,
                 attachments=resolved_attachments,
                 system=system,
+                schema=schema,
                 **kwargs,
             )
             if should_stream:

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -114,28 +114,19 @@ def attachment_types_callback(ctx, param, values):
     return collected
 
 
-def _validate_metadata_json(ctx, param, value):
-    if value is None:
-        return value
-    try:
-        obj = json.loads(value)
-        if not isinstance(obj, dict):
-            raise click.BadParameter("Metadata must be a JSON object")
-        return obj
-    except json.JSONDecodeError:
-        raise click.BadParameter("Metadata must be valid JSON")
+def json_validator(object_name):
+    def validator(ctx, param, value):
+        if value is None:
+            return value
+        try:
+            obj = json.loads(value)
+            if not isinstance(obj, dict):
+                raise click.BadParameter(f"{object_name} must be a JSON object")
+            return obj
+        except json.JSONDecodeError:
+            raise click.BadParameter(f"{object_name} must be valid JSON")
 
-
-def _validate_schema_json(ctx, param, value):
-    if value is None:
-        return value
-    try:
-        obj = json.loads(value)
-        if not isinstance(obj, dict):
-            raise click.BadParameter("Schema must be a JSON object")
-        return obj
-    except json.JSONDecodeError:
-        raise click.BadParameter("Schema must be valid JSON")
+    return validator
 
 
 @click.group(
@@ -197,7 +188,7 @@ def cli():
     help="key/value options for the model",
 )
 @click.option(
-    "--schema", callback=_validate_schema_json, help="JSON schema to use for output"
+    "--schema", callback=json_validator("schema"), help="JSON schema to use for output"
 )
 @click.option("-t", "--template", help="Template to use")
 @click.option(
@@ -1546,7 +1537,7 @@ def uninstall(packages, yes):
 @click.option(
     "--metadata",
     help="JSON object metadata to store",
-    callback=_validate_metadata_json,
+    callback=json_validator("metadata"),
 )
 @click.option(
     "format_",

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -865,6 +865,7 @@ select
 {columns}
 from
     responses
+left join schemas on responses.schema_id = schemas.id
 left join conversations on responses.conversation_id = conversations.id
 join responses_fts on responses_fts.rowid = responses.rowid
 where responses_fts match :query{extra_where}

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -848,13 +848,15 @@ LOGS_COLUMNS = """    responses.id,
     responses.output_tokens,
     responses.token_details,
     conversations.name as conversation_name,
-    conversations.model as conversation_model"""
+    conversations.model as conversation_model,
+    schemas.content as schema_json"""
 
 LOGS_SQL = """
 select
 {columns}
 from
     responses
+left join schemas on responses.schema_id = schemas.id
 left join conversations on responses.conversation_id = conversations.id{extra_where}
 order by responses.id desc{limit}
 """

--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -366,6 +366,8 @@ def _attachment(attachment):
 
 
 class _Shared:
+    supports_schema = True
+
     def __init__(
         self,
         model_id,
@@ -504,6 +506,11 @@ class _Shared:
             kwargs["max_tokens"] = self.default_max_tokens
         if json_object:
             kwargs["response_format"] = {"type": "json_object"}
+        if prompt.schema:
+            kwargs["response_format"] = {
+                "type": "json_schema",
+                "json_schema": {"name": "output", "schema": prompt.schema},
+            }
         if stream:
             kwargs["stream_options"] = {"include_usage": True}
         return kwargs

--- a/llm/migrations.py
+++ b/llm/migrations.py
@@ -249,5 +249,9 @@ def m014_schemas(db):
         pk="id",
     )
     db["responses"].add_column("schema_id", str, fk="schemas", fk_col="id")
-    # Clean up that table's SQL indentation
+    # Clean up SQL create table indentation
     db["responses"].transform()
+    # These changes may have dropped the FTS configuration, fix that
+    db["responses"].enable_fts(
+        ["prompt", "response"], create_triggers=True, replace=True
+    )

--- a/llm/migrations.py
+++ b/llm/migrations.py
@@ -237,3 +237,17 @@ def m013_usage(db):
     db["responses"].add_column("input_tokens", int)
     db["responses"].add_column("output_tokens", int)
     db["responses"].add_column("token_details", str)
+
+
+@migration
+def m014_schemas(db):
+    db["schemas"].create(
+        {
+            "id": str,
+            "content": str,
+        },
+        pk="id",
+    )
+    db["responses"].add_column("schema_id", str, fk="schemas", fk_col="id")
+    # Clean up that table's SQL indentation
+    db["responses"].transform()

--- a/llm/models.py
+++ b/llm/models.py
@@ -122,6 +122,8 @@ class Prompt:
         self.attachments = list(attachments or [])
         self.system = system
         self.prompt_json = prompt_json
+        if schema and not isinstance(schema, dict) and issubclass(schema, BaseModel):
+            schema = schema.model_json_schema()
         self.schema = schema
         self.options = options or {}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,7 @@ def env_setup(monkeypatch, user_path):
 class MockModel(llm.Model):
     model_id = "mock"
     attachment_types = {"image/png", "audio/wav"}
+    supports_schema = True
 
     class Options(llm.Options):
         max_tokens: Optional[int] = Field(
@@ -97,6 +98,7 @@ class MockAsyncKeyModel(llm.AsyncKeyModel):
 
 class AsyncMockModel(llm.AsyncModel):
     model_id = "mock"
+    supports_schema = True
 
     def __init__(self):
         self.history = []

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -53,6 +53,7 @@ def test_chat_basic(mock_model, logs_db):
             "input_tokens": 1,
             "output_tokens": 1,
             "token_details": None,
+            "schema_id": None,
         },
         {
             "id": ANY,
@@ -69,6 +70,7 @@ def test_chat_basic(mock_model, logs_db):
             "input_tokens": 2,
             "output_tokens": 1,
             "token_details": None,
+            "schema_id": None,
         },
     ]
     # Now continue that conversation
@@ -113,6 +115,7 @@ def test_chat_basic(mock_model, logs_db):
             "input_tokens": 1,
             "output_tokens": 1,
             "token_details": None,
+            "schema_id": None,
         }
     ]
 
@@ -153,6 +156,7 @@ def test_chat_system(mock_model, logs_db):
             "input_tokens": 1,
             "output_tokens": 1,
             "token_details": None,
+            "schema_id": None,
         }
     ]
 
@@ -184,6 +188,7 @@ def test_chat_options(mock_model, logs_db):
             "input_tokens": 1,
             "output_tokens": 1,
             "token_details": None,
+            "schema_id": None,
         }
     ]
 

--- a/tests/test_embed_cli.py
+++ b/tests/test_embed_cli.py
@@ -76,8 +76,8 @@ def test_embed_errors(args, expected_error):
         (None, None),
         ('{"foo": "bar"}', None),
         ('{"foo": [1, 2, 3]}', None),
-        ("[1, 2, 3]", "Metadata must be a JSON object"),  # Must be a dictionary
-        ('{"foo": "incomplete}', "Metadata must be valid JSON"),
+        ("[1, 2, 3]", "metadata must be a JSON object"),  # Must be a dictionary
+        ('{"foo": "incomplete}', "metadata must be valid JSON"),
     ),
 )
 def test_embed_store(user_path, metadata, metadata_error):

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -20,6 +20,7 @@ EXPECTED = {
     "input_tokens": int,
     "output_tokens": int,
     "token_details": str,
+    "schema_id": str,
 }
 
 


### PR DESCRIPTION
Refs:
- #776

TODO:

- [x] Logging the schema that was used in a database (ideally without duplicating it too many times)
- [x] Schema should be shown in `llm logs --json`
- [x] Schema should be shown in `llm logs` Markdown
- [x] Docs on how to use this
  - [x] Note in the docs about schema compatibility - how different models may have slightly different JSON schema features that they support (kind of sucks but I'm stuck with that I think) - in the future maybe describe a subset of JSON schema that LLM supports and ensure that all plugins support that subset
- [x] Get the thing where you can pass a Pydantic BaseModel to `prompt(..., schema=)` to work (or cancel that feature)
- [x] Automated tests
- [x] Docs on how to write plugins that support schemas

