### PR TITLE
Add shell completion for models, templates and option names

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -347,6 +347,20 @@ def complete_embedding_model(ctx: click.Context, param: click.Parameter, incompl
 
     return [CompletionItem(alias) for alias in get_embedding_model_aliases().keys() if alias.startswith(incomplete)]
 
+def complete_option(ctx: click.Context, param: click.Parameter, incomplete):
+    from click.shell_completion import CompletionItem
+
+    # This function is actually hit for the option 'value' as well.
+    # But there's no way to tell without patching click.
+
+    try:
+        model_id = ctx.params["model_id"]
+        model = get_model(model_id or get_default_model())
+    except (AttributeError, UnknownModelError):
+        return []
+    options = model.Options.model_json_schema()["properties"].keys()
+    return [CompletionItem(option) for option in options if option.startswith(incomplete)]
+
 class TemplateType(click.ParamType):
     name = "template"
 
@@ -434,6 +448,7 @@ class TemplateType(click.ParamType):
     type=(str, str),
     multiple=True,
     help="key/value options for the model",
+    shell_complete=complete_option,
 )
 @schema_option
 @click.option(
@@ -983,6 +998,7 @@ def prompt(
     type=(str, str),
     multiple=True,
     help="key/value options for the model",
+    shell_complete=complete_option,
 )
 @click.option(
     "-d",

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -347,6 +347,12 @@ def complete_embedding_model(ctx: click.Context, param: click.Parameter, incompl
 
     return [CompletionItem(alias) for alias in get_embedding_model_aliases().keys() if alias.startswith(incomplete)]
 
+def complete_template(ctx: click.Context, param: click.Parameter, incomplete: str):
+    from click.shell_completion import CompletionItem
+
+    path = template_dir()
+    return [CompletionItem(file.stem) for file in path.glob(incomplete + "*.yaml")]
+
 
 
 @cli.command(name="prompt")
@@ -446,7 +452,7 @@ def complete_embedding_model(ctx: click.Context, param: click.Parameter, incompl
     multiple=True,
     help="Fragment to add to system prompt",
 )
-@click.option("-t", "--template", help="Template to use")
+@click.option("-t", "--template", help="Template to use", shell_complete=complete_template)
 @click.option(
     "-p",
     "--param",
@@ -960,7 +966,7 @@ def prompt(
     multiple=True,
     help="Fragment to add to system prompt",
 )
-@click.option("-t", "--template", help="Template to use")
+@click.option("-t", "--template", help="Template to use", shell_complete=complete_template)
 @click.option(
     "-p",
     "--param",

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -342,6 +342,12 @@ def complete_model(ctx: click.Context, param: click.Parameter, incomplete: str):
 
     return [CompletionItem(alias) for alias in get_model_aliases().keys() if alias.startswith(incomplete)]
 
+def complete_embedding_model(ctx: click.Context, param: click.Parameter, incomplete: str):
+    from click.shell_completion import CompletionItem
+
+    return [CompletionItem(alias) for alias in get_embedding_model_aliases().keys() if alias.startswith(incomplete)]
+
+
 
 @cli.command(name="prompt")
 @click.argument("prompt", required=False)
@@ -2997,7 +3003,8 @@ def uninstall(packages, yes):
     help="File to embed",
 )
 @click.option(
-    "-m", "--model", help="Embedding model to use", envvar="LLM_EMBEDDING_MODEL"
+    "-m", "--model", help="Embedding model to use", envvar="LLM_EMBEDDING_MODEL",
+    shell_complete=complete_embedding_model
 )
 @click.option("--store", is_flag=True, help="Store the text itself in the database")
 @click.option(
@@ -3141,7 +3148,8 @@ def embed(
 )
 @click.option("--prefix", help="Prefix to add to the IDs", default="")
 @click.option(
-    "-m", "--model", help="Embedding model to use", envvar="LLM_EMBEDDING_MODEL"
+    "-m", "--model", help="Embedding model to use", envvar="LLM_EMBEDDING_MODEL",
+    shell_complete=complete_embedding_model
 )
 @click.option(
     "--prepend",

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -347,12 +347,14 @@ def complete_embedding_model(ctx: click.Context, param: click.Parameter, incompl
 
     return [CompletionItem(alias) for alias in get_embedding_model_aliases().keys() if alias.startswith(incomplete)]
 
-def complete_template(ctx: click.Context, param: click.Parameter, incomplete: str):
-    from click.shell_completion import CompletionItem
+class TemplateType(click.ParamType):
+    name = "template"
 
-    path = template_dir()
-    return [CompletionItem(file.stem) for file in path.glob(incomplete + "*.yaml")]
+    def shell_complete(self, ctx, param, incomplete):
+        from click.shell_completion import CompletionItem
 
+        path = template_dir()
+        return [CompletionItem(file.stem) for file in path.glob(incomplete + "*.yaml")]
 
 
 @cli.command(name="prompt")
@@ -452,7 +454,7 @@ def complete_template(ctx: click.Context, param: click.Parameter, incomplete: st
     multiple=True,
     help="Fragment to add to system prompt",
 )
-@click.option("-t", "--template", help="Template to use", shell_complete=complete_template)
+@click.option("-t", "--template", help="Template to use", type=TemplateType())
 @click.option(
     "-p",
     "--param",
@@ -966,7 +968,7 @@ def prompt(
     multiple=True,
     help="Fragment to add to system prompt",
 )
-@click.option("-t", "--template", help="Template to use", shell_complete=complete_template)
+@click.option("-t", "--template", help="Template to use", type=TemplateType())
 @click.option(
     "-p",
     "--param",
@@ -2357,7 +2359,7 @@ def templates_list():
 
 
 @templates.command(name="show")
-@click.argument("name")
+@click.argument("name", type=TemplateType())
 def templates_show(name):
     "Show the specified prompt template"
     try:
@@ -2374,7 +2376,7 @@ def templates_show(name):
 
 
 @templates.command(name="edit")
-@click.argument("name")
+@click.argument("name", type=TemplateType())
 def templates_edit(name):
     "Edit the specified prompt template using the default $EDITOR"
     # First ensure it exists

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -337,10 +337,16 @@ def cli():
     """
 
 
+def complete_model(ctx: click.Context, param: click.Parameter, incomplete: str):
+    from click.shell_completion import CompletionItem
+
+    return [CompletionItem(alias) for alias in get_model_aliases().keys() if alias.startswith(incomplete)]
+
+
 @cli.command(name="prompt")
 @click.argument("prompt", required=False)
 @click.option("-s", "--system", help="System prompt to use")
-@click.option("model_id", "-m", "--model", help="Model to use", envvar="LLM_MODEL")
+@click.option("model_id", "-m", "--model", help="Model to use", envvar="LLM_MODEL", shell_complete=complete_model)
 @click.option(
     "-d",
     "--database",
@@ -919,7 +925,7 @@ def prompt(
 
 @cli.command()
 @click.option("-s", "--system", help="System prompt to use")
-@click.option("model_id", "-m", "--model", help="Model to use", envvar="LLM_MODEL")
+@click.option("model_id", "-m", "--model", help="Model to use", envvar="LLM_MODEL", shell_complete=complete_model)
 @click.option(
     "_continue",
     "-c",


### PR DESCRIPTION
This adds support for autocompleting the `-m`, `-t` and `-o` arguments. I've found it very useful so far to look up gemini models and remember what the options were called.

click shell_completion docs: https://click.palletsprojects.com/en/stable/shell-completion/

Quick setup/testing:

- bash: `eval $(_LLM_COMPLETE=bash_source llm)`
- zsh: `eval "$(_FOO_BAR_COMPLETE=zsh_source foo-bar)"`
- fish: `_LLM_COMPLETE=fish_source llm | source`
