### PR TITLE
fix: custom model options in `Conversation.chain()`

### DIFF
--- a/llm/models.py
+++ b/llm/models.py
@@ -436,7 +436,7 @@ class Conversation(_BaseConversation):
         before_call: Optional[BeforeCallSync] = None,
         after_call: Optional[AfterCallSync] = None,
         key: Optional[str] = None,
-        options: Optional[dict] = None,
+        **options,
     ) -> "ChainResponse":
         self.model._validate_attachments(attachments)
         return ChainResponse(


### PR DESCRIPTION
Normally, `llm prompt ...` calls use `Model.prompt()`, which takes model options as `Model.prompt(..., **options)`. However, `llm prompt ...` calls with tools (or other configurations that require a conversation) use `Conversation.chain()`, which takes model options as `Conversation.chain(..., options: Optional[dict] = None)`. This causes those calls to fail with invalid options when custom model options are provided.

An easy way to trigger this error is via a custom `provider` option for OpenRouter models via the llm-openrouter plugin.

```
$ llm -m openrouter/deepseek/deepseek-chat-v3-0324 -T llm_version "what version of llm is this?" -o provider '{"only": ["deepseek"]}'

Error: Conversation.chain() got an unexpected keyword argument 'provider'
```

There is no equivalent error when tools are not used:

```
$ llm -m openrouter/deepseek/deepseek-chat-v3-0324 "what version of llm is this?" -o provider '{"only": ["deepseek"]}'
<response>...
```

With this fix, we can successfully prompt with the tool call:

```
$ llm -m openrouter/deepseek/deepseek-chat-v3-0324 -T llm_version "what version of llm is this?" -o provider '{"only": ["deepseek"]}'

The installed version of LLM is 0.26.
```