### PR TITLE
Should resolve #738, "prompts in python are not saved it the database"

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -46,6 +46,16 @@ Number of responses logged:     48
 Database file size:             19.96MB
 ```
 
+(logging-python-api)=
+
+## Logging in Python API
+
+`llm.get_model()` accepts a `log_queries` argument. If `log_queries` is True, 
+all Python API queries for that model will be logged to the database like 
+command-line invocations are. 
+
+Note that the Python API does NOT respect the `llm logs on/off` settings the CLI uses.
+
 (logging-view)=
 
 ## Viewing the logs

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -266,6 +266,16 @@ The `response.text()` method described earlier does this for you - it runs throu
 
 If a response has been evaluated, `response.text()` will continue to return the same string.
 
+(python-api-logging-queries)=
+
+### Logging Queries
+
+`llm.get_model()` accepts a `log_queries` argument. If `log_queries` is True, 
+all Python API queries for that model will be logged to the database like 
+command-line invocations are. 
+
+Note that the Python API does NOT respect the `llm logs on/off` settings the CLI uses.
+
 (python-api-async)=
 
 ## Async models

--- a/llm/__init__.py
+++ b/llm/__init__.py
@@ -222,12 +222,15 @@ def get_async_model(name: Optional[str] = None) -> AsyncModel:
             raise UnknownModelError("Unknown model: " + name)
 
 
-def get_model(name: Optional[str] = None, _skip_async: bool = False) -> Model:
+def get_model(name: Optional[str] = None, _skip_async: bool = False, log_queries: bool = False) -> Model:
     "Get a model by name or alias"
     aliases = get_model_aliases()
     name = name or get_default_model()
     try:
-        return aliases[name]
+        model = aliases[name]
+        # Set the log_queries attribute on the model
+        model.log_queries = log_queries
+        return model
     except KeyError:
         # Does an async model exist?
         if _skip_async:


### PR DESCRIPTION
adds `log_queries:bool = False` argument to `llm.get_model()`. Default is False, so there's no change to current default behavior, but if `log_queries` is True, all queries will be logged to the sqlite db just as command line queries are.

includes tests. Note that if `log_queries` default were to be changed to True, tests would have to be updated.

All of this code was generated by Claude Sonnet 3.7 in Windsurf, after Windsurf's Google Gemini 2.5 Pro implementation tied itself in knots.

(Note that there are a couple Ruff-generated reorderings of arguments to `Prompt()` calls. Normally, I frown on this kind of messing with somebody else's formatting, but they don't appear to do any harm and do match the argument structure of the Prompt class more closely, so I've left them in. )