### PR TITLE
fix: make attachment content loading properly asyncio-friendly #1143

### DIFF
--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -1,6 +1,7 @@
 from llm import AsyncKeyModel, EmbeddingModel, KeyModel, hookimpl
 import llm
 from llm.utils import (
+    asyncify,
     dicts_to_table_string,
     remove_dict_none_values,
     logging_client,
@@ -753,7 +754,7 @@ class AsyncChat(_Shared, AsyncKeyModel):
     ) -> AsyncGenerator[str, None]:
         if prompt.system and not self.allows_system_prompt:
             raise NotImplementedError("Model does not support system prompts")
-        messages = self.build_messages(prompt, conversation)
+        messages = await asyncify(self.build_messages, prompt, conversation)
         kwargs = self.build_kwargs(prompt, stream)
         client = self.get_client(key, async_=True)
         usage = None

--- a/llm/utils.py
+++ b/llm/utils.py
@@ -13,6 +13,7 @@ import os
 import threading
 import time
 from typing import Final
+import asyncio
 
 from ulid import ULID
 
@@ -734,3 +735,7 @@ def _fresh(ms: int) -> bytes:
     timestamp = int.to_bytes(ms, TIMESTAMP_LEN, "big")
     randomness = os.urandom(RANDOMNESS_LEN)
     return timestamp + randomness
+
+
+async def asyncify(func, *args, **kwargs):
+    return await asyncio.to_thread(func, *args, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ test = [
     "types-PyYAML",
     "types-setuptools",
     "llm-echo==0.3a3",
+    "pyleak>=0.1.13",
 ]
 
 [build-system]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -484,3 +484,10 @@ def extract_braces(s):
     if first != -1 and last != -1 and first < last:
         return s[first : last + 1]
     return None
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", 
+        "no_leaks: detect asyncio task leaks, thread leaks, and event loop blocking"
+    )
+    


### PR DESCRIPTION
## A proposal to fix https://github.com/simonw/llm/issues/1143

Since all invocations in `llm.Attachment` are doing IO using `httpx` non-async primitives, we can `asyncify` `build_messages` by executing it in a different thread using `asyncio.to_thread`. 

The same can be verified using the following code (event loop block detected with [pyleak](https://github.com/deepankarm/pyleak)). 

```python
import os
import asyncio

from llm.default_plugins.openai_models import AsyncChat
from llm.models import Attachment
from pyleak import no_event_loop_blocking

async def main():
    model = AsyncChat(
        model_id="gpt-4.1-2025-04-14",
        api_base="https://api.openai.com/v1",
        key=os.getenv("OPENAI_API_KEY"),
    )
    conversation = model.conversation()
    async with no_event_loop_blocking(action="raise"):
        await conversation.prompt(
            prompt="What is this image?",
            attachments=[
                Attachment(
                    url="https://upload.wikimedia.org/wikipedia/commons/thumb/7/74/A-Cat.jpg/1200px-A-Cat.jpg?20101227100718",
                ),
            ],
        )
    print(conversation.responses)

if __name__ == "__main__":
    asyncio.run(main())
```


### Before 

with `messages = self.build_messages(prompt, conversation)`

```
pyleak.eventloop.EventLoopBlockError: Detected 1 event loop blocks

Event Loop Block: block-1
  Duration: 0.305s (threshold: 0.100s)
  Timestamp: 1751442718.988
  Blocking Stack:
    File "/.../deepankarm/dummy/llm-run-1.py", line 30, in <module>
        asyncio.run(main())
      File "/opt/homebrew/anaconda3/envs/ffa/lib/python3.12/asyncio/runners.py", line 194, in run
        return runner.run(main)
      File "/opt/homebrew/anaconda3/envs/ffa/lib/python3.12/asyncio/runners.py", line 118, in run
        return self._loop.run_until_complete(task)
      File "/opt/homebrew/anaconda3/envs/ffa/lib/python3.12/asyncio/base_events.py", line 671, in run_until_complete
        self.run_forever()
      File "/opt/homebrew/anaconda3/envs/ffa/lib/python3.12/asyncio/base_events.py", line 638, in run_forever
        self._run_once()
      File "/opt/homebrew/anaconda3/envs/ffa/lib/python3.12/asyncio/base_events.py", line 1971, in _run_once
        handle._run()
      File "/opt/homebrew/anaconda3/envs/ffa/lib/python3.12/asyncio/events.py", line 84, in _run
        self._context.run(self._callback, *self._args)
      File "/.../deepankarm/dummy/llm-1.py", line 17, in main
        await conversation.prompt(
      File "/.../deepankarm/llm/llm/models.py", line 1382, in _force
        async for chunk in self:
      File "/.../deepankarm/llm/llm/models.py", line 1365, in __anext__
        chunk = await self._generator.__anext__()
      File "/.../deepankarm/llm/llm/default_plugins/openai_models.py", line 758, in execute
        messages = self.build_messages(prompt, conversation)
      File "/.../deepankarm/llm/llm/default_plugins/openai_models.py", line 593, in build_messages
        attachment_message.append(_attachment(attachment))
      File "/.../deepankarm/llm/llm/default_plugins/openai_models.py", line 437, in _attachment
        if attachment.resolve_type() == "application/pdf":
      File "/.../deepankarm/llm/llm/models.py", line 79, in resolve_type
        response = httpx.head(self.url)
      File "/opt/homebrew/anaconda3/envs/ffa/lib/python3.12/site-packages/httpx/_api.py", line 267, in head
        return request(
      File "/opt/homebrew/anaconda3/envs/ffa/lib/python3.12/site-packages/httpx/_api.py", line 102, in request
        with Client(
      File "/opt/homebrew/anaconda3/envs/ffa/lib/python3.12/site-packages/httpx/_client.py", line 688, in __init__
        self._transport = self._init_transport(
      File "/opt/homebrew/anaconda3/envs/ffa/lib/python3.12/site-packages/httpx/_client.py", line 731, in _init_transport
        return HTTPTransport(
      File "/opt/homebrew/anaconda3/envs/ffa/lib/python3.12/site-packages/httpx/_transports/default.py", line 153, in __init__
        ssl_context = create_ssl_context(verify=verify, cert=cert, trust_env=trust_env)
      File "/opt/homebrew/anaconda3/envs/ffa/lib/python3.12/site-packages/httpx/_config.py", line 40, in create_ssl_context
        ctx = ssl.create_default_context(cafile=certifi.where())
      File "/opt/homebrew/anaconda3/envs/ffa/lib/python3.12/ssl.py", line 708, in create_default_context
        context.load_verify_locations(cafile, capath, cadata)
```


### After 

with `messages = await asyncify(self.build_messages, prompt, conversation)`

```
[<AsyncResponse prompt='What is this image?' text='This image shows a close-up of a tabby cat. The cat has greenish-yellow eyes, a pink nose, and a coat with distinctive stripes and markings typical of a tabby pattern. The background appears to be outdoors, possibly on a tiled surface with some dry grass or plants.'>]
```

I've also added a unit test that detects event loop blocking using `pytest.mark.pyleak` with mocked a `httpx.head` response. 

> Disclaimer: I'm the author of pyleak. 
