### PR TITLE
Add model_name parameter to OpenAI extra models documentation

### DIFF
--- a/docs/openai-models.md
+++ b/docs/openai-models.md
@@ -134,9 +134,10 @@ Let's say OpenAI have just released the `gpt-3.5-turbo-0613` model and you want 
 
 ```yaml
 - model_id: gpt-3.5-turbo-0613
+  model_name: gpt-3.5-turbo-0613
   aliases: ["0613"]
 ```
-The `model_id` is the identifier that will be recorded in the LLM logs. You can use this to specify the model, or you can optionally include a list of aliases for that model.
+The `model_id` is the identifier that will be recorded in the LLM logs. You can use this to specify the model, or you can optionally include a list of aliases for that model. The `model_name` is the actual model identifier that will be passed to the API, which must match exactly what the API expects.
 
 If the model is a completion model (such as `gpt-3.5-turbo-instruct`) add `completion: true` to the configuration.
 


### PR DESCRIPTION
## Summary
- Fix documentation for extra OpenAI models configuration by adding the required model_name parameter
- Add explanation about the difference between model_id and model_name
- model_id is used internally for logging while model_name is passed to the API

Fixes #925

🤖 Generated with [Claude Code](https://claude.ai/code)