### PR TITLE
If extract_last is set, start with the last row

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1168,7 +1168,7 @@ def logs_list(
         output = json.dumps(list(rows), indent=2)
     elif extract or extract_last:
         # Extract and return first code block
-        for row in rows:
+        for row in reversed(rows) if extract_last else rows:
             output = extract_fenced_code_block(row["response"], last=extract_last)
             if output is not None:
                 break


### PR DESCRIPTION
```
llm logs -r
```
will return back the last response, but will load up in memory the last three rows. 

```
llm logs -r --xl
```
will load up in memory the last three responses, and will return back the last command block of the first row that has command blocks. 

I found this confusing in my workflow. I would type in `llm logs -r`, see the command that i would want, then type in `llm logs -r --xl` and get a different command extracted. This oughta fix that. 

An alternative approach would be to treat `-r` as `-n 1` since it effectively throws away all the rows except the last one. 