### PR TITLE
support default query

### DIFF
--- a/docs/other-models.md
+++ b/docs/other-models.md
@@ -76,3 +76,16 @@ Some providers such as [openrouter.ai](https://openrouter.ai/docs) may require t
     HTTP-Referer: "https://llm.datasette.io/"
     X-Title: LLM
 ```
+
+### Extra HTTP query
+
+Some providers may require the setting of additional HTTP query. You can set those using the `query:` key like this:
+
+```yaml
+- model_id: claude
+  model_name: anthropic/claude-2
+  api_base: "https://example.com/api/v1"
+  api_key_name: example
+  query:
+    example_query: "test"
+```

--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -178,6 +178,7 @@ def register_models(register):
         api_version = extra_model.get("api_version")
         api_engine = extra_model.get("api_engine")
         headers = extra_model.get("headers")
+        query = extra_model.get("query")
         reasoning = extra_model.get("reasoning")
         kwargs = {}
         if extra_model.get("can_stream") is False:
@@ -202,6 +203,7 @@ def register_models(register):
             api_version=api_version,
             api_engine=api_engine,
             headers=headers,
+            query=query,
             reasoning=reasoning,
             **kwargs,
         )
@@ -467,6 +469,7 @@ class _Shared:
         api_version=None,
         api_engine=None,
         headers=None,
+        query=None,
         can_stream=True,
         vision=False,
         audio=False,
@@ -485,6 +488,7 @@ class _Shared:
         self.api_version = api_version
         self.api_engine = api_engine
         self.headers = headers
+        self.query = query
         self.can_stream = can_stream
         self.vision = vision
         self.allows_system_prompt = allows_system_prompt
@@ -621,6 +625,8 @@ class _Shared:
             kwargs["api_key"] = "DUMMY_KEY"
         if self.headers:
             kwargs["default_headers"] = self.headers
+        if self.query:
+            kwargs["default_query"] = self.query
         if os.environ.get("LLM_OPENAI_SHOW_RESPONSES"):
             kwargs["http_client"] = logging_client()
         if async_:


### PR DESCRIPTION
Some OpenAI-compatible APIs require specific query parameters. This PR adds support for a query configuration in extra-openai-models.yaml, allowing users to define and use these custom APIs more flexibly.