### PR TITLE
add `llm upgrade` command and track installed plugins

### DIFF
--- a/llm/__init__.py
+++ b/llm/__init__.py
@@ -43,12 +43,15 @@ __all__ = [
     "get_model",
     "hookimpl",
     "KeyModel",
+    "get_installed_plugins",
     "Model",
     "ModelError",
     "NeedsKeyException",
     "Options",
     "Prompt",
+    "remove_installed_plugin",
     "Response",
+    "save_installed_plugin",
     "Template",
     "user_dir",
     "schema_dsl",
@@ -289,6 +292,33 @@ def load_keys():
         return json.loads(path.read_text())
     else:
         return {}
+
+
+def get_installed_plugins():
+    path = user_dir() / "plugins.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not path.exists():
+        path.write_text("[]\n")
+    try:
+        return json.loads(path.read_text())
+    except json.decoder.JSONDecodeError:
+        return []
+
+
+def save_installed_plugin(plugin_name):
+    plugins = get_installed_plugins()
+    if plugin_name not in plugins:
+        plugins.append(plugin_name)
+        path = user_dir() / "plugins.json"
+        path.write_text(json.dumps(plugins, indent=2))
+
+
+def remove_installed_plugin(plugin_name):
+    plugins = get_installed_plugins()
+    if plugin_name in plugins:
+        plugins.remove(plugin_name)
+        path = user_dir() / "plugins.json"
+        path.write_text(json.dumps(plugins, indent=2))
 
 
 def user_dir():


### PR DESCRIPTION
👋 Hiya Simon! I've been giving `llm` a try and have really been enjoying it. I have it installed via `uv tool` and the upgrade process has been driving me up the wall -- `uv tool upgrade llm` wipes out any installed plugins every single time. I had resorted to just using the builtin `llm install -U ...` command, but that doesn't help if I happen to upgrade all the tools using `uv tool upgrade --all`.

I saw there were a couple open issues regarding this (#575, #733, #870), but no resolution to them, so I took a stab at this.

The general idea is to track the installed plugins in the user's config directory (just like aliases and keys), so that in the event `llm` is updated using `uv tool upgrade` you can at least recover and get everything back to what you had:

```shell
$ ./test-llm-upgrade.sh
+ uv tool uninstall llm
Uninstalled 1 executable: llm
+ rm -f /home/josh/.config/io.datasette.llm/plugins.json
+ uv tool install /home/josh/projects/llm
Resolved 32 packages in 32ms
Installed 32 packages in 69ms
 + annotated-types==0.7.0
 + anyio==4.9.0
 + certifi==2025.1.31
 + click==8.1.8
 + click-default-group==1.2.4
 + condense-json==0.1.2
 + distro==1.9.0
 + h11==0.14.0
 + httpcore==1.0.8
 + httpx==0.28.1
 + idna==3.10
 + jiter==0.9.0
 + llm==0.25a0 (from file:///home/josh/projects/llm)
 + openai==1.75.0
 + pip==25.0.1
 + pluggy==1.5.0
 + puremagic==1.28
 + pydantic==2.11.3
 + pydantic-core==2.33.1
 + python-dateutil==2.9.0.post0
 + python-ulid==3.0.0
 + pyyaml==6.0.2
 + setuptools==78.1.0
 + six==1.17.0
 + sniffio==1.3.1
 + sqlite-fts4==1.0.3
 + sqlite-migrate==0.1b0
 + sqlite-utils==3.38
 + tabulate==0.9.0
 + tqdm==4.67.1
 + typing-extensions==4.13.2
 + typing-inspection==0.4.0
Installed 1 executable: llm
+ llm plugins
[]
+ [[ -f /home/josh/.config/io.datasette.llm/plugins.json ]]
+ llm install llm-anthropic
package='llm-anthropic'
package.startswith('llm-')=True
[]
saved plugin
Collecting llm-anthropic
  Using cached llm_anthropic-0.15.1-py3-none-any.whl.metadata (9.3 kB)
Requirement already satisfied: llm>=0.23 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from llm-anthropic) (0.25a0)
Collecting anthropic>=0.48.0 (from llm-anthropic)
  Using cached anthropic-0.49.0-py3-none-any.whl.metadata (24 kB)
Requirement already satisfied: anyio<5,>=3.5.0 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from anthropic>=0.48.0->llm-anthropic) (4.9.0)
Requirement already satisfied: distro<2,>=1.7.0 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from anthropic>=0.48.0->llm-anthropic) (1.9.0)
Requirement already satisfied: httpx<1,>=0.23.0 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from anthropic>=0.48.0->llm-anthropic) (0.28.1)
Requirement already satisfied: jiter<1,>=0.4.0 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from anthropic>=0.48.0->llm-anthropic) (0.9.0)
Requirement already satisfied: pydantic<3,>=1.9.0 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from anthropic>=0.48.0->llm-anthropic) (2.11.3)
Requirement already satisfied: sniffio in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from anthropic>=0.48.0->llm-anthropic) (1.3.1)
Requirement already satisfied: typing-extensions<5,>=4.10 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from anthropic>=0.48.0->llm-anthropic) (4.13.2)
Requirement already satisfied: click in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from llm>=0.23->llm-anthropic) (8.1.8)
Requirement already satisfied: condense-json>=0.1.2 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from llm>=0.23->llm-anthropic) (0.1.2)
Requirement already satisfied: openai>=1.55.3 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from llm>=0.23->llm-anthropic) (1.75.0)
Requirement already satisfied: click-default-group>=1.2.3 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from llm>=0.23->llm-anthropic) (1.2.4)
Requirement already satisfied: sqlite-utils>=3.37 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from llm>=0.23->llm-anthropic) (3.38)
Requirement already satisfied: sqlite-migrate>=0.1a2 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from llm>=0.23->llm-anthropic) (0.1b0)
Requirement already satisfied: PyYAML in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from llm>=0.23->llm-anthropic) (6.0.2)
Requirement already satisfied: pluggy in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from llm>=0.23->llm-anthropic) (1.5.0)
Requirement already satisfied: python-ulid in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from llm>=0.23->llm-anthropic) (3.0.0)
Requirement already satisfied: setuptools in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from llm>=0.23->llm-anthropic) (78.1.0)
Requirement already satisfied: pip in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from llm>=0.23->llm-anthropic) (25.0.1)
Requirement already satisfied: puremagic in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from llm>=0.23->llm-anthropic) (1.28)
Requirement already satisfied: idna>=2.8 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from anyio<5,>=3.5.0->anthropic>=0.48.0->llm-anthropic) (3.10)
Requirement already satisfied: certifi in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from httpx<1,>=0.23.0->anthropic>=0.48.0->llm-anthropic) (2025.1.31)
Requirement already satisfied: httpcore==1.* in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from httpx<1,>=0.23.0->anthropic>=0.48.0->llm-anthropic) (1.0.8)
Requirement already satisfied: h11<0.15,>=0.13 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from httpcore==1.*->httpx<1,>=0.23.0->anthropic>=0.48.0->llm-anthropic) (0.14.0)
Requirement already satisfied: tqdm>4 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from openai>=1.55.3->llm>=0.23->llm-anthropic) (4.67.1)
Requirement already satisfied: annotated-types>=0.6.0 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from pydantic<3,>=1.9.0->anthropic>=0.48.0->llm-anthropic) (0.7.0)
Requirement already satisfied: pydantic-core==2.33.1 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from pydantic<3,>=1.9.0->anthropic>=0.48.0->llm-anthropic) (2.33.1)
Requirement already satisfied: typing-inspection>=0.4.0 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from pydantic<3,>=1.9.0->anthropic>=0.48.0->llm-anthropic) (0.4.0)
Requirement already satisfied: sqlite-fts4 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from sqlite-utils>=3.37->llm>=0.23->llm-anthropic) (1.0.3)
Requirement already satisfied: tabulate in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from sqlite-utils>=3.37->llm>=0.23->llm-anthropic) (0.9.0)
Requirement already satisfied: python-dateutil in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from sqlite-utils>=3.37->llm>=0.23->llm-anthropic) (2.9.0.post0)
Requirement already satisfied: six>=1.5 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from python-dateutil->sqlite-utils>=3.37->llm>=0.23->llm-anthropic) (1.17.0)
Using cached llm_anthropic-0.15.1-py3-none-any.whl (12 kB)
Using cached anthropic-0.49.0-py3-none-any.whl (243 kB)
Installing collected packages: anthropic, llm-anthropic
Successfully installed anthropic-0.49.0 llm-anthropic-0.15.1
+ llm plugins
[
  {
    "name": "llm-anthropic",
    "hooks": [
      "register_models"
    ],
    "version": "0.15.1"
  }
]
+ awk 1 /home/josh/.config/io.datasette.llm/plugins.json
[
  "llm-anthropic"
]
+ uv tool upgrade llm
Modified llm environment
 - anthropic==0.49.0
 - llm-anthropic==0.15.1
+ llm plugins
[]
+ awk 1 /home/josh/.config/io.datasette.llm/plugins.json
[
  "llm-anthropic"
]
+ llm upgrade
Requirement already satisfied: llm in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (0.25a0)
Collecting llm-anthropic
  Using cached llm_anthropic-0.15.1-py3-none-any.whl.metadata (9.3 kB)
Requirement already satisfied: click in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from llm) (8.1.8)
Requirement already satisfied: condense-json>=0.1.2 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from llm) (0.1.2)
Requirement already satisfied: openai>=1.55.3 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from llm) (1.75.0)
Requirement already satisfied: click-default-group>=1.2.3 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from llm) (1.2.4)
Requirement already satisfied: sqlite-utils>=3.37 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from llm) (3.38)
Requirement already satisfied: sqlite-migrate>=0.1a2 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from llm) (0.1b0)
Requirement already satisfied: pydantic>=2.0.0 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from llm) (2.11.3)
Requirement already satisfied: PyYAML in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from llm) (6.0.2)
Requirement already satisfied: pluggy in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from llm) (1.5.0)
Requirement already satisfied: python-ulid in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from llm) (3.0.0)
Requirement already satisfied: setuptools in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from llm) (78.1.0)
Requirement already satisfied: pip in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from llm) (25.0.1)
Requirement already satisfied: puremagic in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from llm) (1.28)
Collecting anthropic>=0.48.0 (from llm-anthropic)
  Using cached anthropic-0.49.0-py3-none-any.whl.metadata (24 kB)
Requirement already satisfied: anyio<5,>=3.5.0 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from anthropic>=0.48.0->llm-anthropic) (4.9.0)
Requirement already satisfied: distro<2,>=1.7.0 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from anthropic>=0.48.0->llm-anthropic) (1.9.0)
Requirement already satisfied: httpx<1,>=0.23.0 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from anthropic>=0.48.0->llm-anthropic) (0.28.1)
Requirement already satisfied: jiter<1,>=0.4.0 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from anthropic>=0.48.0->llm-anthropic) (0.9.0)
Requirement already satisfied: sniffio in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from anthropic>=0.48.0->llm-anthropic) (1.3.1)
Requirement already satisfied: typing-extensions<5,>=4.10 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from anthropic>=0.48.0->llm-anthropic) (4.13.2)
Requirement already satisfied: tqdm>4 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from openai>=1.55.3->llm) (4.67.1)
Requirement already satisfied: annotated-types>=0.6.0 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from pydantic>=2.0.0->llm) (0.7.0)
Requirement already satisfied: pydantic-core==2.33.1 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from pydantic>=2.0.0->llm) (2.33.1)
Requirement already satisfied: typing-inspection>=0.4.0 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from pydantic>=2.0.0->llm) (0.4.0)
Requirement already satisfied: sqlite-fts4 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from sqlite-utils>=3.37->llm) (1.0.3)
Requirement already satisfied: tabulate in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from sqlite-utils>=3.37->llm) (0.9.0)
Requirement already satisfied: python-dateutil in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from sqlite-utils>=3.37->llm) (2.9.0.post0)
Requirement already satisfied: idna>=2.8 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from anyio<5,>=3.5.0->anthropic>=0.48.0->llm-anthropic) (3.10)
Requirement already satisfied: certifi in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from httpx<1,>=0.23.0->anthropic>=0.48.0->llm-anthropic) (2025.1.31)
Requirement already satisfied: httpcore==1.* in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from httpx<1,>=0.23.0->anthropic>=0.48.0->llm-anthropic) (1.0.8)
Requirement already satisfied: h11<0.15,>=0.13 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from httpcore==1.*->httpx<1,>=0.23.0->anthropic>=0.48.0->llm-anthropic) (0.14.0)
Requirement already satisfied: six>=1.5 in /home/josh/.local/share/uv/tools/llm/lib/python3.13/site-packages (from python-dateutil->sqlite-utils>=3.37->llm) (1.17.0)
Using cached llm_anthropic-0.15.1-py3-none-any.whl (12 kB)
Using cached anthropic-0.49.0-py3-none-any.whl (243 kB)
Installing collected packages: anthropic, llm-anthropic
Successfully installed anthropic-0.49.0 llm-anthropic-0.15.1
```

No real tests beyond my simple script above, mainly because TBH I don't *love* the user API here and it feels like it's papering over another issue (one I stumbled on after I had already done the quick work to add this command, of course 😆).

The `uv` way of installing extra packages in a tool's environment is `uv tool install --with llm-anthropic llm` -- if you install this way, the extra packages persist through tool upgrades. So while my solution here technically *works* and allows you to recover your installed plugins, I think the actual answer is changing `llm install` to respect whether `llm` was installed via the `uv tool` approach and if so, alter the approach. Whether that's calling uv itself, or finding the python the `uv tool` installed `llm` is using and change to that for the `pip` call, I'm not sure.

Anyway, feel free to close this PR as now that I've talked through the problem, I'm not sure this is the solution. But I did want to at least open it to get your thoughts on how best to proceed here -- if you have the time.

Thanks again!