### PR TITLE
remove setuptools and pip from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,6 @@ dependencies = [
     "PyYAML",
     "pluggy",
     "python-ulid",
-    "setuptools",
-    "pip",
     "pyreadline3; sys_platform == 'win32'",
     "puremagic",
 ]


### PR DESCRIPTION
those are not needed at runtime, only when building the package