### PR TITLE
Add feature to calculate similarity score between two embeddings without storing them in a collection

### DIFF
--- a/docs/help.md
+++ b/docs/help.md
@@ -71,6 +71,7 @@ Commands:
   embed         Embed text and store or return the result
   embed-models  Manage available embedding models
   embed-multi   Store embeddings for multiple strings at once
+  embed-score   Calculate similarity score between two embeddings without...
   install       Install packages from PyPI into the same environment as LLM
   keys          Manage stored API keys for different models
   logs          Tools for exploring logged prompts and responses
@@ -589,6 +590,31 @@ Options:
   --store                      Store the text itself in the database
   -d, --database FILE
   --help                       Show this message and exit.
+```
+
+(help-embed-score)=
+### llm embed-score --help
+```
+Usage: llm embed-score [OPTIONS]
+
+  Calculate similarity score between two embeddings without storing them to a
+  collection.
+
+  Example usage:
+
+      llm embed-score -c1 "I like pelicans" -c2 "I love pelicans"
+      llm embed-score -i1 file1.txt -i2 file2.txt
+      llm embed-score -i1 image1.jpg -i2 image2.jpg --binary
+
+Options:
+  -i1, --input1 PATH        First file to embed
+  -i2, --input2 PATH        Second file to embed
+  -c1, --content1 TEXT      First content to embed
+  -c2, --content2 TEXT      Second content to embed
+  --binary                  Treat input as binary data
+  -m, --model TEXT          Embedding model to use
+  -f, --format [json|text]  Output format
+  --help                    Show this message and exit.
 ```
 
 (help-similar)=

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1910,7 +1910,7 @@ def embed_multi(
 )
 def embed_score(input1, input2, content1, content2, binary, model, format_):
     """
-    Calculate similarity score between two embeddings without storing them.
+    Calculate similarity score between two embeddings without storing them to a collection.
 
     Example usage:
 

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1974,7 +1974,11 @@ def embed_score(input1, input2, content1, content2, binary, model, format_):
 
     # Output the score in the requested format
     if format_ == "json":
-        click.echo(json.dumps({"score": score, "content1": embedding_1, "content2": embedding_2}))
+        click.echo(
+            json.dumps(
+                {"score": score, "content1": embedding_1, "content2": embedding_2}
+            )
+        )
     else:
         click.echo(f"{score}")
 

--- a/tests/test_embed_score.py
+++ b/tests/test_embed_score.py
@@ -41,7 +41,7 @@ def test_embed_score_with_content():
     assert json.loads(result.output.strip()) == {
         "score": pytest.approx(0.9734171683335759),
         "content1": [4, 2, 4, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-        "content2": [4, 2, 4, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        "content2": [4, 2, 4, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     }
 
 

--- a/tests/test_embed_score.py
+++ b/tests/test_embed_score.py
@@ -1,0 +1,107 @@
+import json
+import pytest
+from click.testing import CliRunner
+from llm.cli import cli
+
+
+def test_embed_score_with_content():
+    """Test the embed-score command with content parameters"""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "embed-score",
+            "-c1",
+            "This is text one",
+            "-c2",
+            "This is text seven",
+            "-m",
+            "embed-demo",
+        ],
+    )
+    assert result.exit_code == 0
+    assert float(result.output.strip()) == pytest.approx(0.9734171683335759)
+
+    # Test with JSON output format
+    result = runner.invoke(
+        cli,
+        [
+            "embed-score",
+            "-c1",
+            "This is text one",
+            "-c2",
+            "This is text seven",
+            "-f",
+            "json",
+            "-m",
+            "embed-demo",
+        ],
+    )
+    assert result.exit_code == 0
+    assert json.loads(result.output.strip()) == {
+        "score": pytest.approx(0.9734171683335759),
+        "content1": [4, 2, 4, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        "content2": [4, 2, 4, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    }
+
+
+def test_embed_score_with_files(tmp_path):
+    """Test the embed-score command with file inputs"""
+    # Create temporary test files
+    file1 = tmp_path / "file1.txt"
+    file2 = tmp_path / "file2.txt"
+    file1.write_text("This is text one")
+    file2.write_text("This is text seven")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["embed-score", "-i1", str(file1), "-i2", str(file2), "-m", "embed-demo"],
+    )
+    assert result.exit_code == 0
+    assert float(result.output.strip()) == pytest.approx(0.9734171683335759)
+
+
+def test_embed_score_binary_input(tmp_path):
+    """Test the embed-score command with binary inputs"""
+    # Create temporary binary files
+    file1 = tmp_path / "file1.bin"
+    file2 = tmp_path / "file2.bin"
+    file1.write_bytes(b"\x00\x01\x02")
+    file2.write_bytes(b"\x03\x04\x05")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "embed-score",
+            "-i1",
+            str(file1),
+            "-i2",
+            str(file2),
+            "-m",
+            "embed-demo",
+            "--binary",
+        ],
+    )
+    assert result.exit_code == 0
+    assert float(result.output.strip()) == pytest.approx(1.0)
+
+
+def test_embed_score_missing_inputs():
+    """Test the embed-score command with missing inputs"""
+    runner = CliRunner()
+
+    # Missing first input
+    result = runner.invoke(
+        cli, ["embed-score", "-c2", "This is text two", "-m", "embed-demo"]
+    )
+    assert result.exit_code != 0
+    assert "No content provided for first input" in result.output
+
+    # Missing second input
+    result = runner.invoke(
+        cli, ["embed-score", "-c1", "This is text one", "-m", "embed-demo"]
+    )
+    assert result.exit_code != 0
+    assert "No content provided for second input" in result.output


### PR DESCRIPTION
Embeddings are great, but they are meaningful only in the relationship between each other.
I thought it would be helpful if we had a command to directly calculate the similarity score between two contents without storing them in a collection when trying out embedding models. 

This PR adds a command `embed-score`, which takes two contents and returns the cosine similarity score (and actual embeddings when the given format is 'json').
```
# Basic usage
llm embed-score -c1 "I like pelicans" -c2 "I love pelicans" -m 3-small
0.9376833959553552
```
The new function describes my rough intention, but I'm fully open to any suggestions on the interface/implementation if this feature is worth having in this tool.

Confession: This is a collaborative work with Anthropic's Cline and Claude 3.7. I prompted Cline to write a new function I wanted and post-edited the generated code. Claude did a great job but couldn't produce unit tests that worked and aligned with existing fixtures (in a reasonable time slot). The whole process greatly helped me to understand the codebase.

Still needs to
- Add documentation about the new command