### PR TITLE
WIP: dynamic toolboxes

### DIFF
--- a/llm/__init__.py
+++ b/llm/__init__.py
@@ -21,6 +21,7 @@ from .models import (
     Response,
     Tool,
     Toolbox,
+    BaseToolbox,
     ToolCall,
     ToolResult,
 )
@@ -59,6 +60,7 @@ __all__ = [
     "Template",
     "Tool",
     "Toolbox",
+    "BaseToolbox",
     "ToolCall",
     "ToolResult",
     "user_dir",
@@ -139,22 +141,22 @@ def get_fragment_loaders() -> Dict[
     return _get_loaders(pm.hook.register_fragment_loaders)
 
 
-def get_tools() -> Dict[str, Union[Tool, Type[Toolbox]]]:
+def get_tools() -> Dict[str, Union[Tool, Type[BaseToolbox]]]:
     """Return all tools (llm.Tool and llm.Toolbox) registered by plugins."""
     load_plugins()
-    tools: Dict[str, Union[Tool, Type[Toolbox]]] = {}
+    tools: Dict[str, Union[Tool, Type[BaseToolbox]]] = {}
 
     # Variable to track current plugin name
     current_plugin_name = None
 
     def register(
-        tool_or_function: Union[Tool, Type[Toolbox], Callable[..., Any]],
+        tool_or_function: Union[Tool, Type[BaseToolbox], Callable[..., Any]],
         name: Optional[str] = None,
     ) -> None:
-        tool: Union[Tool, Type[Toolbox], None] = None
+        tool: Union[Tool, Type[BaseToolbox], None] = None
 
         # If it's a Toolbox class, set the plugin field on it
-        if inspect.isclass(tool_or_function) and issubclass(tool_or_function, Toolbox):
+        if inspect.isclass(tool_or_function) and issubclass(tool_or_function, BaseToolbox):
             tool = tool_or_function
             if current_plugin_name:
                 tool.plugin = current_plugin_name
@@ -177,7 +179,7 @@ def get_tools() -> Dict[str, Union[Tool, Type[Toolbox]]]:
         # Get the name for the tool/toolbox
         if tool:
             # For Toolbox classes, use their name attribute or class name
-            if inspect.isclass(tool) and issubclass(tool, Toolbox):
+            if inspect.isclass(tool) and issubclass(tool, BaseToolbox):
                 prefix = name or getattr(tool, "name", tool.__name__) or ""
             else:
                 prefix = name or tool.name or ""

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -2603,11 +2603,11 @@ def tools_list(json_, python_tools):
         for base_toolbox in base_toolbox_objects:
             click.echo(base_toolbox.name + ":\n")
             for tool in base_toolbox.method_tools():
-                click.echo(tool.name + ":\n")
+                click.echo(tool.name)
+                click.echo(f" (plugin: {tool.plugin})" if tool.plugin else "")
                 if tool.description:
-                    click.echo(textwrap.indent(tool.description.strip(), "  ") + "\n")
-                if tool.plugin:
-                    click.echo(f"  plugin: {tool.plugin}\n")
+                    click.echo(":\n")
+                    click.echo(textwrap.indent(tool.description.strip(), "    ") + "\n")
 
 
 @cli.group(

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -2542,7 +2542,6 @@ def tools_list(json_, python_tools):
                 }
             )
         elif issubclass(tool, BaseToolbox):
-            toolbox_objects.append(tool)
             output_toolboxes.append(
                 {
                     "name": name,

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -2542,15 +2542,18 @@ def tools_list(json_, python_tools):
                 }
             )
         elif issubclass(tool, BaseToolbox):
+            instance = tool()
             output_toolboxes.append(
                 {
                     "name": name,
                     "tools": [
                         {
-                            "name": "runtime",
-                            "description": "runtime",
-                            "arguments": "runtime"
-                        }
+                            "name": one_tool.name,
+                            "description": one_tool.description,
+                            "arguments": one_tool.input_schema,
+                            "plugin": one_tool.plugin
+                        } 
+                        for one_tool in instance.method_tools()
                     ],
                 }
             )

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -18,6 +18,7 @@ from llm import (
     Template,
     Tool,
     Toolbox,
+    BaseToolbox,
     UnknownModelError,
     KeyModel,
     encode,
@@ -2500,7 +2501,7 @@ def tools():
 )
 def tools_list(json_, python_tools):
     "List available tools that have been provided by plugins"
-    tools: Dict[str, Union[Tool, Type[Toolbox]]] = get_tools()
+    tools: Dict[str, Union[Tool, Type[BaseToolbox]]] = get_tools()
     if python_tools:
         for code_or_path in python_tools:
             for tool in _tools_from_code(code_or_path):
@@ -3900,8 +3901,8 @@ def _approve_tool_call(_, tool_call):
 
 def _gather_tools(
     tool_specs: List[str], python_tools: List[str]
-) -> List[Union[Tool, Type[Toolbox]]]:
-    tools: List[Union[Tool, Type[Toolbox]]] = []
+) -> List[Union[Tool, Type[BaseToolbox]]]:
+    tools: List[Union[Tool, Type[BaseToolbox]]] = []
     if python_tools:
         for code_or_path in python_tools:
             tools.extend(_tools_from_code(code_or_path))

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -2605,7 +2605,7 @@ def tools_list(json_, python_tools):
             for tool in base_toolbox.method_tools():
                 click.echo("{}{}\n".format(tool.name, " (plugin: {})".format(tool.plugin) if tool.plugin else ""))
                 if tool.description:
-                    click.echo(textwrap.indent(tool.description.strip(), "  "))
+                    click.echo(textwrap.indent(tool.description.strip(), "  ") + "\n")
 
 
 @cli.group(

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -2481,6 +2481,10 @@ def schemas_dsl_debug(input, multi):
     schema = schema_dsl(input, multi)
     click.echo(json.dumps(schema, indent=2))
 
+def describe_type(obj: object) -> str:
+    if isinstance(obj, type):
+        return f"{obj.__module__}.{obj.__qualname__} (class)"
+    return f"{type(obj).__module__}.{type(obj).__qualname__} (instance)"
 
 @cli.group(
     cls=DefaultGroup,
@@ -2522,7 +2526,7 @@ def tools_list(json_, python_tools):
                     "plugin": tool.plugin,
                 }
             )
-        else:
+        elif issubclass(tool, Toolbox):
             toolbox_objects.append(tool)
             output_toolboxes.append(
                 {
@@ -2537,6 +2541,22 @@ def tools_list(json_, python_tools):
                     ],
                 }
             )
+        elif issubclass(tool, BaseToolbox):
+            toolbox_objects.append(tool)
+            output_toolboxes.append(
+                {
+                    "name": name,
+                    "tools": [
+                        {
+                            "name": "runtime",
+                            "description": "runtime",
+                            "arguments": "runtime"
+                        }
+                    ],
+                }
+            )
+        else:
+            print("WTFWTFWWTF")
     if json_:
         click.echo(
             json.dumps(

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -2603,11 +2603,9 @@ def tools_list(json_, python_tools):
         for base_toolbox in base_toolbox_objects:
             click.echo(base_toolbox.name + ":\n")
             for tool in base_toolbox.method_tools():
-                click.echo(tool.name)
-                click.echo(f" (plugin: {tool.plugin})" if tool.plugin else "")
+                click.echo("{}{}\n".format(tool.name, " (plugin: {})".format(tool.plugin) if tool.plugin else ""))
                 if tool.description:
-                    click.echo(":\n")
-                    click.echo(textwrap.indent(tool.description.strip(), "    ") + "\n")
+                    click.echo(textwrap.indent(tool.description.strip(), "  "))
 
 
 @cli.group(

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -2515,6 +2515,7 @@ def tools_list(json_, python_tools):
     output_toolboxes = []
     tool_objects = []
     toolbox_objects = []
+    base_toolbox_objects = []
     for name, tool in sorted(tools.items()):
         if isinstance(tool, Tool):
             tool_objects.append(tool)
@@ -2543,6 +2544,7 @@ def tools_list(json_, python_tools):
             )
         elif issubclass(tool, BaseToolbox):
             instance = tool()
+            base_toolbox_objects.append(instance)
             output_toolboxes.append(
                 {
                     "name": name,
@@ -2598,6 +2600,14 @@ def tools_list(json_, python_tools):
                     click.echo(
                         textwrap.indent(method["description"].strip(), "    ") + "\n"
                     )
+        for base_toolbox in base_toolbox_objects:
+            click.echo(base_toolbox.name + ":\n")
+            for tool in base_toolbox.method_tools():
+                click.echo(tool.name + ":\n")
+                if tool.description:
+                    click.echo(textwrap.indent(tool.description.strip(), "  ") + "\n")
+                if tool.plugin:
+                    click.echo(f"  plugin: {tool.plugin}\n")
 
 
 @cli.group(

--- a/llm/models.py
+++ b/llm/models.py
@@ -176,7 +176,6 @@ def _get_arguments_input_schema(function, name):
 class BaseToolbox:
     name: Optional[str] = None
     instance_id: Optional[int] = None
-
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -191,6 +191,25 @@ async def test_async_toolbox():
     output = await chain_response.text()
     assert '"output": "This was async"' in output
 
+@pytest.mark.asyncio
+async def test_async_dynamic_toolbox():
+    class Tools(llm.BaseToolbox):
+        def __init__(self, name: str):
+            self.name = name
+
+        def _return_name(self):
+            return self.name
+
+        def method_tools(self):
+            yield llm.Tool(name="return_name", description="This is a test tool with name {name}", implementation=self._return_name)
+
+    model = llm.get_async_model("echo")
+    chain_response = model.chain(
+        json.dumps({"tool_calls": [{"name": "return_name"}]}),
+        tools=[Tools("this_is_name")],
+    )
+    output = await chain_response.text()
+    assert '"output": "this_is_name"' in output
 
 @pytest.mark.vcr
 def test_conversation_with_tools(vcr):


### PR DESCRIPTION
Work in progress! 

Related issue: #1111 

How to use from plugins? See example here: [llm_tools_mcp.py#L157-L176](https://github.com/VirtusLab/llm-tools-mcp/blob/b4f7bb3319f16628634f09af123a3970bf6d7de4/llm_tools_mcp.py#L157-L176).

## Testing (manually)

How to test together with https://github.com/Virtuslab/llm-tools-mcp (for now):

1. Add some MCP servers (stdio preferred) in `~.llm-tools-mcp/mcp.json`.
  Example: 
    ```json
    {
      "mcpServers": {
        "filesystem": {
          "command": "npx",
          "args": [
            "-y",
            "@modelcontextprotocol/server-filesystem",
            "~/demo"
          ]
        }
      }
    }
   ```
   Make sure to create `~/demo` directory with some files before testing
2. Install `llm` from the fork (`base-toolbox-issue-1111` branch).
   `uv tool install git+https://github.com/myhau/llm@base-toolbox-issue-1111` 
3. Install `llm-tools-mcp` plugin from `dynamic-toolbox` branch.
   `llm install git+https://github.com/VirtusLab/llm-tools-mcp@dynamic-toolbox`
4. Run `llm tools` to see tools (together with the ones from dynamic toolboxes).

   Example output on my machine:
    ```console
    λ llm tools | head -n 18
    
    llm_time() -> dict (plugin: llm.default_plugins.default_tools)
    
      Returns the current time, as local time and UTC
    
    llm_version() -> str (plugin: llm.default_plugins.default_tools)
    
      Return the installed version of llm
    
    MCP:
    
    read_file (plugin: llm-tools-mcp)
    
      Read the complete contents of a file from the file system. Handles various text encodings and provides detailed error messages if the file cannot be read. Use this tool when you need to examine the contents of a single file. Only works within allowed directories.
    
    read_multiple_files (plugin: llm-tools-mcp)
    
      Read the contents of multiple files simultaneously. This is more efficient than reading files one by one when you need to analyze or compare multiple files. Each file's content is returned with its path as a reference. Failed reads for individual files won't stop the entire operation. Only works within allowed directories.
    
    ```

5. Run `llm -T MCP "{prompt}"` to test tool calls for the `MCP` toolbox (defined in `llm-tools-mcp` plugin).

    Example outputs on my machine:
    
    ```console
    λ llm -T 'MCP' 'what tools are you able to call?'
    
    I have access to various tools that allow me to perform a range of actions, including:
    
    1. **File Operations**: Read, write, edit, move files, and create directories.
    2. **Directory Management**: List directories and get a tree view of directory structures.
    3. **File Search**: Search for files matching specific patterns.
    4. **File Information**: Retrieve detailed metadata about files or directories.
    5. **Memory Management**: Add, search, list, and delete memories based on our conversations.
    
    If you have a specific task in mind, feel free to ask!
    ```
  
    ```console
    λ llm --td -T 'MCP' 'list files in ~/demo dir'
    
    Tool call: list_directory({'path': '~/demo'})
      [
        "TextContent(type='text', text='[FILE] other-file\\n[FILE] test-file', annotations=None)"
      ]
    
    In the `~/demo` directory, there are the following files:
    
    - other-file
    - test-file
    ```