### PR TITLE
Support supports_tools parameters in openai compatible models

### DIFF
--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -184,6 +184,8 @@ def register_models(register):
             kwargs["can_stream"] = False
         if extra_model.get("supports_schema") is True:
             kwargs["supports_schema"] = True
+        if extra_model.get("supports_tools") is True:
+            kwargs["supports_tools"] = True
         if extra_model.get("vision") is True:
             kwargs["vision"] = True
         if extra_model.get("audio") is True:


### PR DESCRIPTION
Adds support for `supports_tools` parameter in OpenAI compatible models.