### PR TITLE
Honor default model options when using aliases

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -667,7 +667,7 @@ def prompt(
             raise click.ClickException(render_errors(ex.errors()))
 
     # Add on any default model options
-    default_options = get_model_options(model_id)
+    default_options = get_model_options(model.model_id)
     for key_, value in default_options.items():
         if key_ not in validated_options:
             validated_options[key_] = value


### PR DESCRIPTION
When getting the default options for a model, the resolved model_id was not being used if the user invoked the cli using an alias, like `llm -m <alias> "..."`.

Fixes #968