### PR TITLE
docs: adds the llm-huggingface-plugin to the plugin directory

### DIFF
--- a/docs/plugins/directory.md
+++ b/docs/plugins/directory.md
@@ -41,6 +41,7 @@ These plugins can be used to interact with remotely hosted models via their API:
 - **[llm-deepseek](https://github.com/abrasumente233/llm-deepseek)** adds support for the [DeepSeek](https://deepseek.com)'s DeepSeek-Chat and DeepSeek-Coder models.
 - **[llm-lambda-labs](https://github.com/simonw/llm-lambda-labs)** provides access to models hosted by [Lambda Labs](https://docs.lambdalabs.com/public-cloud/lambda-chat-api/), including the Nous Hermes 3 series.
 - **[llm-venice](https://github.com/ar-jan/llm-venice)** provides access to uncensored models hosted by privacy-focused [Venice AI](https://docs.venice.ai/), including Llama 3.1 405B.
+- **[llm-huggingface-plugin](https://github.com/SecKatie/llm-huggingface-plugin)** by Katie Mulliken provides access to models through the [Hugging Face Inference Providers](https://huggingface.co/docs/inference-providers/index) auto router.
 
 If an API model host provides an OpenAI-compatible API you can also [configure LLM to talk to it](https://llm.datasette.io/en/stable/other-models.html#openai-compatible-models) without needing an extra plugin.
 


### PR DESCRIPTION
Adds the [llm-huggingface-plugin](https://github.com/SecKatie/llm-huggingface-plugin) by Katie Mulliken to the plugin directory. This plugin adds support for Hugging Face's automatic router to connect to their partner inference providers.

It supports:
- text-generation and image-text-to-text models
- Image inputs using attachments for image-text-to-text models
- Tool calling
- Schemas