### PR TITLE
Add supports_schema to extra-openai-models.yaml

### DIFF
--- a/docs/other-models.md
+++ b/docs/other-models.md
@@ -47,6 +47,8 @@ Add `completion: true` if the model is a completion model that uses a `/completi
 
 If a model does not support streaming, add `can_stream: false` to disable the streaming option.
 
+If a model supports structured output via JSON schemas, you can add `supports_schema: true` to support this feature.
+
 Having configured the model like this, run `llm models` to check that it installed correctly. You can then run prompts against it like so:
 
 ```bash

--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -135,6 +135,8 @@ def register_models(register):
         kwargs = {}
         if extra_model.get("can_stream") is False:
             kwargs["can_stream"] = False
+        if extra_model.get("supports_schema") is True:
+            kwargs["supports_schema"] = True
         if extra_model.get("completion"):
             klass = Completion
         else:


### PR DESCRIPTION
Recently support for structured output was added. But custom OpenAI-compatible models didn't support the `supports_schema` property in the config file `extra-openai-models.yaml`.

I validated the change by adding the following to my `extra-openai-models.yaml`:
```
- model_id: openai_custom
  model_name: gpt-4o-mini
  api_base: "https://api.openai.com/v1"
  api_key_name: openai
  supports_schema: true
```
and observing the output of
```
uv run llm -m openai_custom --schema 'name,age int,short_bio' 'invent a cool dog'
```