### PR TITLE
Fix model options handling in chain method when using tools

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -817,12 +817,16 @@ def prompt(
 
     if tool_implementations:
         prompt_method = conversation.chain
-        kwargs["chain_limit"] = chain_limit
+        kwargs = {
+            "chain_limit": chain_limit,
+            "tools": tool_implementations,
+        }
         if tools_debug:
             kwargs["after_call"] = _debug_tool_call
         if tools_approve:
             kwargs["before_call"] = _approve_tool_call
-        kwargs["tools"] = tool_implementations
+        if validated_options:
+            kwargs["options"] = validated_options
 
     try:
         if async_:


### PR DESCRIPTION
## Problem

When using tools with models that have default options set via `llm models options set`, the CLI throws an error:

```
Error: Conversation.chain() got an unexpected keyword argument 'temperature'
```

This occurs at line 865 in `llm/cli.py` when the code switches from using `conversation.prompt()` to `conversation.chain()` for tool execution.

## Root Cause

The issue stems from different parameter signatures between these methods:

- `conversation.prompt()` accepts model options via `**options` (e.g., `temperature=0.7`)
- `conversation.chain()` expects model options in a dedicated `options` dict parameter (e.g., `options={'temperature': 0.7}`)

When tools are present, the code switches to `chain()` but still passes model options as individual keyword arguments, causing the error.

## Solution

This PR fixes the issue by:

1. Restructuring `kwargs` when tools are detected to only include parameters that `chain()` expects
2. Passing `validated_options` (which contains model options like `temperature`) via the `options` parameter instead of individual kwargs

## Steps to Reproduce

1. Set a default model option: `llm models options set <MODEL> temperature 0.7`
2. Try using tools: `llm -T <tool_name> "some prompt"`
3. Observe the error before this fix

## Testing

- ✅ Works with tools and default model options
- ✅ Works without tools (existing functionality preserved)
- ✅ Works with models that don't have default options set

---

*Description generated by Claude based on investigation, fix implementation, and testing by @kczyk*