### PR TITLE
fix: Check that template path is actually a file

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -3920,12 +3920,12 @@ def load_template(name: str) -> Template:
             raise LoadTemplateError("Could not load template {}: {}".format(name, ex))
 
     # Try local file
-    if potential_path.exists():
+    if potential_path.is_file():
         path = potential_path
     else:
         # Look for template in template_dir()
         path = template_dir() / f"{name}.yaml"
-    if not path.exists():
+    if not path.is_file():
         raise LoadTemplateError(f"Invalid template: {name}")
     content = path.read_text()
     template_obj = _parse_yaml_template(name, content)


### PR DESCRIPTION
When the template name is also the name of a directory in the current directory, the llm command fails:
`$ llm --model my_model --template also_a_directory_name -- "Hello"`
```
Traceback (most recent call last):         
  File "/users/USERNAME/.local/bin/llm", line 10, in <module>
    sys.exit(cli())                                                                       
             ~~~^^                                                                        
  File "/users/USERNAME/.local/share/uv/tools/llm/lib/python3.13/site-packages/click/core.py", line 1442, in __call__
    return self.main(*args, **kwargs)                                                                                                                                               
           ~~~~~~~~~^^^^^^^^^^^^^^^^^                                                     
  File "/users/USERNAME/.local/share/uv/tools/llm/lib/python3.13/site-packages/click/core.py", line 1363, in main
    rv = self.invoke(ctx)                                                                                                                                                           
  File "/users/USERNAME/.local/share/uv/tools/llm/lib/python3.13/site-packages/click/core.py", line 1830, in invoke                                                                                                                                                                                                                                                     
    return _process_result(sub_ctx.command.invoke(sub_ctx))                                                                                                                                                                                                                                                                                                             
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^ 
  File "/users/USERNAME/.local/share/uv/tools/llm/lib/python3.13/site-packages/click/core.py", line 1226, in invoke
    return ctx.invoke(self.callback, **ctx.params)                                                                                                                                  
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                        
  File "/users/USERNAME/.local/share/uv/tools/llm/lib/python3.13/site-packages/click/core.py", line 794, in invoke
    return callback(*args, **kwargs)                                                                                                                                                
  File "/users/USERNAME/.local/share/uv/tools/llm/lib/python3.13/site-packages/llm/cli.py", line 673, in prompt
    template_obj = load_template(template)                                                                                                                                          
  File "/users/USERNAME/.local/share/uv/tools/llm/lib/python3.13/site-packages/llm/cli.py", line 3931, in load_template
    content = path.read_text()                                                                                                                                                      
  File "/users/USERNAME/.local/share/uv/python/cpython-3.13.2-linux-x86_64-gnu/lib/python3.13/pathlib/_local.py", line 546, in read_text
    return PathBase.read_text(self, encoding, errors, newline)                                                                                                                      
           ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                      
  File "/users/USERNAME/.local/share/uv/python/cpython-3.13.2-linux-x86_64-gnu/lib/python3.13/pathlib/_abc.py", line 632, in read_text
    with self.open(mode='r', encoding=encoding, errors=errors, newline=newline) as f:                                                                                               
         ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      
  File "/users/USERNAME/.local/share/uv/python/cpython-3.13.2-linux-x86_64-gnu/lib/python3.13/pathlib/_local.py", line 537, in open
    return io.open(self, mode, buffering, encoding, errors, newline)                                                                                                                
           ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                      
IsADirectoryError: [Errno 21] Is a directory: 'also_a_directory_name'
```

This PR makes the code check that the template path is a file rather than just checking if the path exists.