### PR TITLE
Do not concat the tool function argument twice when parsing the tool call from the OpenAI API

### DIFF
--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -693,9 +693,10 @@ class Chat(_Shared, KeyModel):
                         index = tool_call.index
                         if index not in tool_calls:
                             tool_calls[index] = tool_call
-                        tool_calls[
-                            index
-                        ].function.arguments += tool_call.function.arguments
+                        else:
+                            tool_calls[
+                                index
+                            ].function.arguments += tool_call.function.arguments
                 try:
                     content = chunk.choices[0].delta.content
                 except IndexError:


### PR DESCRIPTION
The function arguments were being duplicated:
'{"x": 3, "y": 2}{"x": 3, "y": 2}'

causing "Error: Extra data: line 1 column 17 (char 16)"