### PR TITLE
Annotations

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,12 +17,10 @@ Here's a [YouTube video demo](https://www.youtube.com/watch?v=QUXQNi6jQ30) and [
 Background on this project:
 - [llm, ttok and strip-tags—CLI tools for working with ChatGPT and other LLMs](https://simonwillison.net/2023/May/18/cli-tools-for-llms/)
 - [The LLM CLI tool now supports self-hosted language models via plugins](https://simonwillison.net/2023/Jul/12/llm/)
-- [Accessing Llama 2 from the command-line with the llm-replicate plugin](https://simonwillison.net/2023/Jul/18/accessing-llama-2/)
-- [Run Llama 2 on your own Mac using LLM and Homebrew](https://simonwillison.net/2023/Aug/1/llama-2-mac/)
-- [Catching up on the weird world of LLMs](https://simonwillison.net/2023/Aug/3/weird-world-of-llms/)
 - [LLM now provides tools for working with embeddings](https://simonwillison.net/2023/Sep/4/llm-embeddings/)
 - [Build an image search engine with llm-clip, chat with models with llm chat](https://simonwillison.net/2023/Sep/12/llm-clip-and-chat/)
-- [Many options for running Mistral models in your terminal using LLM](https://simonwillison.net/2023/Dec/18/mistral/)
+- [You can now run prompts against images, audio and video in your terminal using LLM](https://simonwillison.net/2024/Oct/29/llm-multi-modal/)
+- [Structured data extraction from unstructured content using LLM schemas](https://simonwillison.net/2025/Feb/28/llm-schemas/)
 
 For more check out [the llm tag](https://simonwillison.net/tags/llm/) on my blog.
 

--- a/docs/openai-models.md
+++ b/docs/openai-models.md
@@ -55,6 +55,8 @@ OpenAI Chat: o1-preview
 OpenAI Chat: o1-mini
 OpenAI Chat: o3-mini
 OpenAI Completion: gpt-3.5-turbo-instruct (aliases: 3.5-instruct, chatgpt-instruct)
+OpenAI Chat: gpt-4o-search-preview
+OpenAI Chat: gpt-4o-mini-search-preview
 ```
 <!-- [[[end]]] -->
 

--- a/docs/openai-models.md
+++ b/docs/openai-models.md
@@ -66,6 +66,15 @@ See [the OpenAI models documentation](https://platform.openai.com/docs/models) f
 
 [o1-pro](https://platform.openai.com/docs/models/o1-pro) is not available  through the Chat Completions API used by LLM's default OpenAI plugin. You can install the new [llm-openai-plugin](https://github.com/simonw/llm-openai-plugin) plugin to access that model.
 
+## Model features
+
+The following features work with OpenAI models:
+
+- {ref}`System prompts <usage-system-prompts>` can be used to provide instructions that have a higher weight than the prompt itself.
+- {ref}`Attachments <usage-attachments>`. Many OpenAI models support image inputs - check which ones using `llm models --options`. Any model that accepts images can also accept PDFs.
+- {ref}`Schemas <usage-schemas>` can be used to influence the JSON structure of the model output.
+- {ref}`Model options <usage-model-options>` can be used to set parameters like `temperature`. Use `llm models --options` for a full list of supported options.
+
 (openai-models-embedding)=
 
 ## OpenAI embedding models

--- a/docs/plugins/advanced-model-plugins.md
+++ b/docs/plugins/advanced-model-plugins.md
@@ -1,9 +1,15 @@
 (advanced-model-plugins)=
 # Advanced model plugins
 
-The {ref}`model plugin tutorial <tutorial-model-plugin>` covers the basics of developing a plugin that adds support for a new model.
+The {ref}`model plugin tutorial <tutorial-model-plugin>` covers the basics of developing a plugin that adds support for a new model. This document covers more advanced topics.
 
-This document covers more advanced topics.
+Features to consider for your model plugin include:
+
+- {ref}`Accepting API keys <advanced-model-plugins-api-keys>` using the standard mechanism that incorporates `llm keys set`, environment variables and support for passing an explicit key to the model.
+- Including support for {ref}`Async models <advanced-model-plugins-async>` that can be used with Python's `asyncio` library.
+- Support for {ref}`structured output <advanced-model-plugins-schemas>` using JSON schemas.
+- Handling {ref}`attachments <advanced-model-plugins-attachments>` (images, audio and more) for multi-modal models.
+- Tracking {ref}`token usage <advanced-model-plugins-usage>` for models that charge by the token.
 
 (advanced-model-plugins-api-keys)=
 

--- a/docs/plugins/advanced-model-plugins.md
+++ b/docs/plugins/advanced-model-plugins.md
@@ -59,7 +59,7 @@ class MyAsyncModel(llm.AsyncModel):
 
     async def execute(
         self, prompt, stream, response, conversation=None
-    ) -> AsyncGenerator[str, None]:
+    ) -> AsyncGenerator[Union[llm.Chunk, str], None]:
         if stream:
             completion = await client.chat.completions.create(
                 model=self.model_id,
@@ -83,7 +83,7 @@ class MyAsyncModel(llm.AsyncKeyModel):
     ...
     async def execute(
         self, prompt, stream, response, conversation=None, key=None
-    ) -> AsyncGenerator[str, None]:
+    ) -> AsyncGenerator[Union[llm.Chunk, str], None]:
 ```
 
 

--- a/docs/plugins/advanced-model-plugins.md
+++ b/docs/plugins/advanced-model-plugins.md
@@ -9,6 +9,7 @@ Features to consider for your model plugin include:
 - Including support for {ref}`Async models <advanced-model-plugins-async>` that can be used with Python's `asyncio` library.
 - Support for {ref}`structured output <advanced-model-plugins-schemas>` using JSON schemas.
 - Handling {ref}`attachments <advanced-model-plugins-attachments>` (images, audio and more) for multi-modal models.
+- Supporting {ref}`annotations <advanced-model-plugins-annotations>` for models that return different types of text, or objects that should be attached to sections of the response.
 - Tracking {ref}`token usage <advanced-model-plugins-usage>` for models that charge by the token.
 
 (advanced-model-plugins-api-keys)=
@@ -243,3 +244,52 @@ This example logs 15 input tokens, 340 output tokens and notes that 37 tokens we
 ```python
 response.set_usage(input=15, output=340, details={"cached": 37})
 ```
+
+(advanced-model-plugins-annotations)=
+
+## Models that return annotations
+
+Some models may return additional structured data to accompany their text output. LLM calls these **annotations**. Common use-cases for these include:
+
+- Reasoning models that return a portion of text representing "thinking" tokens prior to the main response.
+- Models that return structured citation information attached to portions of the text.
+- Similarly, some search models return references to search reults used to generate the response.
+
+Model plugins can return these annotations directly from their `execute()` method. This method usually yields a series of strings - to attach a citation to one of these strings, return a `Chunk` object instead:
+
+```python
+from llm import Chunk
+
+...
+    # Inside the execute() method:
+    yield llm.Chunk(
+        text="This has an annotation",
+        annotation={
+            "title": "Document title",
+            "url": "https://example.com/document",
+        }
+    )
+```
+The `annotation=` must be a dictionary but can take any shape. LLM will automatically record the annotation with the start and end index of the generated text that it is attached to.
+
+Some annotations may need to be attached to a point in the document without a separate end index. In this case the `text=` parameter should be set to `None`.
+
+Models may exist that do not return their annotations as part of the general stream but instead produce them at the end of the response, specifying start and end indexes to show which parts of the text they should be attached to. This is often the case for non-streaming APIs.
+
+For these cases the `response.add_annotations()` method should be used at the end of the `.execute()` method:
+
+```python
+response.add_annotations([
+    llm.Annotation(
+        start_index=0,
+        end_index=10,
+        data={
+            "title": "Document title",
+            "url": "https://example.com/document"
+        }
+    )
+])
+```
+The method accepts a list of `llm.Annotation` objects, each with a `start_index=`, `end_index=` and `data=` dictionary describing the annotation.
+
+For annotations that are attached to a point rather than a range the `start_index=` and `end_index=` should be the same integer value.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -59,6 +59,11 @@ This can be combined with the `-m` option to specify a different model:
 curl -s https://llm.datasette.io/en/latest/ | \
   llm -t summarize -m gpt-3.5-turbo-16k
 ```
+Templates can also be specified as full URLs to YAML files:
+```bash
+llm -t https://raw.githubusercontent.com/simonw/llm-templates/refs/heads/main/python-app.yaml \
+  'Python app to pick a random line from a file'
+```
 
 (prompt-templates-list)=
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -45,6 +45,7 @@ Will run a prompt of:
 ```
 For models that support them, {ref}`system prompts <usage-system-prompts>` are a better tool for this kind of prompting.
 
+(usage-model-options)=
 ### Model options
 
 Some models support options. You can pass these using `-o/--option name value` - for example, to set the temperature to 1.5 run this:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -742,6 +742,34 @@ OpenAI Completion: gpt-3.5-turbo-instruct (aliases: 3.5-instruct, chatgpt-instru
       Include the log probabilities of most likely N per token
   Features:
   - streaming
+OpenAI Chat: gpt-4o-search-preview
+  Options:
+    temperature: float
+    max_tokens: int
+    top_p: float
+    frequency_penalty: float
+    presence_penalty: float
+    stop: str
+    logit_bias: dict, str
+    seed: int
+    search_context_size: str
+  Features:
+  - streaming
+  - async
+OpenAI Chat: gpt-4o-mini-search-preview
+  Options:
+    temperature: float
+    max_tokens: int
+    top_p: float
+    frequency_penalty: float
+    presence_penalty: float
+    stop: str
+    logit_bias: dict, str
+    seed: int
+    search_context_size: str
+  Features:
+  - streaming
+  - async
 
 ```
 <!-- [[[end]]] -->

--- a/llm/__init__.py
+++ b/llm/__init__.py
@@ -4,11 +4,13 @@ from .errors import (
     NeedsKeyException,
 )
 from .models import (
+    Annotation,
     AsyncConversation,
     AsyncKeyModel,
     AsyncModel,
     AsyncResponse,
     Attachment,
+    Chunk,
     Conversation,
     EmbeddingModel,
     EmbeddingModelWithAliases,
@@ -31,10 +33,12 @@ import pathlib
 import struct
 
 __all__ = [
+    "Annotation",
     "AsyncConversation",
     "AsyncKeyModel",
     "AsyncResponse",
     "Attachment",
+    "Chunk",
     "Collection",
     "Conversation",
     "get_async_model",

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -10,6 +10,7 @@ from llm import (
     AsyncConversation,
     AsyncKeyModel,
     AsyncResponse,
+    Chunk,
     Collection,
     Conversation,
     Response,
@@ -561,6 +562,8 @@ def prompt(
             )
             if should_stream:
                 for chunk in response:
+                    if isinstance(chunk, Chunk) and chunk.annotation:
+                        print(chunk.annotation)
                     print(chunk, end="")
                     sys.stdout.flush()
                 print("")

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -2527,7 +2527,28 @@ def logs_db_path():
     return user_dir() / "logs.db"
 
 
+def _parse_yaml_template(name, content):
+    try:
+        loaded = yaml.safe_load(content)
+    except yaml.YAMLError as ex:
+        raise click.ClickException("Invalid YAML: {}".format(str(ex)))
+    if isinstance(loaded, str):
+        return Template(name=name, prompt=loaded)
+    loaded["name"] = name
+    try:
+        return Template(**loaded)
+    except pydantic.ValidationError as ex:
+        msg = "A validation error occurred:\n"
+        msg += render_errors(ex.errors())
+        raise click.ClickException(msg)
+
+
 def load_template(name):
+    if name.startswith("https://") or name.startswith("http://"):
+        response = httpx.get(name)
+        response.raise_for_status()
+        return _parse_yaml_template(name, response.text)
+
     if ":" in name:
         prefix, rest = name.split(":", 1)
         loaders = get_template_loaders()
@@ -2544,19 +2565,8 @@ def load_template(name):
     path = template_dir() / f"{name}.yaml"
     if not path.exists():
         raise click.ClickException(f"Invalid template: {name}")
-    try:
-        loaded = yaml.safe_load(path.read_text())
-    except yaml.YAMLError as ex:
-        raise click.ClickException("Invalid YAML: {}".format(str(ex)))
-    if isinstance(loaded, str):
-        return Template(name=name, prompt=loaded)
-    loaded["name"] = name
-    try:
-        return Template(**loaded)
-    except pydantic.ValidationError as ex:
-        msg = "A validation error occurred:\n"
-        msg += render_errors(ex.errors())
-        raise click.ClickException(msg)
+    content = path.read_text()
+    return _parse_yaml_template(name, content)
 
 
 def get_history(chat_id):

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1384,13 +1384,12 @@ def format_chunks(chunks: Iterable[Chunk]) -> str:
         combined_text += chunk.text
         end_pos = len(combined_text)
 
-        # If chunk has data, record its position and data
-        if chunk.data:
+        if chunk.annotation:
             annotation_positions.append(
                 {
                     "start": start_pos,
                     "end": end_pos,
-                    "data": chunk.data,
+                    "data": chunk.annotation,
                     "index": annotation_index,
                 }
             )

--- a/llm/examples.py
+++ b/llm/examples.py
@@ -1,0 +1,61 @@
+import llm
+import random
+from typing import AsyncGenerator, Union
+
+
+def build_markov_table(text):
+    words = text.split()
+    transitions = {}
+    # Loop through all but the last word
+    for i in range(len(words) - 1):
+        word = words[i]
+        next_word = words[i + 1]
+        transitions.setdefault(word, []).append(next_word)
+    return transitions
+
+
+def generate(transitions, length, start_word=None):
+    all_words = list(transitions.keys())
+    next_word = start_word or random.choice(all_words)
+    for i in range(length):
+        yield next_word
+        options = transitions.get(next_word) or all_words
+        next_word = random.choice(options)
+
+
+class Markov(llm.Model):
+    model_id = "markov"
+
+    def execute(self, prompt, stream, response, conversation):
+        text = prompt.prompt
+        transitions = build_markov_table(text)
+        for word in generate(transitions, 20):
+            yield word + " "
+
+
+class AnnotationsModel(llm.Model):
+    model_id = "annotations"
+    can_stream = True
+
+    def execute(self, prompt, stream, response, conversation):
+        yield "Here is text before the annotation. "
+        yield llm.Chunk(
+            text="This is the annotated text. ",
+            annotation={"title": "Annotation Title", "content": "Annotation Content"},
+        )
+        yield "Here is text after the annotation."
+
+
+class AnnotationsModelAsync(llm.AsyncModel):
+    model_id = "annotations"
+    can_stream = True
+
+    async def execute(
+        self, prompt, stream, response, conversation=None
+    ) -> AsyncGenerator[Union[llm.Chunk, str], None]:
+        yield "Here is text before the annotation. "
+        yield llm.Chunk(
+            text="This is the annotated text. ",
+            annotation={"title": "Annotation Title", "content": "Annotation Content"},
+        )
+        yield "Here is text after the annotation."

--- a/llm/migrations.py
+++ b/llm/migrations.py
@@ -255,3 +255,18 @@ def m014_schemas(db):
     db["responses"].enable_fts(
         ["prompt", "response"], create_triggers=True, replace=True
     )
+
+
+@migration
+def m015_response_annotations(db):
+    db["response_annotations"].create(
+        {
+            "id": int,
+            "response_id": str,
+            "start_index": int,
+            "end_index": int,
+            "data": str,
+        },
+        pk="id",
+        foreign_keys=(("response_id", "responses", "id"),),
+    )

--- a/llm/models.py
+++ b/llm/models.py
@@ -858,7 +858,7 @@ class Model(_Model):
         stream: bool,
         response: Response,
         conversation: Optional[Conversation],
-    ) -> Iterator[str]:
+    ) -> Iterator[Union[str, Chunk]]:
         pass
 
 
@@ -871,7 +871,7 @@ class KeyModel(_Model):
         response: Response,
         conversation: Optional[Conversation],
         key: Optional[str],
-    ) -> Iterator[str]:
+    ) -> Iterator[Union[str, Chunk]]:
         pass
 
 
@@ -914,7 +914,7 @@ class AsyncModel(_AsyncModel):
         stream: bool,
         response: AsyncResponse,
         conversation: Optional[AsyncConversation],
-    ) -> AsyncGenerator[str, None]:
+    ) -> AsyncGenerator[Union[str, Chunk], None]:
         yield ""
 
 
@@ -927,7 +927,7 @@ class AsyncKeyModel(_AsyncModel):
         response: AsyncResponse,
         conversation: Optional[AsyncConversation],
         key: Optional[str],
-    ) -> AsyncGenerator[str, None]:
+    ) -> AsyncGenerator[Union[str, Chunk], None]:
         yield ""
 
 

--- a/llm/models.py
+++ b/llm/models.py
@@ -250,7 +250,7 @@ class Annotation(BaseModel):
 
 class Chunk(BaseModel):
     text: str
-    data: Optional[dict]
+    annotation: Optional[dict]
     start_index: int
     end_index: int
 
@@ -390,7 +390,7 @@ class _BaseResponse:
                 gap_text = text[current_index : annotation.start_index]
                 yield Chunk(
                     text=gap_text,
-                    data=None,
+                    annotation=None,
                     start_index=current_index,
                     end_index=annotation.start_index,
                 )
@@ -399,7 +399,7 @@ class _BaseResponse:
             chunk_text = text[annotation.start_index : annotation.end_index]
             yield Chunk(
                 text=chunk_text,
-                data=annotation.data,
+                annotation=annotation.data,
                 start_index=annotation.start_index,
                 end_index=annotation.end_index,
             )
@@ -410,7 +410,7 @@ class _BaseResponse:
         if current_index < len(text):
             yield Chunk(
                 text=text[current_index:],
-                data=None,
+                annotation=None,
                 start_index=current_index,
                 end_index=len(text),
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,6 +82,15 @@ class MockModel(llm.Model):
         )
 
 
+class EchoModel(llm.Model):
+    model_id = "echo"
+
+    def execute(self, prompt, stream, response, conversation):
+        yield "system:\n{}\n\nprompt:\n{}".format(
+            prompt.system or "", prompt.prompt or ""
+        )
+
+
 class MockKeyModel(llm.KeyModel):
     model_id = "mock_key"
     needs_key = "mock"
@@ -205,6 +214,22 @@ def register_embed_demo_model(embed_demo, mock_model, async_mock_model):
         yield
     finally:
         pm.unregister(name="undo-mock-models-plugin")
+
+
+@pytest.fixture(autouse=True)
+def register_echo_model():
+    class EchoModelPlugin:
+        __name__ = "EchoModelPlugin"
+
+        @llm.hookimpl
+        def register_models(self, register):
+            register(EchoModel())
+
+    pm.register(EchoModelPlugin(), name="undo-EchoModelPlugin")
+    try:
+        yield
+    finally:
+        pm.unregister(name="undo-EchoModelPlugin")
 
 
 @pytest.fixture


### PR DESCRIPTION
- #716

TODO:

- [x] Documentation for `execute()` plugin authors (which is not yet implemented yet)
- [ ] Handle model `.execute()` methods that yield `Chunk` in addition to `str`
- [x] Spin up a dummy model with annotations that I can start writing tests against
- [ ] Implement `Response.chunks()` method [described here](https://github.com/simonw/llm/issues/716#issuecomment-2735156054) for Python API, with docs
- [ ] `llm prompt` should display annotations correctly as they are yielded by the new `.execute()` method
- [ ] Redo the work to add annotation display to `llm logs` - previous prototype [is here](https://github.com/simonw/llm/blob/563a4837f278168dab141d6a8eb3449b6af9b99e/llm/cli.py#L1107-L1360).
- [ ] `llm-openai-plugin` to use annotations for `web_search` tool
- [ ] `llm-anthropic` plugin to use annotations for [Claude citations](https://www.anthropic.com/news/introducing-citations-api)