### PR TITLE
Provide type hint for response_json

### DIFF
--- a/llm/models.py
+++ b/llm/models.py
@@ -525,7 +525,7 @@ class _BaseResponse:
         self._chunks: List[str] = []
         self._done = False
         self._tool_calls: List[ToolCall] = []
-        self.response_json = None
+        self.response_json: Optional[Dict[str, Any]] = None
         self.conversation = conversation
         self.attachments: List[Attachment] = []
         self._start: Optional[float] = None


### PR DESCRIPTION
Satisfies the type checker, I got:

> Cannot assign to attribute "response_json" for class "Response"
> Expression of type "dict[str, Any]" cannot be assigned to attribute "response_json" of class "Response"
> "dict[str, Any]" is not assignable to "None"