### PR TITLE
Add llm-fragments-youtube-transcript to plugin directory

### DIFF
--- a/docs/plugins/directory.md
+++ b/docs/plugins/directory.md
@@ -66,6 +66,7 @@ The following plugins add new {ref}`tools <tools>` that can be used by models:
 - **[llm-fragments-pdf](https://github.com/daturkel/llm-fragments-pdf)** by Dan Turkel converts PDFs to markdown with [PyMuPDF4LLM](https://pymupdf.readthedocs.io/en/latest/pymupdf4llm/index.html) to use as fragments: `llm -f pdf:something.pdf "what's this about?"`.
 - **[llm-fragments-site-text](https://github.com/daturkel/llm-fragments-site-text)** by Dan Turkel converts websites to markdown with [Trafilatura](https://trafilatura.readthedocs.io/en/latest/) to use as fragments: `llm -f site:https://example.com "summarize this"`.
 - **[llm-fragments-reader](https://github.com/simonw/llm-fragments-reader)** runs a URL theough the Jina Reader API: `llm -f 'reader:https://simonwillison.net/tags/jina/' summary`.
+- **[llm-fragments-youtube-transcript](https://github.com/jackbow/llm-fragments-youtube-transcript)** fetches a youtube transcript as a fragment: `llm -f 'yt:https://youtube.com/watch?v=id' "summarize this video"`.
 
 ## Embedding models
 


### PR DESCRIPTION
This plugin loads youtube transcripts as fragments. It also includes the uploader, date, title and description in the fragment, of the format:

```
Video Information:
Title: ...
Uploader: ...
Date: ...
Description: ...
Transcription: ...
```
Example usage: `llm -f 'yt:https://youtube.com/watch?v=id' "summarize this video"`