### PR TITLE
Handle None in tool/function arguments.

### DIFF
--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -690,6 +690,8 @@ class Chat(_Shared, KeyModel):
                     usage = chunk.usage.model_dump()
                 if chunk.choices and chunk.choices[0].delta:
                     for tool_call in chunk.choices[0].delta.tool_calls or []:
+                        if tool_call.function.arguments is None:
+                            tool_call.function.arguments = ""
                         index = tool_call.index
                         if index not in tool_calls:
                             tool_calls[index] = tool_call
@@ -711,7 +713,7 @@ class Chat(_Shared, KeyModel):
                         llm.ToolCall(
                             tool_call_id=value.id,
                             name=value.function.name,
-                            arguments=json.loads(value.function.arguments),
+                            arguments=json.loads(value.function.arguments or "{}"),
                         )
                     )
         else:
@@ -774,6 +776,8 @@ class AsyncChat(_Shared, AsyncKeyModel):
                     usage = chunk.usage.model_dump()
                 if chunk.choices and chunk.choices[0].delta:
                     for tool_call in chunk.choices[0].delta.tool_calls or []:
+                        if tool_call.function.arguments is None:
+                            tool_call.function.arguments = ""
                         index = tool_call.index
                         if index not in tool_calls:
                             tool_calls[index] = tool_call
@@ -794,7 +798,7 @@ class AsyncChat(_Shared, AsyncKeyModel):
                         llm.ToolCall(
                             tool_call_id=value.id,
                             name=value.function.name,
-                            arguments=json.loads(value.function.arguments),
+                            arguments=json.loads(value.function.arguments or "{}"),
                         )
                     )
             response.response_json = remove_dict_none_values(combine_chunks(chunks))


### PR DESCRIPTION
The normal OpenAI API returns an empty string when there are no function arguments. The GitHub Copilot wrapper around the OpenAI API seems to return None instead of an empty string when there are no arguments.

Treat None as an empty string. If we still have an empty string at the point that we parse the JSON for the arguments, then use "{}" instead so that we get the expected empty map.