### PR TITLE
Update docs grammar

### DIFF
--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -62,7 +62,7 @@ response = model.prompt(
 
 ### Attachments
 
-Model that accept multi-modal input (images, audio, video etc) can be passed attachments using the `attachments=` keyword argument. This accepts a list of `llm.Attachment()` instances.
+Models that accept multi-modal input (images, audio, video etc) can be passed attachments using the `attachments=` keyword argument. This accepts a list of `llm.Attachment()` instances.
 
 This example shows two attachments - one from a file path and one from a URL:
 ```python


### PR DESCRIPTION
## Summary
- fix grammar for attachments section in python-api docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlite_utils')*


------
https://chatgpt.com/codex/tasks/task_e_683f7a62564c8326999064783bbd0dba