### PR TITLE
Handle Open WebUI's special flavor of missing fields in API response

### DIFF
--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -697,7 +697,8 @@ class Chat(_Shared, KeyModel):
                             index
                         ].function.arguments += tool_call.function.arguments
                 try:
-                    content = chunk.choices[0].delta.content
+                    delta = chunk.choices[0].delta
+                    content = None if delta is None else delta.content
                 except IndexError:
                     content = None
                 if content is not None:
@@ -905,8 +906,8 @@ def combine_chunks(chunks: List) -> dict:
                     }
                 )
 
-            if not hasattr(choice, "delta"):
-                content += choice.text
+            if getattr(choice, "delta", None) is None:
+                content += getattr(choice, "text", "")
                 continue
             role = choice.delta.role
             if choice.delta.content is not None:


### PR DESCRIPTION
The last chunk in an Open WebUI 0.3.32 response does not have a "delta" field in its "choices" array.
It also has no "text" field.

This PR handles those missing fields so `llm` works with Open WebUI 0.3.32 flavor of the OpenAI API (not idea if later versions behave better).