### PR TITLE
Allow escaping a dollar sign in templates by adding another dollar sign

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -32,6 +32,11 @@ Or options:
 ```bash
 llm --system 'Speak in French' -o temperature 1.8 --save wild-french
 ```
+If you want to include a literal `$` sign in your prompt, use `$$` instead:
+```bash
+llm --system 'Estimate the cost in $$ of this: $input' --save estimate
+```
+
 Add `--schema` to bake a {ref}`schema <usage-schemas>` into your template:
 
 ```bash

--- a/llm/templates.py
+++ b/llm/templates.py
@@ -20,7 +20,9 @@ class Template(BaseModel):
     class MissingVariables(Exception):
         pass
 
-    def evaluate(self, input: str, params: Optional[Dict[str, Any]] = None) -> Tuple[Optional[str], Optional[str]]:
+    def evaluate(
+        self, input: str, params: Optional[Dict[str, Any]] = None
+    ) -> Tuple[Optional[str], Optional[str]]:
         params = params or {}
         params["input"] = input
         if self.defaults:
@@ -54,9 +56,15 @@ class Template(BaseModel):
         vars = cls.extract_vars(string_template)
         missing = [p for p in vars if p not in params]
         if missing:
-            raise cls.MissingVariables("Missing variables: {}".format(", ".join(missing)))
+            raise cls.MissingVariables(
+                "Missing variables: {}".format(", ".join(missing))
+            )
         return string_template.substitute(**params)
 
     @staticmethod
     def extract_vars(string_template: string.Template) -> List[str]:
-        return [match.group("named") for match in string_template.pattern.finditer(string_template.template) if match.group("named")]
+        return [
+            match.group("named")
+            for match in string_template.pattern.finditer(string_template.template)
+            if match.group("named")
+        ]

--- a/llm/templates.py
+++ b/llm/templates.py
@@ -20,9 +20,7 @@ class Template(BaseModel):
     class MissingVariables(Exception):
         pass
 
-    def evaluate(
-        self, input: str, params: Optional[Dict[str, Any]] = None
-    ) -> Tuple[Optional[str], Optional[str]]:
+    def evaluate(self, input: str, params: Optional[Dict[str, Any]] = None) -> Tuple[Optional[str], Optional[str]]:
         params = params or {}
         params["input"] = input
         if self.defaults:
@@ -56,14 +54,9 @@ class Template(BaseModel):
         vars = cls.extract_vars(string_template)
         missing = [p for p in vars if p not in params]
         if missing:
-            raise cls.MissingVariables(
-                "Missing variables: {}".format(", ".join(missing))
-            )
+            raise cls.MissingVariables("Missing variables: {}".format(", ".join(missing)))
         return string_template.substitute(**params)
 
     @staticmethod
     def extract_vars(string_template: string.Template) -> List[str]:
-        return [
-            match.group("named")
-            for match in string_template.pattern.finditer(string_template.template)
-        ]
+        return [match.group("named") for match in string_template.pattern.finditer(string_template.template) if match.group("named")]

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -17,6 +17,7 @@ import yaml
         ("$one and $two", None, None, {}, None, None, "Missing variables: one, two"),
         ("$one and $two", None, None, {"one": 1, "two": 2}, "1 and 2", None, None),
         ("$one and $two", None, {"one": 1}, {"two": 2}, "1 and 2", None, None),
+        ("$one and $$2", None, None, {"one": 1}, "1 and $2", None, None),
         (
             "$one and $two",
             None,
@@ -28,9 +29,7 @@ import yaml
         ),
     ),
 )
-def test_template_evaluate(
-    prompt, system, defaults, params, expected_prompt, expected_system, expected_error
-):
+def test_template_evaluate(prompt, system, defaults, params, expected_prompt, expected_system, expected_error):
     t = Template(name="t", prompt=prompt, system=system, defaults=defaults)
     if expected_error:
         with pytest.raises(Template.MissingVariables) as ex:
@@ -53,15 +52,9 @@ def test_templates_list_no_templates_found():
 def test_templates_list(templates_path, args):
     (templates_path / "one.yaml").write_text("template one", "utf-8")
     (templates_path / "two.yaml").write_text("template two", "utf-8")
-    (templates_path / "three.yaml").write_text(
-        "template three is very long " * 4, "utf-8"
-    )
-    (templates_path / "four.yaml").write_text(
-        "'this one\n\nhas newlines in it'", "utf-8"
-    )
-    (templates_path / "both.yaml").write_text(
-        "system: summarize this\nprompt: $input", "utf-8"
-    )
+    (templates_path / "three.yaml").write_text("template three is very long " * 4, "utf-8")
+    (templates_path / "four.yaml").write_text("'this one\n\nhas newlines in it'", "utf-8")
+    (templates_path / "both.yaml").write_text("system: summarize this\nprompt: $input", "utf-8")
     (templates_path / "sys.yaml").write_text("system: Summarize this", "utf-8")
     runner = CliRunner()
     result = runner.invoke(cli, args)
@@ -109,11 +102,7 @@ def test_templates_list(templates_path, args):
                 "--schema",
                 '{"properties": {"b": {"type": "string"}, "a": {"type": "string"}}}',
             ],
-            {
-                "schema_object": {
-                    "properties": {"b": {"type": "string"}, "a": {"type": "string"}}
-                }
-            },
+            {"schema_object": {"properties": {"b": {"type": "string"}, "a": {"type": "string"}}}},
             None,
         ),
     ),
@@ -124,10 +113,7 @@ def test_templates_prompt_save(templates_path, args, expected_prompt, expected_e
     result = runner.invoke(cli, args + ["--save", "saved"], catch_exceptions=False)
     if not expected_error:
         assert result.exit_code == 0
-        assert (
-            yaml.safe_load((templates_path / "saved.yaml").read_text("utf-8"))
-            == expected_prompt
-        )
+        assert yaml.safe_load((templates_path / "saved.yaml").read_text("utf-8")) == expected_prompt
     else:
         assert result.exit_code == 1
         assert expected_error in result.output
@@ -135,18 +121,12 @@ def test_templates_prompt_save(templates_path, args, expected_prompt, expected_e
 
 def test_templates_error_on_missing_schema(templates_path):
     runner = CliRunner()
-    runner.invoke(
-        cli, ["the-prompt", "--save", "prompt_no_schema"], catch_exceptions=False
-    )
+    runner.invoke(cli, ["the-prompt", "--save", "prompt_no_schema"], catch_exceptions=False)
     # This should complain about no schema
-    result = runner.invoke(
-        cli, ["hi", "--schema", "t:prompt_no_schema"], catch_exceptions=False
-    )
+    result = runner.invoke(cli, ["hi", "--schema", "t:prompt_no_schema"], catch_exceptions=False)
     assert result.output == "Error: Template 'prompt_no_schema' has no schema\n"
     # And this is just an invalid template
-    result2 = runner.invoke(
-        cli, ["hi", "--schema", "t:bad_template"], catch_exceptions=False
-    )
+    result2 = runner.invoke(cli, ["hi", "--schema", "t:bad_template"], catch_exceptions=False)
     assert result2.output == "Error: Invalid template: bad_template\n"
 
 
@@ -269,9 +249,7 @@ def test_execute_prompt_with_a_template(
     runner = CliRunner()
     result = runner.invoke(
         cli,
-        ["--no-stream", "-t", "template"]
-        + ([input_text] if input_text else [])
-        + extra_args,
+        ["--no-stream", "-t", "template"] + ([input_text] if input_text else []) + extra_args,
         catch_exceptions=False,
     )
     if isinstance(expected_input, str):

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -29,7 +29,9 @@ import yaml
         ),
     ),
 )
-def test_template_evaluate(prompt, system, defaults, params, expected_prompt, expected_system, expected_error):
+def test_template_evaluate(
+    prompt, system, defaults, params, expected_prompt, expected_system, expected_error
+):
     t = Template(name="t", prompt=prompt, system=system, defaults=defaults)
     if expected_error:
         with pytest.raises(Template.MissingVariables) as ex:
@@ -52,9 +54,15 @@ def test_templates_list_no_templates_found():
 def test_templates_list(templates_path, args):
     (templates_path / "one.yaml").write_text("template one", "utf-8")
     (templates_path / "two.yaml").write_text("template two", "utf-8")
-    (templates_path / "three.yaml").write_text("template three is very long " * 4, "utf-8")
-    (templates_path / "four.yaml").write_text("'this one\n\nhas newlines in it'", "utf-8")
-    (templates_path / "both.yaml").write_text("system: summarize this\nprompt: $input", "utf-8")
+    (templates_path / "three.yaml").write_text(
+        "template three is very long " * 4, "utf-8"
+    )
+    (templates_path / "four.yaml").write_text(
+        "'this one\n\nhas newlines in it'", "utf-8"
+    )
+    (templates_path / "both.yaml").write_text(
+        "system: summarize this\nprompt: $input", "utf-8"
+    )
     (templates_path / "sys.yaml").write_text("system: Summarize this", "utf-8")
     runner = CliRunner()
     result = runner.invoke(cli, args)
@@ -102,7 +110,11 @@ def test_templates_list(templates_path, args):
                 "--schema",
                 '{"properties": {"b": {"type": "string"}, "a": {"type": "string"}}}',
             ],
-            {"schema_object": {"properties": {"b": {"type": "string"}, "a": {"type": "string"}}}},
+            {
+                "schema_object": {
+                    "properties": {"b": {"type": "string"}, "a": {"type": "string"}}
+                }
+            },
             None,
         ),
     ),
@@ -113,7 +125,10 @@ def test_templates_prompt_save(templates_path, args, expected_prompt, expected_e
     result = runner.invoke(cli, args + ["--save", "saved"], catch_exceptions=False)
     if not expected_error:
         assert result.exit_code == 0
-        assert yaml.safe_load((templates_path / "saved.yaml").read_text("utf-8")) == expected_prompt
+        assert (
+            yaml.safe_load((templates_path / "saved.yaml").read_text("utf-8"))
+            == expected_prompt
+        )
     else:
         assert result.exit_code == 1
         assert expected_error in result.output
@@ -121,12 +136,18 @@ def test_templates_prompt_save(templates_path, args, expected_prompt, expected_e
 
 def test_templates_error_on_missing_schema(templates_path):
     runner = CliRunner()
-    runner.invoke(cli, ["the-prompt", "--save", "prompt_no_schema"], catch_exceptions=False)
+    runner.invoke(
+        cli, ["the-prompt", "--save", "prompt_no_schema"], catch_exceptions=False
+    )
     # This should complain about no schema
-    result = runner.invoke(cli, ["hi", "--schema", "t:prompt_no_schema"], catch_exceptions=False)
+    result = runner.invoke(
+        cli, ["hi", "--schema", "t:prompt_no_schema"], catch_exceptions=False
+    )
     assert result.output == "Error: Template 'prompt_no_schema' has no schema\n"
     # And this is just an invalid template
-    result2 = runner.invoke(cli, ["hi", "--schema", "t:bad_template"], catch_exceptions=False)
+    result2 = runner.invoke(
+        cli, ["hi", "--schema", "t:bad_template"], catch_exceptions=False
+    )
     assert result2.output == "Error: Invalid template: bad_template\n"
 
 
@@ -249,7 +270,9 @@ def test_execute_prompt_with_a_template(
     runner = CliRunner()
     result = runner.invoke(
         cli,
-        ["--no-stream", "-t", "template"] + ([input_text] if input_text else []) + extra_args,
+        ["--no-stream", "-t", "template"]
+        + ([input_text] if input_text else [])
+        + extra_args,
         catch_exceptions=False,
     )
     if isinstance(expected_input, str):


### PR DESCRIPTION
Right now it's impossible to escape a dollar sign on a template, so we can't create a template like the folowing:

```bash
llm 'Does this item cost $10?' --save cost
llm 'What are the contents of my $PATH variable?' --save path
```

This commit allows escaping dollar signs which would allow this:
```bash
llm 'Does this item cost $$10?' --save cost
```

And then we can use the template with:
```bash
llm -t cost "banana"
```
