### PR TITLE
doc(plugin): adding volcengine's doubao and deepseek models

### DIFF
--- a/docs/plugins/directory.md
+++ b/docs/plugins/directory.md
@@ -39,6 +39,7 @@ These plugins can be used to interact with remotely hosted models via their API:
 - **[llm-deepseek](https://github.com/abrasumente233/llm-deepseek)** adds support for the [DeepSeek](https://deepseek.com)'s DeepSeek-Chat and DeepSeek-Coder models.
 - **[llm-lambda-labs](https://github.com/simonw/llm-lambda-labs)** provides access to models hosted by [Lambda Labs](https://docs.lambdalabs.com/public-cloud/lambda-chat-api/), including the Nous Hermes 3 series.
 - **[llm-venice](https://github.com/ar-jan/llm-venice)** provides access to uncensored models hosted by privacy-focused [Venice AI](https://docs.venice.ai/), including Llama 3.1 405B.
+- **[llm-ark](https://github.com/TRSWNCA/llm-ark)** provides access to the [ByteDance Volcengine](https://www.volcengine.com/)'s Doubao and Deepseek models.
 
 If an API model host provides an OpenAI-compatible API you can also [configure LLM to talk to it](https://llm.datasette.io/en/stable/other-models.html#openai-compatible-models) without needing an extra plugin.
 


### PR DESCRIPTION
Add support for [ByteDance Volcengine](https://www.volcengine.com/)'s Doubao and Deepseek models