### PR TITLE
Filter IDs with `--prefix` in `llm similar`

### DIFF
--- a/docs/embeddings/cli.md
+++ b/docs/embeddings/cli.md
@@ -347,7 +347,7 @@ This embeds the provided string and returns a newline-delimited list of JSON obj
 ```
 Use `-p/--plain` to get back results in plain text instead of JSON:
 ```bash
-llm -similar quotations -c 'computer science' -p
+llm similar quotations -c 'computer science' -p
 ```
 Example output:
 ```
@@ -364,6 +364,12 @@ echo 'computer science' | llm similar quotations -i -
 When using a model like CLIP, you can find images similar to an input image using `-i filename` with `--binary`:
 ```bash
 llm similar photos -i image.jpg --binary
+```
+
+You can filter results to only show IDs that begin with a specific prefix using --prefix:
+
+```bash
+llm similar quotations --prefix 'movies/' -c 'star wars'
 ```
 
 (embeddings-cli-embed-models)=

--- a/docs/help.md
+++ b/docs/help.md
@@ -940,6 +940,7 @@ Options:
   -n, --number INTEGER  Number of results to return
   -p, --plain           Output in plain text format
   -d, --database FILE
+  --prefix TEXT         Filters results to those with this prefix in their ID
   --help                Show this message and exit.
 ```
 

--- a/docs/help.md
+++ b/docs/help.md
@@ -940,7 +940,7 @@ Options:
   -n, --number INTEGER  Number of results to return
   -p, --plain           Output in plain text format
   -d, --database FILE
-  --prefix TEXT         Filters results to those with this prefix in their ID
+  --prefix TEXT         Just IDs with this prefix
   --help                Show this message and exit.
 ```
 

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -2213,7 +2213,9 @@ def schemas_list(path, database, queries, full):
       on responses.schema_id = schemas.id
     {} group by responses.schema_id
     order by recently_used
-    """.format(where_sql)
+    """.format(
+        where_sql
+    )
     rows = db.query(sql, params)
     for row in rows:
         click.echo("- id: {}".format(row["id"]))
@@ -2504,7 +2506,9 @@ def fragments_list(queries, aliases, json_):
     group by
         fragments.id, fragments.hash, fragments.content, fragments.datetime_utc, fragments.source
     order by fragments.datetime_utc
-    """.format(where=where)
+    """.format(
+        where=where
+    )
     results = list(db.query(sql, params))
     for result in results:
         result["aliases"] = json.loads(result["aliases"])

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -3036,9 +3036,7 @@ def embed_multi(
     type=click.Path(file_okay=True, allow_dash=False, dir_okay=False, writable=True),
     envvar="LLM_EMBEDDINGS_DB",
 )
-@click.option(
-    "--prefix", help="Just IDs with this prefix", default=""
-)
+@click.option("--prefix", help="Just IDs with this prefix", default="")
 def similar(collection, id, input, content, binary, number, plain, database, prefix):
     """
     Return top N similar IDs from a collection using cosine similarity.

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -2213,9 +2213,7 @@ def schemas_list(path, database, queries, full):
       on responses.schema_id = schemas.id
     {} group by responses.schema_id
     order by recently_used
-    """.format(
-        where_sql
-    )
+    """.format(where_sql)
     rows = db.query(sql, params)
     for row in rows:
         click.echo("- id: {}".format(row["id"]))
@@ -2506,9 +2504,7 @@ def fragments_list(queries, aliases, json_):
     group by
         fragments.id, fragments.hash, fragments.content, fragments.datetime_utc, fragments.source
     order by fragments.datetime_utc
-    """.format(
-        where=where
-    )
+    """.format(where=where)
     results = list(db.query(sql, params))
     for result in results:
         result["aliases"] = json.loads(result["aliases"])
@@ -3036,7 +3032,10 @@ def embed_multi(
     type=click.Path(file_okay=True, allow_dash=False, dir_okay=False, writable=True),
     envvar="LLM_EMBEDDINGS_DB",
 )
-def similar(collection, id, input, content, binary, number, plain, database):
+@click.option(
+    "--prefix", help="Only results with this prefix will be returned", default=""
+)
+def similar(collection, id, input, content, binary, number, plain, database, prefix):
     """
     Return top N similar IDs from a collection using cosine similarity.
 
@@ -3068,7 +3067,7 @@ def similar(collection, id, input, content, binary, number, plain, database):
 
     if id:
         try:
-            results = collection_obj.similar_by_id(id, number)
+            results = collection_obj.similar_by_id(id, number, prefix=prefix)
         except Collection.DoesNotExist:
             raise click.ClickException("ID not found in collection")
     else:
@@ -3084,7 +3083,7 @@ def similar(collection, id, input, content, binary, number, plain, database):
                     content = f.read()
         if not content:
             raise click.ClickException("No content provided")
-        results = collection_obj.similar(content, number)
+        results = collection_obj.similar(content, number, prefix=prefix)
 
     for result in results:
         if plain:

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -3033,7 +3033,7 @@ def embed_multi(
     envvar="LLM_EMBEDDINGS_DB",
 )
 @click.option(
-    "--prefix", help="Only results with this prefix will be returned", default=""
+    "--prefix", help="Filters results to those with this prefix in their ID", default=""
 )
 def similar(collection, id, input, content, binary, number, plain, database, prefix):
     """

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -3037,7 +3037,7 @@ def embed_multi(
     envvar="LLM_EMBEDDINGS_DB",
 )
 @click.option(
-    "--prefix", help="Filters results to those with this prefix in their ID", default=""
+    "--prefix", help="Just IDs with this prefix", default=""
 )
 def similar(collection, id, input, content, binary, number, plain, database, prefix):
     """

--- a/llm/embeddings.py
+++ b/llm/embeddings.py
@@ -249,7 +249,7 @@ class Collection:
             vector (list): Vector to search by
             number (int, optional): Number of similar items to return
             skip_id (str, optional): An ID to exclude from the results
-            prefix: (str, optional): An ID prefix which all results must have
+            prefix: (str, optional): Filter results to IDs witih this prefix
 
         Returns:
             list: List of Entry objects
@@ -303,7 +303,7 @@ class Collection:
         Args:
             id (str): ID to search by
             number (int, optional): Number of similar items to return
-            prefix: (str, optional): An ID prefix which all results must share.
+            prefix: (str, optional): Filter results to IDs with this prefix
 
         Returns:
             list: List of Entry objects
@@ -332,7 +332,7 @@ class Collection:
         Args:
             value (str or bytes): value to search by
             number (int, optional): Number of similar items to return
-            prefix: (str, optional): An ID prefix which all results must share.
+            prefix: (str, optional): Filter results to IDs with this prefix
 
         Returns:
             list: List of Entry objects

--- a/llm/embeddings.py
+++ b/llm/embeddings.py
@@ -202,7 +202,9 @@ class Collection:
                     """
                     select id from embeddings
                     where collection_id = ? and content_hash in ({})
-                    """.format(",".join("?" for _ in items_and_hashes)),
+                    """.format(
+                        ",".join("?" for _ in items_and_hashes)
+                    ),
                     [collection_id]
                     + [item_and_hash[1] for item_and_hash in items_and_hashes],
                 )

--- a/llm/embeddings.py
+++ b/llm/embeddings.py
@@ -202,9 +202,7 @@ class Collection:
                     """
                     select id from embeddings
                     where collection_id = ? and content_hash in ({})
-                    """.format(
-                        ",".join("?" for _ in items_and_hashes)
-                    ),
+                    """.format(",".join("?" for _ in items_and_hashes)),
                     [collection_id]
                     + [item_and_hash[1] for item_and_hash in items_and_hashes],
                 )
@@ -238,7 +236,11 @@ class Collection:
                 )
 
     def similar_by_vector(
-        self, vector: List[float], number: int = 10, skip_id: Optional[str] = None
+        self,
+        vector: List[float],
+        number: int = 10,
+        skip_id: Optional[str] = None,
+        prefix: Optional[str] = None,
     ) -> List[Entry]:
         """
         Find similar items in the collection by a given vector.
@@ -246,6 +248,8 @@ class Collection:
         Args:
             vector (list): Vector to search by
             number (int, optional): Number of similar items to return
+            skip_id (str, optional): An ID to exclude from the results
+            prefix: (str, optional): An ID prefix which all results must have
 
         Returns:
             list: List of Entry objects
@@ -260,6 +264,10 @@ class Collection:
 
         where_bits = ["collection_id = ?"]
         where_args = [str(self.id)]
+
+        if prefix:
+            where_bits.append("id LIKE ? || '%'")
+            where_args.append(prefix)
 
         if skip_id:
             where_bits.append("id != ?")
@@ -286,13 +294,16 @@ class Collection:
             )
         ]
 
-    def similar_by_id(self, id: str, number: int = 10) -> List[Entry]:
+    def similar_by_id(
+        self, id: str, number: int = 10, prefix: Optional[str] = None
+    ) -> List[Entry]:
         """
         Find similar items in the collection by a given ID.
 
         Args:
             id (str): ID to search by
             number (int, optional): Number of similar items to return
+            prefix: (str, optional): An ID prefix which all results must share.
 
         Returns:
             list: List of Entry objects
@@ -308,21 +319,26 @@ class Collection:
             raise self.DoesNotExist("ID not found")
         embedding = matches[0]["embedding"]
         comparison_vector = llm.decode(embedding)
-        return self.similar_by_vector(comparison_vector, number, skip_id=id)
+        return self.similar_by_vector(
+            comparison_vector, number, skip_id=id, prefix=prefix
+        )
 
-    def similar(self, value: Union[str, bytes], number: int = 10) -> List[Entry]:
+    def similar(
+        self, value: Union[str, bytes], number: int = 10, prefix: Optional[str] = None
+    ) -> List[Entry]:
         """
         Find similar items in the collection by a given value.
 
         Args:
             value (str or bytes): value to search by
             number (int, optional): Number of similar items to return
+            prefix: (str, optional): An ID prefix which all results must share.
 
         Returns:
             list: List of Entry objects
         """
         comparison_vector = self.model().embed(value)
-        return self.similar_by_vector(comparison_vector, number)
+        return self.similar_by_vector(comparison_vector, number, prefix=prefix)
 
     @classmethod
     def exists(cls, db: Database, name: str) -> bool:

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -93,6 +93,13 @@ def test_similar(collection):
     ]
 
 
+def test_similar_prefixed(collection):
+    results = list(collection.similar("hello world", prefix="2"))
+    assert results == [
+        Entry(id="2", score=pytest.approx(0.9863939238321437)),
+    ]
+
+
 def test_similar_by_id(collection):
     results = list(collection.similar_by_id("1"))
     assert results == [

--- a/tests/test_embed_cli.py
+++ b/tests/test_embed_cli.py
@@ -15,11 +15,18 @@ from unittest.mock import ANY
         ("json", "[5, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]\n"),
         (
             "base64",
-            ("AACgQAAAoEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==\n"),
+            (
+                "AACgQAAAoEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==\n"
+            ),
         ),
         (
             "hex",
-            ("0000a0400000a0400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\n"),
+            (
+                "0000a0400000a04000000000000000000000000000000000000000000"
+                "000000000000000000000000000000000000000000000000000000000"
+                "00000000000000\n"
+            ),
         ),
         (
             "blob",
@@ -128,7 +135,9 @@ def test_embed_store(user_path, metadata, metadata_error):
         result2 = runner.invoke(cli, args)
         assert result2.exit_code == 0
         if is_json:
-            assert json.loads(result2.output) == [{"name": "items", "model": "embed-demo", "num_embeddings": 1}]
+            assert json.loads(result2.output) == [
+                {"name": "items", "model": "embed-demo", "num_embeddings": 1}
+            ]
         else:
             assert result2.output == "items: embed-demo\n  1 embedding\n"
 
@@ -172,7 +181,9 @@ def test_collection_delete_errors(user_path):
     assert db["collections"].count == 1
     assert db["embeddings"].count == 1
     runner = CliRunner()
-    result = runner.invoke(cli, ["collections", "delete", "does-not-exist"], catch_exceptions=False)
+    result = runner.invoke(
+        cli, ["collections", "delete", "does-not-exist"], catch_exceptions=False
+    )
     assert result.exit_code == 1
     assert "Collection does not exist" in result.output
     assert db["collections"].count == 1
@@ -208,7 +219,9 @@ def test_similar_by_id_cli(user_path_with_embeddings):
 @pytest.mark.parametrize("option", ("-p", "--plain"))
 def test_similar_by_id_cli_output_plain(user_path_with_embeddings, option):
     runner = CliRunner()
-    result = runner.invoke(cli, ["similar", "demo", "1", option], catch_exceptions=False)
+    result = runner.invoke(
+        cli, ["similar", "demo", "1", option], catch_exceptions=False
+    )
     assert result.exit_code == 0
     # Replace score with a placeholder
     output = result.output.split("(")[0] + "(score)" + result.output.split(")")[1]
@@ -246,7 +259,6 @@ def test_similar_by_content_cli(tmpdir, user_path_with_embeddings, scenario):
         "metadata": None,
     }
 
-
 @pytest.mark.parametrize(
     "prefix,expected_result",
     (
@@ -275,7 +287,6 @@ def test_similar_by_content_prefixed(user_path_with_embeddings, prefix, expected
     result = runner.invoke(cli, ["similar", "demo", "-c", "world", "--prefix", prefix, "-n", "1"], catch_exceptions=False)
     assert result.exit_code == 0
     assert json.loads(result.output) == expected_result
-
 
 @pytest.mark.parametrize("use_stdin", (False, True))
 @pytest.mark.parametrize("prefix", (None, "prefix"))
@@ -588,7 +599,9 @@ def test_embed_multi_files_encoding(multi_files, extra_args, expected_error):
         assert result.exit_code == 0
         assert not result.stderr
         embeddings_db = sqlite_utils.Database(db_path)
-        rows = list(embeddings_db.query("select id, content from embeddings order by id"))
+        rows = list(
+            embeddings_db.query("select id, content from embeddings order by id")
+        )
         assert rows == [
             {"id": "ignored.ini", "content": "Has weird \x96 character"},
         ]
@@ -636,7 +649,9 @@ def test_llm_embed_models_query(user_path, args, expected_model_id):
 def test_default_embed_model_errors(user_path, default_is_set, command):
     runner = CliRunner()
     if default_is_set:
-        (user_path / "default_embedding_model.txt").write_text("embed-demo", encoding="utf8")
+        (user_path / "default_embedding_model.txt").write_text(
+            "embed-demo", encoding="utf8"
+        )
     args = []
     input = None
     if command == "embed-multi":
@@ -649,7 +664,10 @@ def test_default_embed_model_errors(user_path, default_is_set, command):
         assert result.exit_code == 0
     else:
         assert result.exit_code == 1
-        assert "You need to specify an embedding model (no default model is set)" in result.output
+        assert (
+            "You need to specify an embedding model (no default model is set)"
+            in result.output
+        )
         # Now set the default model and try again
         result2 = runner.invoke(cli, ["embed-models", "default", "embed-demo"])
         assert result2.exit_code == 0
@@ -681,7 +699,9 @@ def test_duplicate_content_embedded_only_once(embed_demo):
     assert len(embed_demo.embedded_content) == 3
 
     # Same again for embed_multi
-    collection.embed_multi((("1", "hello world"), ("2", "goodbye world"), ("3", "this is new")))
+    collection.embed_multi(
+        (("1", "hello world"), ("2", "goodbye world"), ("3", "this is new"))
+    )
     # Should have only embedded one more thing
     assert db["embeddings"].count == 4
     assert len(embed_demo.embedded_content) == 4

--- a/tests/test_embed_cli.py
+++ b/tests/test_embed_cli.py
@@ -15,18 +15,11 @@ from unittest.mock import ANY
         ("json", "[5, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]\n"),
         (
             "base64",
-            (
-                "AACgQAAAoEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==\n"
-            ),
+            ("AACgQAAAoEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==\n"),
         ),
         (
             "hex",
-            (
-                "0000a0400000a04000000000000000000000000000000000000000000"
-                "000000000000000000000000000000000000000000000000000000000"
-                "00000000000000\n"
-            ),
+            ("0000a0400000a0400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\n"),
         ),
         (
             "blob",
@@ -135,9 +128,7 @@ def test_embed_store(user_path, metadata, metadata_error):
         result2 = runner.invoke(cli, args)
         assert result2.exit_code == 0
         if is_json:
-            assert json.loads(result2.output) == [
-                {"name": "items", "model": "embed-demo", "num_embeddings": 1}
-            ]
+            assert json.loads(result2.output) == [{"name": "items", "model": "embed-demo", "num_embeddings": 1}]
         else:
             assert result2.output == "items: embed-demo\n  1 embedding\n"
 
@@ -181,9 +172,7 @@ def test_collection_delete_errors(user_path):
     assert db["collections"].count == 1
     assert db["embeddings"].count == 1
     runner = CliRunner()
-    result = runner.invoke(
-        cli, ["collections", "delete", "does-not-exist"], catch_exceptions=False
-    )
+    result = runner.invoke(cli, ["collections", "delete", "does-not-exist"], catch_exceptions=False)
     assert result.exit_code == 1
     assert "Collection does not exist" in result.output
     assert db["collections"].count == 1
@@ -219,9 +208,7 @@ def test_similar_by_id_cli(user_path_with_embeddings):
 @pytest.mark.parametrize("option", ("-p", "--plain"))
 def test_similar_by_id_cli_output_plain(user_path_with_embeddings, option):
     runner = CliRunner()
-    result = runner.invoke(
-        cli, ["similar", "demo", "1", option], catch_exceptions=False
-    )
+    result = runner.invoke(cli, ["similar", "demo", "1", option], catch_exceptions=False)
     assert result.exit_code == 0
     # Replace score with a placeholder
     output = result.output.split("(")[0] + "(score)" + result.output.split(")")[1]
@@ -258,6 +245,36 @@ def test_similar_by_content_cli(tmpdir, user_path_with_embeddings, scenario):
         "content": "goodbye world",
         "metadata": None,
     }
+
+
+@pytest.mark.parametrize(
+    "prefix,expected_result",
+    (
+        (
+            1,
+            {
+                "id": "1",
+                "score": pytest.approx(0.7071067811865475),
+                "content": "hello world",
+                "metadata": None,
+            },
+        ),
+        (
+            2,
+            {
+                "id": "2",
+                "score": pytest.approx(0.8137334712067349),
+                "content": "goodbye world",
+                "metadata": None,
+            },
+        ),
+    ),
+)
+def test_similar_by_content_prefixed(user_path_with_embeddings, prefix, expected_result):
+    runner = CliRunner()
+    result = runner.invoke(cli, ["similar", "demo", "-c", "world", "--prefix", prefix, "-n", "1"], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert json.loads(result.output) == expected_result
 
 
 @pytest.mark.parametrize("use_stdin", (False, True))
@@ -571,9 +588,7 @@ def test_embed_multi_files_encoding(multi_files, extra_args, expected_error):
         assert result.exit_code == 0
         assert not result.stderr
         embeddings_db = sqlite_utils.Database(db_path)
-        rows = list(
-            embeddings_db.query("select id, content from embeddings order by id")
-        )
+        rows = list(embeddings_db.query("select id, content from embeddings order by id"))
         assert rows == [
             {"id": "ignored.ini", "content": "Has weird \x96 character"},
         ]
@@ -621,9 +636,7 @@ def test_llm_embed_models_query(user_path, args, expected_model_id):
 def test_default_embed_model_errors(user_path, default_is_set, command):
     runner = CliRunner()
     if default_is_set:
-        (user_path / "default_embedding_model.txt").write_text(
-            "embed-demo", encoding="utf8"
-        )
+        (user_path / "default_embedding_model.txt").write_text("embed-demo", encoding="utf8")
     args = []
     input = None
     if command == "embed-multi":
@@ -636,10 +649,7 @@ def test_default_embed_model_errors(user_path, default_is_set, command):
         assert result.exit_code == 0
     else:
         assert result.exit_code == 1
-        assert (
-            "You need to specify an embedding model (no default model is set)"
-            in result.output
-        )
+        assert "You need to specify an embedding model (no default model is set)" in result.output
         # Now set the default model and try again
         result2 = runner.invoke(cli, ["embed-models", "default", "embed-demo"])
         assert result2.exit_code == 0
@@ -671,9 +681,7 @@ def test_duplicate_content_embedded_only_once(embed_demo):
     assert len(embed_demo.embedded_content) == 3
 
     # Same again for embed_multi
-    collection.embed_multi(
-        (("1", "hello world"), ("2", "goodbye world"), ("3", "this is new"))
-    )
+    collection.embed_multi((("1", "hello world"), ("2", "goodbye world"), ("3", "this is new")))
     # Should have only embedded one more thing
     assert db["embeddings"].count == 4
     assert len(embed_demo.embedded_content) == 4

--- a/tests/test_embed_cli.py
+++ b/tests/test_embed_cli.py
@@ -259,6 +259,7 @@ def test_similar_by_content_cli(tmpdir, user_path_with_embeddings, scenario):
         "metadata": None,
     }
 
+
 @pytest.mark.parametrize(
     "prefix,expected_result",
     (
@@ -282,11 +283,18 @@ def test_similar_by_content_cli(tmpdir, user_path_with_embeddings, scenario):
         ),
     ),
 )
-def test_similar_by_content_prefixed(user_path_with_embeddings, prefix, expected_result):
+def test_similar_by_content_prefixed(
+    user_path_with_embeddings, prefix, expected_result
+):
     runner = CliRunner()
-    result = runner.invoke(cli, ["similar", "demo", "-c", "world", "--prefix", prefix, "-n", "1"], catch_exceptions=False)
+    result = runner.invoke(
+        cli,
+        ["similar", "demo", "-c", "world", "--prefix", prefix, "-n", "1"],
+        catch_exceptions=False,
+    )
     assert result.exit_code == 0
     assert json.loads(result.output) == expected_result
+
 
 @pytest.mark.parametrize("use_stdin", (False, True))
 @pytest.mark.parametrize("prefix", (None, "prefix"))


### PR DESCRIPTION
This PR complements the `--prefix` arg in `llm embed-multi` with an analogous `--prefix` arg in `llm similar` that filters results by id prefix. This propagates through the various python API similar methods, has a unit test for the underlying functionality and a unit test for the CLI command.