### PR TITLE
Use isort in ruff, merge ruff.toml into pyproject.toml

### DIFF
--- a/docs/plugins/llm-markov/llm_markov.py
+++ b/docs/plugins/llm-markov/llm_markov.py
@@ -1,8 +1,10 @@
-import llm
 import random
 import time
 from typing import Optional
-from pydantic import field_validator, Field
+
+from pydantic import Field, field_validator
+
+import llm
 
 
 @llm.hookimpl

--- a/llm/__init__.py
+++ b/llm/__init__.py
@@ -1,8 +1,18 @@
-from .hookspecs import hookimpl
+import inspect
+import json
+import os
+import pathlib
+import struct
+from typing import Any, Callable, Dict, List, Optional, Type, Union
+
+import click
+
+from .embeddings import Collection
 from .errors import (
     ModelError,
     NeedsKeyException,
 )
+from .hookspecs import hookimpl
 from .models import (
     AsyncConversation,
     AsyncKeyModel,
@@ -24,17 +34,9 @@ from .models import (
     ToolCall,
     ToolResult,
 )
-from .utils import schema_dsl, Fragment
-from .embeddings import Collection
+from .plugins import load_plugins, pm
 from .templates import Template
-from .plugins import pm, load_plugins
-import click
-from typing import Any, Dict, List, Optional, Callable, Type, Union
-import inspect
-import json
-import os
-import pathlib
-import struct
+from .utils import Fragment, schema_dsl
 
 __all__ = [
     "AsyncConversation",

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1,49 +1,67 @@
 import asyncio
-import click
-from click_default_group import DefaultGroup
-from dataclasses import asdict
+import base64
+import inspect
 import io
 import json
 import os
+import pathlib
+import re
+import readline
+import shutil
+import sys
+import textwrap
+import warnings
+from dataclasses import asdict
+from runpy import run_module
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, Union, cast
+
+import click
+import httpx
+import pydantic
+import sqlite_utils
+import yaml
+from click_default_group import DefaultGroup
+from sqlite_utils.utils import Format, rows_from_file
+
 from llm import (
-    Attachment,
     AsyncConversation,
     AsyncKeyModel,
     AsyncResponse,
+    Attachment,
     CancelToolCall,
     Collection,
     Conversation,
     Fragment,
+    KeyModel,
     Response,
     Template,
     Tool,
     Toolbox,
     UnknownModelError,
-    KeyModel,
     encode,
     get_async_model,
-    get_default_model,
     get_default_embedding_model,
-    get_embedding_models_with_aliases,
-    get_embedding_model_aliases,
+    get_default_model,
     get_embedding_model,
-    get_plugins,
-    get_tools,
+    get_embedding_model_aliases,
+    get_embedding_models_with_aliases,
     get_fragment_loaders,
-    get_template_loaders,
     get_model,
     get_model_aliases,
     get_models_with_aliases,
-    user_dir,
-    set_alias,
-    set_default_model,
-    set_default_embedding_model,
+    get_plugins,
+    get_template_loaders,
+    get_tools,
     remove_alias,
+    set_alias,
+    set_default_embedding_model,
+    set_default_model,
+    user_dir,
 )
-from llm.models import _BaseConversation, ChainResponse
+from llm.models import ChainResponse, _BaseConversation
 
 from .migrations import migrate
-from .plugins import pm, load_plugins
+from .plugins import load_plugins, pm
 from .utils import (
     ensure_fragment,
     extract_fenced_code_block,
@@ -62,22 +80,6 @@ from .utils import (
     token_usage_string,
     truncate_string,
 )
-import base64
-import httpx
-import inspect
-import pathlib
-import pydantic
-import re
-import readline
-from runpy import run_module
-import shutil
-import sqlite_utils
-from sqlite_utils.utils import rows_from_file, Format
-import sys
-import textwrap
-from typing import cast, Dict, Optional, Iterable, List, Union, Tuple, Type, Any
-import warnings
-import yaml
 
 warnings.simplefilter("ignore", ResourceWarning)
 

--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -1,23 +1,23 @@
-from llm import AsyncKeyModel, EmbeddingModel, KeyModel, hookimpl
-import llm
-from llm.utils import (
-    dicts_to_table_string,
-    remove_dict_none_values,
-    logging_client,
-    simplify_usage_dict,
-)
-import click
 import datetime
+import json
+import os
 from enum import Enum
+from typing import AsyncGenerator, Iterable, Iterator, List, Optional, Union
+
+import click
 import httpx
 import openai
-import os
-
-from pydantic import field_validator, Field
-
-from typing import AsyncGenerator, List, Iterable, Iterator, Optional, Union
-import json
 import yaml
+from pydantic import Field, field_validator
+
+import llm
+from llm import AsyncKeyModel, EmbeddingModel, KeyModel, hookimpl
+from llm.utils import (
+    dicts_to_table_string,
+    logging_client,
+    remove_dict_none_values,
+    simplify_usage_dict,
+)
 
 
 @hookimpl

--- a/llm/embeddings.py
+++ b/llm/embeddings.py
@@ -1,13 +1,15 @@
-from .models import EmbeddingModel
-from .embeddings_migrations import embeddings_migrations
-from dataclasses import dataclass
 import hashlib
-from itertools import islice
 import json
+import time
+from dataclasses import dataclass
+from itertools import islice
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union, cast
+
 from sqlite_utils import Database
 from sqlite_utils.db import Table
-import time
-from typing import cast, Any, Dict, Iterable, List, Optional, Tuple, Union
+
+from .embeddings_migrations import embeddings_migrations
+from .models import EmbeddingModel
 
 
 @dataclass

--- a/llm/embeddings_migrations.py
+++ b/llm/embeddings_migrations.py
@@ -1,6 +1,7 @@
-from sqlite_migrate import Migrations
 import hashlib
 import time
+
+from sqlite_migrate import Migrations
 
 embeddings_migrations = Migrations("llm.embeddings")
 

--- a/llm/hookspecs.py
+++ b/llm/hookspecs.py
@@ -1,5 +1,4 @@
-from pluggy import HookimplMarker
-from pluggy import HookspecMarker
+from pluggy import HookimplMarker, HookspecMarker
 
 hookspec = HookspecMarker("llm")
 hookimpl = HookimplMarker("llm")

--- a/llm/models.py
+++ b/llm/models.py
@@ -1,14 +1,14 @@
 import asyncio
 import base64
-from condense_json import condense_json
-from dataclasses import dataclass, field
 import datetime
-from .errors import NeedsKeyException
 import hashlib
-import httpx
-from itertools import islice
+import inspect
+import json
 import re
 import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from itertools import islice
 from typing import (
     Any,
     AsyncGenerator,
@@ -24,19 +24,21 @@ from typing import (
     Union,
     get_type_hints,
 )
+
+import httpx
+from condense_json import condense_json
+from pydantic import BaseModel, ConfigDict, create_model
+
+from .errors import NeedsKeyException
 from .utils import (
     ensure_fragment,
     ensure_tool,
     make_schema_id,
     mimetype_from_path,
     mimetype_from_string,
-    token_usage_string,
     monotonic_ulid,
+    token_usage_string,
 )
-from abc import ABC, abstractmethod
-import inspect
-import json
-from pydantic import BaseModel, ConfigDict, create_model
 
 CONVERSATION_NAME_LENGTH = 32
 
@@ -622,7 +624,7 @@ class _BaseResponse:
 
     @classmethod
     def from_row(cls, db, row, _async=False):
-        from llm import get_model, get_async_model
+        from llm import get_async_model, get_model
 
         if _async:
             model = get_async_model(row["model"])

--- a/llm/plugins.py
+++ b/llm/plugins.py
@@ -1,8 +1,10 @@
 import importlib
-from importlib import metadata
 import os
-import pluggy
 import sys
+from importlib import metadata
+
+import pluggy
+
 from . import hookspecs
 
 DEFAULT_PLUGINS = (

--- a/llm/templates.py
+++ b/llm/templates.py
@@ -1,6 +1,7 @@
-from pydantic import BaseModel, ConfigDict
 import string
-from typing import Optional, Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
+
+from pydantic import BaseModel, ConfigDict
 
 
 class AttachmentType(BaseModel):

--- a/llm/tools.py
+++ b/llm/tools.py
@@ -1,6 +1,6 @@
+import time
 from datetime import datetime, timezone
 from importlib.metadata import version
-import time
 
 
 def llm_version() -> str:

--- a/llm/utils.py
+++ b/llm/utils.py
@@ -1,21 +1,19 @@
-import click
 import hashlib
-import httpx
 import itertools
 import json
-import pathlib
-import puremagic
-import re
-import sqlite_utils
-import textwrap
-from typing import Any, List, Dict, Optional, Tuple, Type
 import os
+import pathlib
+import re
+import textwrap
 import threading
 import time
-from typing import Final
+from typing import Any, Dict, Final, List, Optional, Tuple, Type
 
+import click
+import httpx
+import puremagic
+import sqlite_utils
 from ulid import ULID
-
 
 MIME_TYPE_FIXES = {
     "audio/wave": "audio/wav",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,3 +73,9 @@ test = [
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+line-length = 160
+
+[tool.ruff.lint]
+extend-select = ["I"]  # Add isort rules to the default set

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,1 +1,0 @@
-line-length = 160

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,14 @@
+import json
+from typing import Optional
+
+import llm_echo
 import pytest
 import sqlite_utils
-import json
-import llm
-import llm_echo
-from llm.plugins import pm
 from pydantic import Field
 from pytest_httpx import IteratorStream
-from typing import Optional
+
+import llm
+from llm.plugins import pm
 
 
 def pytest_configure(config):

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -1,9 +1,11 @@
-from click.testing import CliRunner
-from llm.cli import cli
-import llm
 import json
-import pytest
 import re
+
+import pytest
+from click.testing import CliRunner
+
+import llm
+from llm.cli import cli
 
 
 @pytest.mark.parametrize("model_id_or_alias", ("gpt-3.5-turbo", "chatgpt"))

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,5 +1,6 @@
-import llm
 import pytest
+
+import llm
 
 
 @pytest.mark.asyncio

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -1,8 +1,10 @@
-from click.testing import CliRunner
 from unittest.mock import ANY
+
+import pytest
+from click.testing import CliRunner
+
 import llm
 from llm import cli
-import pytest
 
 TINY_PNG = (
     b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\xa6\x00\x00\x01\x1a"

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,11 +1,13 @@
-from click.testing import CliRunner
-from unittest.mock import ANY
 import json
-import llm.cli
-import pytest
-import sqlite_utils
 import sys
 import textwrap
+from unittest.mock import ANY
+
+import pytest
+import sqlite_utils
+from click.testing import CliRunner
+
+import llm.cli
 
 
 @pytest.mark.xfail(sys.platform == "win32", reason="Expected to fail on Windows")

--- a/tests/test_cli_openai_models.py
+++ b/tests/test_cli_openai_models.py
@@ -1,7 +1,8 @@
-from click.testing import CliRunner
-from llm.cli import cli
 import pytest
 import sqlite_utils
+from click.testing import CliRunner
+
+from llm.cli import cli
 
 
 @pytest.fixture

--- a/tests/test_cli_options.py
+++ b/tests/test_cli_options.py
@@ -1,7 +1,9 @@
-from click.testing import CliRunner
-from llm.cli import cli
-import pytest
 import json
+
+import pytest
+from click.testing import CliRunner
+
+from llm.cli import cli
 
 
 @pytest.mark.parametrize(

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -1,9 +1,11 @@
 import json
-import llm
-from llm.embeddings import Entry
+from unittest.mock import ANY
+
 import pytest
 import sqlite_utils
-from unittest.mock import ANY
+
+import llm
+from llm.embeddings import Entry
 
 
 def test_demo_plugin():

--- a/tests/test_embed_cli.py
+++ b/tests/test_embed_cli.py
@@ -1,12 +1,14 @@
-from click.testing import CliRunner
-from llm.cli import cli
-from llm import Collection
 import json
 import pathlib
-import pytest
-import sqlite_utils
 import sys
 from unittest.mock import ANY
+
+import pytest
+import sqlite_utils
+from click.testing import CliRunner
+
+from llm import Collection
+from llm.cli import cli
 
 
 @pytest.mark.parametrize(

--- a/tests/test_encode_decode.py
+++ b/tests/test_encode_decode.py
@@ -1,6 +1,7 @@
-import llm
-import pytest
 import numpy as np
+import pytest
+
+import llm
 
 
 @pytest.mark.parametrize(

--- a/tests/test_fragments_cli.py
+++ b/tests/test_fragments_cli.py
@@ -1,8 +1,10 @@
-from click.testing import CliRunner
-from llm.cli import cli
-import yaml
-import sqlite_utils
 import textwrap
+
+import sqlite_utils
+import yaml
+from click.testing import CliRunner
+
+from llm.cli import cli
 
 
 def test_fragments_set_show_remove(user_path):

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -1,9 +1,11 @@
-from click.testing import CliRunner
 import json
-from llm.cli import cli
 import pathlib
-import pytest
 import sys
+
+import pytest
+from click.testing import CliRunner
+
+from llm.cli import cli
 
 
 @pytest.mark.xfail(sys.platform == "win32", reason="Expected to fail on Windows")

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,14 +1,16 @@
-from click.testing import CliRunner
-import llm
-from llm.cli import cli
-from llm.models import Usage
 import json
 import os
 import pathlib
-from pydantic import BaseModel
+from unittest import mock
+
 import pytest
 import sqlite_utils
-from unittest import mock
+from click.testing import CliRunner
+from pydantic import BaseModel
+
+import llm
+from llm.cli import cli
+from llm.models import Usage
 
 
 def test_version():

--- a/tests/test_llm_logs.py
+++ b/tests/test_llm_logs.py
@@ -1,20 +1,21 @@
-from click.testing import CliRunner
-from llm.cli import cli
-from llm.migrations import migrate
-from llm.utils import monotonic_ulid
-from llm import Fragment
 import datetime
 import json
 import pathlib
-import pytest
 import re
-import sqlite_utils
 import sys
 import textwrap
 import time
-from ulid import ULID
-import yaml
 
+import pytest
+import sqlite_utils
+import yaml
+from click.testing import CliRunner
+from ulid import ULID
+
+from llm import Fragment
+from llm.cli import cli
+from llm.migrations import migrate
+from llm.utils import monotonic_ulid
 
 SINGLE_ID = "5843577700ba729bb14c327b30441885"
 MULTI_ID = "4860edd987df587d042a9eb2b299ce5c"

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -1,9 +1,9 @@
-import llm
-from llm.migrations import migrate
-from llm.embeddings_migrations import embeddings_migrations
 import pytest
 import sqlite_utils
 
+import llm
+from llm.embeddings_migrations import embeddings_migrations
+from llm.migrations import migrate
 
 EXPECTED = {
     "id": str,

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,12 +1,14 @@
-from click.testing import CliRunner
-import click
 import importlib
 import json
-import llm
-from llm.tools import llm_version, llm_time
-from llm import cli, hookimpl, plugins, get_template_loaders, get_fragment_loaders
 import pathlib
 import textwrap
+
+import click
+from click.testing import CliRunner
+
+import llm
+from llm import cli, get_fragment_loaders, get_template_loaders, hookimpl, plugins
+from llm.tools import llm_time, llm_version
 
 
 def test_register_commands():

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,14 +1,17 @@
 import json
 import os
 import pathlib
+import textwrap
+from importlib.metadata import version
 from unittest import mock
 
 import pytest
 import yaml
 from click.testing import CliRunner
 
-from llm import Template
+from llm import Template, Toolbox, hookimpl, user_dir
 from llm.cli import cli
+from llm.plugins import pm
 
 
 @pytest.mark.parametrize(
@@ -401,3 +404,138 @@ def test_execute_prompt_from_template_path():
             "stream": True,
             "previous": [],
         }
+
+
+FUNCTIONS_EXAMPLE = """
+def greet(name: str) -> str:
+    return f"Hello, {name}!"
+"""
+
+
+class Greeting(Toolbox):
+    def __init__(self, greeting: str):
+        self.greeting = greeting
+
+    def greet(self, name: str) -> str:
+        "Greet name with a greeting"
+        return f"{self.greeting}, {name}!"
+
+
+class GreetingsPlugin:
+    __name__ = "GreetingsPlugin"
+
+    @hookimpl
+    def register_tools(self, register):
+        register(Greeting)
+
+
+@pytest.mark.parametrize(
+    "source,expected_tool_success,expected_functions_success",
+    (
+        ("alias", True, True),
+        ("file", True, True),
+        # Loaded from URL or plugin = functions: should not work
+        ("url", True, False),
+        ("plugin", True, False),
+    ),
+)
+def test_tools_in_templates(
+    source, expected_tool_success, expected_functions_success, httpx_mock, tmpdir
+):
+    template_yaml = textwrap.dedent(
+        """
+    name: test
+    tools:
+    - llm_version
+    - Greeting("hi")
+    functions: |
+      def demo():
+          return "Demo"
+    """
+    )
+    args = []
+
+    def before():
+        pass
+
+    def after():
+        pass
+
+    if source == "alias":
+        args = ["-t", "test"]
+        (user_dir() / "templates").mkdir(parents=True, exist_ok=True)
+        (user_dir() / "templates" / "test.yaml").write_text(template_yaml, "utf-8")
+    elif source == "file":
+        (tmpdir / "test.yaml").write_text(template_yaml, "utf-8")
+        args = ["-t", str(tmpdir / "test.yaml")]
+    elif source == "url":
+        httpx_mock.add_response(
+            url="https://example.com/test.yaml",
+            method="GET",
+            text=template_yaml,
+            status_code=200,
+            is_reusable=True,
+        )
+        args = ["-t", "https://example.com/test.yaml"]
+    elif source == "plugin":
+
+        class LoadTemplatePlugin:
+            __name__ = "LoadTemplatePlugin"
+
+            @hookimpl
+            def register_template_loaders(self, register):
+                register(
+                    "tool-template",
+                    lambda s: Template(
+                        name="tool-template",
+                        tools=["llm_version", 'Greeting("hi")'],
+                        functions=FUNCTIONS_EXAMPLE,
+                    ),
+                )
+
+        def before():
+            pm.register(LoadTemplatePlugin(), name="test-tools-in-templates")
+
+        def after():
+            pm.unregister(name="test-tools-in-templates")
+
+        args = ["-t", "tool-template:"]
+
+    before()
+    pm.register(GreetingsPlugin(), name="greetings-plugin")
+    try:
+        runner = CliRunner()
+        # Test llm_version, then Greeting, then demo
+        for tool_call, text, should_be_present in (
+            ({"name": "llm_version"}, version("llm"), True),
+            (
+                {"name": "Greeting_greet", "arguments": {"name": "Alice"}},
+                "hi, Alice",
+                expected_tool_success,
+            ),
+            (
+                {"name": "Greeting_greet", "arguments": {"name": "Bob"}},
+                "hi, Bob!",
+                expected_tool_success,
+            ),
+            ({"name": "demo"}, '"output": "Demo"', expected_functions_success),
+        ):
+            result = runner.invoke(
+                cli,
+                args
+                + [
+                    "-m",
+                    "echo",
+                    "--no-stream",
+                    json.dumps({"tool_calls": [tool_call]}),
+                ],
+                catch_exceptions=False,
+            )
+            assert result.exit_code == 0
+            if should_be_present:
+                assert text in result.output
+            else:
+                assert text not in result.output
+    finally:
+        after()
+        pm.unregister(name="greetings-plugin")

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,12 +1,14 @@
-from click.testing import CliRunner
 import json
-from llm import Template
-from llm.cli import cli
 import os
-from unittest import mock
 import pathlib
+from unittest import mock
+
 import pytest
 import yaml
+from click.testing import CliRunner
+
+from llm import Template
+from llm.cli import cli
 
 
 @pytest.mark.parametrize(

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,16 +1,17 @@
 import asyncio
-from click.testing import CliRunner
-from importlib.metadata import version
 import json
+import os
+import time
+from importlib.metadata import version
+
+import pytest
+import sqlite_utils
+from click.testing import CliRunner
+
 import llm
 from llm import cli
 from llm.migrations import migrate
 from llm.tools import llm_time
-import os
-import pytest
-import sqlite_utils
-import time
-
 
 API_KEY = os.environ.get("PYTEST_OPENAI_API_KEY", None) or "badkey"
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,15 +1,17 @@
 import json
+
 import pytest
+
+from llm import Toolbox, get_key
 from llm.utils import (
     extract_fenced_code_block,
     instantiate_from_spec,
     maybe_fenced_code,
+    monotonic_ulid,
     schema_dsl,
     simplify_usage_dict,
     truncate_string,
-    monotonic_ulid,
 )
-from llm import get_key, Toolbox
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This makes the import statements more readable by organizing them into groups, and merges the few configuration options from `ruff.toml` into `pyproject.toml`.

One could also merge `mypy.ini` and `pytest.ini` into `pyproject.toml` at least as long as they contain only so few lines of configuration.