### PR TITLE
fix: add --user argument when installing addons

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -2996,7 +2996,12 @@ def display_truncated(text):
     is_flag=True,
     help="Include pre-release and development versions",
 )
-def install(packages, upgrade, editable, force_reinstall, no_cache_dir, pre):
+@click.option(
+    "--user",
+    is_flag=True,
+    help="Install to the Python user install directory for your platform.",
+)
+def install(packages, upgrade, editable, force_reinstall, no_cache_dir, pre, user):
     """Install packages from PyPI into the same environment as LLM"""
     args = ["pip", "install"]
     if upgrade:
@@ -3009,6 +3014,8 @@ def install(packages, upgrade, editable, force_reinstall, no_cache_dir, pre):
         args += ["--no-cache-dir"]
     if pre:
         args += ["--pre"]
+    if user:
+        args += ["--user"]
     args += list(packages)
     sys.argv = args
     run_module("pip", run_name="__main__")


### PR DESCRIPTION
Signed-off-by: thiswillbeyourgithub <26625900+thiswillbeyourgithub@users.noreply.github.com>

pip allows using --user which does the following:

```
  --user                      Install to the Python user
                              install directory for your
                              platform. Typically
                              ~/.local/, or
                              %APPDATA%\Python on
                              Windows. (See the Python
                              documentation for
                              site.USER_BASE for full
                              details.)
```
```

This PR adds the `--user` flag to `llm install`.

This is needed on some install to avoid errors like:
`ERROR: Could not install packages due to an OSError: [Errno 13] Permission denied: '/usr/local/bin/llm'
Consider using the `--user` option or check the permissions.`.
