### PR TITLE
fix: CLI extract option should override template extract option

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -673,8 +673,12 @@ def prompt(
             template_obj = load_template(template)
         except LoadTemplateError as ex:
             raise click.ClickException(str(ex))
-        extract = template_obj.extract
-        extract_last = template_obj.extract_last
+        extract = template_obj.extract if template_obj.extract is not None else extract
+        extract_last = (
+            template_obj.extract_last
+            if template_obj.extract_last is not None
+            else extract_last
+        )
         # Combine with template fragments/system_fragments
         if template_obj.fragments:
             fragments = [*template_obj.fragments, *fragments]


### PR DESCRIPTION
Previous behavior: When using a template, `--extract` and `--extract_last` CLI flags were ignored and overwritten by the values saved in the template (or by the `False` default value if the template does not contain these values).

Expected behavior: CLI flags should always take precedence (but especially when the template contains no value for these options!).

Fixes https://github.com/simonw/llm/issues/1296