### PR TITLE
Allow prompting without quotes

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -302,7 +302,7 @@ def cli():
 
 
 @cli.command(name="prompt")
-@click.argument("prompt", required=False)
+@click.argument("prompt", required=False, nargs=-1)
 @click.option("-s", "--system", help="System prompt to use")
 @click.option("model_id", "-m", "--model", help="Model to use", envvar="LLM_MODEL")
 @click.option(
@@ -494,6 +494,8 @@ def prompt(
     \b
         llm 'JavaScript function for reversing a string' -x
     """
+    prompt = " ".join(prompt) if prompt else None
+
     if log and no_log:
         raise click.ClickException("--log and --no-log are mutually exclusive")
 


### PR DESCRIPTION
Before

```bash
$ llm hi hows it going
Usage: llm prompt [OPTIONS] [PROMPT]
Try 'llm prompt --help' for help.

Error: Got unexpected extra arguments (hows it going)
```

After

```bash
$ uv run llm hi hows it going
Hello! I'm here and ready to help. How can I assist you today?
```

It doesn't break stdin input, if that's a concern

```bash
$ echo "hello hows it going" | uv run llm
Hello! I'm doing well, thank you. How about you? How can I assist you today?
```
