### PR TITLE
Support vision and audio for extra-openai-models.yaml

### DIFF
--- a/docs/other-models.md
+++ b/docs/other-models.md
@@ -49,6 +49,10 @@ If a model does not support streaming, add `can_stream: false` to disable the st
 
 If a model supports structured output via JSON schemas, you can add `supports_schema: true` to support this feature.
 
+If a model is a vision model, you can add `vision: true` to support this feature and use image attachments.
+
+If a model is an audio model, you can add `audio: true` to support this feature and use audio attachments.
+
 Having configured the model like this, run `llm models` to check that it installed correctly. You can then run prompts against it like so:
 
 ```bash

--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -137,6 +137,10 @@ def register_models(register):
             kwargs["can_stream"] = False
         if extra_model.get("supports_schema") is True:
             kwargs["supports_schema"] = True
+        if extra_model.get("vision") is True:
+            kwargs["vision"] = True
+        if extra_model.get("audio") is True:
+            kwargs["audio"] = True
         if extra_model.get("completion"):
             klass = Completion
         else:


### PR DESCRIPTION
Should close https://github.com/simonw/llm/issues/602

`extra-openai-models.yaml` can be used to access OpenAI-compatible models, in my case I use it to access models through a proxy. Certain options supported by OpenAI models when used directly are not supported when using this method.

I noticed something similar for schemas has been merged super-recently https://github.com/simonw/llm/pull/819 so I thought to also do the same for other options, namely vision and audio.
This adds support for OpenAI compatible models specified via the `extra-openai-models.yaml` so that models that support it can receive image and audio attachments

---

tested with
```
- model_id: gw-gpt-4o
  model_name: gpt-4o
  api_base: "http://localhost:8888/v1/"
  vision: true
```
and running
`llm -m gw-gpt-4o "describe this image" -a https://static.simonwillison.net/static/2024/pelicans.jpg`

and
```
- model_id: gw-gpt-4o-audio-preview
  model_name: gpt-4o-audio-preview
  api_base: "http://localhost:7777/v1/"
  audio: true
```
and running
`llm -m gw-gpt-4o-audio-preview 'transcript' -a https://static.simonwillison.net/static/2024/video-scraping-pelicans.mp3`