### PR TITLE
add llm-tools-kiwix

### DIFF
--- a/docs/plugins/directory.md
+++ b/docs/plugins/directory.md
@@ -52,6 +52,8 @@ The following plugins add new {ref}`tools <tools>` that can be used by models:
 - **[llm-tools-datasette](https://github.com/simonw/llm-tools-datasette)** can run SQL queries against a remote [Datasette](https://datasette.io/) instance.
 - **[llm-tools-exa](https://github.com/daturkel/llm-tools-exa)** by Dan Turkel can perform web searches and question-answering using [exa.ai](https://exa.ai/).
 - **[llm-tools-rag](https://github.com/daturkel/llm-tools-rag)** by Dan Turkel can perform searches over your LLM embedding collections for simple RAG.
+- **[llm-tools-rag](https://github.com/daturkel/llm-tools-rag)** by Dan Turkel can perform searches over your LLM embedding collections for simple RAG.
+- **[llm-tools-kiwix](https://github.com/mozanunal/llm-tools-kiwix)** enables LLMs to search and access articles from offline Wikipedia, Stack Exchange, DevDocs, and other Kiwix ZIM archives found locally, making vast resources available without internet access.
 
 ## Fragments and template loaders
 

--- a/docs/plugins/directory.md
+++ b/docs/plugins/directory.md
@@ -52,7 +52,6 @@ The following plugins add new {ref}`tools <tools>` that can be used by models:
 - **[llm-tools-datasette](https://github.com/simonw/llm-tools-datasette)** can run SQL queries against a remote [Datasette](https://datasette.io/) instance.
 - **[llm-tools-exa](https://github.com/daturkel/llm-tools-exa)** by Dan Turkel can perform web searches and question-answering using [exa.ai](https://exa.ai/).
 - **[llm-tools-rag](https://github.com/daturkel/llm-tools-rag)** by Dan Turkel can perform searches over your LLM embedding collections for simple RAG.
-- **[llm-tools-rag](https://github.com/daturkel/llm-tools-rag)** by Dan Turkel can perform searches over your LLM embedding collections for simple RAG.
 - **[llm-tools-kiwix](https://github.com/mozanunal/llm-tools-kiwix)** enables LLMs to search and access articles from offline Wikipedia, Stack Exchange, DevDocs, and other Kiwix ZIM archives found locally, making vast resources available without internet access.
 
 ## Fragments and template loaders


### PR DESCRIPTION
Hi there,

I’m excited to contribute **llm-tools-kiwix**, which lets LLMs access offline Wikipedia, DevDocs, Stack Exchange, and other resources through Kiwix ZIM archives. This should make tons of knowledge available for LLMs completely offline!

I’m a big fan of Simon’s work and the LLM ecosystem, I’m definitely open to any feedback, suggestions, or improvements you might have.

Thanks for your time and consideration!