### PR TITLE
Use click.visible_prompt_func directly instead of prompt() to fix edi…

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -909,7 +909,11 @@ def chat(
     accumulated = []
     end_token = "!end"
     while True:
-        prompt = click.prompt("", prompt_suffix="> " if not in_multi else "")
+        prompt = ""
+        while prompt == "" or prompt.isspace():
+            # use click.termui.visible_prompt_func (overridden during tests) directly
+            # to avoid bug in click.prompt
+            prompt = click.termui.visible_prompt_func("> " if not in_multi else "")
         if prompt.strip().startswith("!multi"):
             in_multi = True
             bits = prompt.strip().split()


### PR DESCRIPTION
click.prompt() was manually printing the prompt characters, confusing readline. This was noticable when using ctrl+backspace or when wrapping a line.

Fixes:
- #582 

Partially:
- #356 