### PR TITLE
Add llm-github-copilot to Plugin Directory

### DIFF
--- a/docs/plugins/directory.md
+++ b/docs/plugins/directory.md
@@ -40,6 +40,7 @@ These plugins can be used to interact with remotely hosted models via their API:
 - **[llm-deepseek](https://github.com/abrasumente233/llm-deepseek)** adds support for the [DeepSeek](https://deepseek.com)'s DeepSeek-Chat and DeepSeek-Coder models.
 - **[llm-lambda-labs](https://github.com/simonw/llm-lambda-labs)** provides access to models hosted by [Lambda Labs](https://docs.lambdalabs.com/public-cloud/lambda-chat-api/), including the Nous Hermes 3 series.
 - **[llm-venice](https://github.com/ar-jan/llm-venice)** provides access to uncensored models hosted by privacy-focused [Venice AI](https://docs.venice.ai/), including Llama 3.1 405B.
+- **[llm-github-copilot](https://github.com/jmdaly/llm-github-copilot)** by John Daly provides access to [GitHub Copilot](https://github.com/features/copilot) models.
 
 If an API model host provides an OpenAI-compatible API you can also [configure LLM to talk to it](https://llm.datasette.io/en/stable/other-models.html#openai-compatible-models) without needing an extra plugin.
 


### PR DESCRIPTION
Hi Simon, thanks for your great CLI tool! I've written a plugin to connect LLM to GitHub Copilot, which I thought I'd share. This PR just adds a link to the plugin's GitHub page. Feel free to merge it if you'd like to have it included in your Plugins Directory :)

I will note that, while I write software every day for work, I'm not a Python developer. So there was definitely some AI help writing this plugin! But it's working well for me.