### PR TITLE
Load template config options in llm chat command

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1060,6 +1060,15 @@ def chat(
             template_obj = load_template(template)
         except LoadTemplateError as ex:
             raise click.ClickException(str(ex))
+        # Combine with template fragments/system_fragments
+        if template_obj.fragments:
+            fragments = [*template_obj.fragments, *fragments]
+        if template_obj.system_fragments:
+            system_fragments = [*template_obj.system_fragments, *system_fragments]
+        if template_obj.tools:
+            tools = [*template_obj.tools, *tools]
+        if template_obj.functions and template_obj._functions_is_trusted:
+            python_tools = [template_obj.functions, *python_tools]
         if model_id is None and template_obj.model:
             model_id = template_obj.model
 


### PR DESCRIPTION
Extends template loading to include fragments, system_fragments, tools, and trusted functions from template objects.