### PR TITLE
Add option to list the nth log? eg: second last log

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -85,6 +85,10 @@ Or `-n 0` to see everything that has ever been logged:
 ```bash
 llm logs -n 0
 ```
+Or `--nth 10` to the see the 10th recent item:
+```bash
+llm logs --nth 10
+```
 You can truncate the display of the prompts and responses using the `-t/--truncate` option. This can help make the JSON output more readable - though the `--short` option is usually better.
 ```bash
 llm logs -n 1 -t --json

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -73,6 +73,7 @@ from typing import cast, Optional, Iterable, List, Union, Tuple, Any
 import warnings
 import yaml
 
+
 warnings.simplefilter("ignore", ResourceWarning)
 
 DEFAULT_TEMPLATE = "prompt: "
@@ -1256,6 +1257,7 @@ order by prompt_attachments."order"
     is_flag=True,
     help="Expand fragments to show their content",
 )
+@click.option("--nth", type=int, help="List the nth entry from the last.", default=None)
 def logs_list(
     count,
     path,
@@ -1281,6 +1283,7 @@ def logs_list(
     id_gte,
     json_output,
     expand,
+    nth,
 ):
     "Show logged prompts and their responses"
     if database and not path:
@@ -1400,6 +1403,11 @@ def logs_list(
         schema_id = make_schema_id(schema)[0]
         where_bits.append("responses.schema_id = :schema_id")
         sql_params["schema_id"] = schema_id
+
+    if nth is not None:
+        if nth <= 0:
+            raise click.ClickException("Invalid `--nth` value. Must be 1 or greater.")
+        sql_format["limit"] = f" limit 1 offset {nth - 1}"
 
     if where_bits:
         where_ = " and " if query else " where "

--- a/tests/test_llm_logs.py
+++ b/tests/test_llm_logs.py
@@ -153,6 +153,23 @@ def test_logs_json(n, log_path):
     assert len(logs) == expected_length
 
 
+def test_logs_nth(log_path):
+    "Test that logs command correctly returns requested --nth record"
+    runner = CliRunner()
+    args = ["logs", "-p", str(log_path), "-n", "3", "--json"]
+    result = runner.invoke(cli, args, catch_exceptions=False)
+    expected_logs = json.loads(result.output)
+
+    # Test last 3 vals as -nth
+    for i in range(1, 3):
+        runner = CliRunner()
+        args = ["logs", "-p", str(log_path), "--nth", str(i), "--json"]
+        result = runner.invoke(cli, args, catch_exceptions=False)
+        assert result.exit_code == 0
+        logs = json.loads(result.output)
+        assert logs[0] == expected_logs[3 - i]
+
+
 @pytest.mark.parametrize(
     "args", (["-r"], ["--response"], ["list", "-r"], ["list", "--response"])
 )


### PR DESCRIPTION
Address the issue https://github.com/simonw/llm/issues/822

Example usage:

Use `--nth 10` to the see the 10th most recent item:
```bash
llm logs --nth 10
```