### PR TITLE
Load model options in chat command

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -910,7 +910,7 @@ def chat(
         conversation.model = model
 
     # Validate options
-    validated_options = {}
+    validated_options = get_model_options(model.model_id)
     if options:
         try:
             validated_options = dict(


### PR DESCRIPTION
This change ensures the `chat` command will load a model's default options. Having default options work for `prompt` but get ignored by `chat` is a very surprising situation, so this is my attempt to resolve that issue.