### PR TITLE
Mention llm-fragments-doc plugin

### DIFF
--- a/docs/plugins/directory.md
+++ b/docs/plugins/directory.md
@@ -68,6 +68,7 @@ If an API model host provides an OpenAI-compatible API you can also [configure L
 - **[llm-templates-fabric](https://github.com/simonw/llm-templates-fabric)** provides access to the [Fabric](https://github.com/danielmiessler/fabric) collection of prompts: `cat setup.py | llm -t fabric:explain_code`.
 - **[llm-fragments-github](https://github.com/simonw/llm-fragments-github)** can load entire GitHub repositories in a single operation: `llm -f github:simonw/files-to-prompt 'explain this code'`.
 - **[llm-hacker-news](https://github.com/simonw/llm-hacker-news)** imports conversations from Hacker News as fragments: `llm -f hn:43615912 'summary with illustrative direct quotes'`.
+- **[llm-fragments-doc](https://github.com/mbode/llm-fragments-doc/)** lets you load various document types into llm using [docling](https://github.com/docling-project/docling): `llm -f doc:https://arxiv.org/pdf/2502.11096 'What is the paper about?'`
 
 ## Just for fun
 


### PR DESCRIPTION
I was really enjoying the new fragments functionality and thought it would be useful being able to work directly with files like pdf, docx, xlsx etc. I built a small prototype using [docling](https://github.com/docling-project/docling) and wanted to politely ask if you'd like to have it mentioned here. Of course, the functionality is rather basic and could be easily integrated into llm itself, but the dependency is somewhat non-light-weight. I'm also open to any suggestions for the plugin.

In any case, thank you very much for all your work!