### PR TITLE
Fix docs commands in AGENTS guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# Repository maintenance notes
+
+This project uses a Python virtual environment for development and tests.
+
+## Setting up a development environment
+
+1. Create and activate a virtual environment:
+
+   ```bash
+   python -m venv venv
+   source venv/bin/activate
+   ```
+2. Install the project with its test dependencies:
+   ```bash
+   pip install -e '.[test]'
+   ```
+3. Run the tests:
+   ```bash
+   pytest
+   ```
+
+## Building the documentation
+
+Run the following commands if you want to build the docs locally:
+
+```bash
+cd docs
+pip install -r requirements.txt
+make html
+```


### PR DESCRIPTION
## Summary
- remove pipenv instructions from AGENTS.md
- use `make html` instead of `make livehtml`

## Testing
- `pip install -e '.[test]'` *(fails: Could not find setuptools due to network issues)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlite_utils')*
- `pip install -r docs/requirements.txt` *(fails: could not find Sphinx)*
- `make html` *(fails: sphinx-build not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f7b71fa0483268d8c059db0208618