### PR TITLE
bugfix: cast path to str in templates_edit

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -2127,7 +2127,7 @@ def templates_edit(name):
     path = template_dir() / f"{name}.yaml"
     if not path.exists():
         path.write_text(DEFAULT_TEMPLATE, "utf-8")
-    click.edit(filename=path)
+    click.edit(filename=str(path))
     # Validate that template
     load_template(name)
 


### PR DESCRIPTION
original:

```
> llm templates edit media-sensible-rename                                                                                                                                                             Wed May 14 14:56:34 2025
Traceback (most recent call last):
  File "/Users/abizer/.local/bin/llm", line 10, in <module>
    sys.exit(cli())
             ^^^^^
  File "/Users/abizer/.local/share/uv/tools/llm/lib/python3.12/site-packages/click/core.py", line 1442, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/abizer/.local/share/uv/tools/llm/lib/python3.12/site-packages/click/core.py", line 1363, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/abizer/.local/share/uv/tools/llm/lib/python3.12/site-packages/click/core.py", line 1830, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/abizer/.local/share/uv/tools/llm/lib/python3.12/site-packages/click/core.py", line 1830, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/abizer/.local/share/uv/tools/llm/lib/python3.12/site-packages/click/core.py", line 1226, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/abizer/.local/share/uv/tools/llm/lib/python3.12/site-packages/click/core.py", line 794, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/abizer/.local/share/uv/tools/llm/lib/python3.12/site-packages/llm/cli.py", line 1909, in templates_edit
    click.edit(filename=path)
  File "/Users/abizer/.local/share/uv/tools/llm/lib/python3.12/site-packages/click/termui.py", line 772, in edit
    ed.edit_files(filenames=filename)
  File "/Users/abizer/.local/share/uv/tools/llm/lib/python3.12/site-packages/click/_termui_impl.py", line 591, in edit_files
    exc_filename = " ".join(f'"{filename}"' for filename in filenames)
                                                            ^^^^^^^^^
TypeError: 'PosixPath' object is not iterable
```

fixed:
```
(llm) .venv > VISUAL=head uv run llm templates edit media-sensible-rename                                                    
prompt: >
  this is a list of files from my downloads directory. 
  id like to rename them...
```