### PR TITLE
Add llm-bedrock-converse to plugin directory

### DIFF
--- a/docs/plugins/directory.md
+++ b/docs/plugins/directory.md
@@ -36,6 +36,7 @@ These plugins can be used to interact with remotely hosted models via their API:
 - **[llm-cohere](https://github.com/Accudio/llm-cohere)** by Alistair Shepherd provides `cohere-generate` and `cohere-summarize` API models, powered by [Cohere](https://cohere.com/).
 - **[llm-bedrock](https://github.com/simonw/llm-bedrock)** adds support for Nova by Amazon via Amazon Bedrock.
 - **[llm-bedrock-anthropic](https://github.com/sblakey/llm-bedrock-anthropic)** by Sean Blakey adds support for Claude and Claude Instant by Anthropic via Amazon Bedrock.
+- **[llm-bedrock-converse](https://github.com/geehexx/llm-bedrock-converse)** provides AWS Bedrock Converse API integration with tool calling support for all Claude models, plus Titan embeddings.
 - **[llm-bedrock-meta](https://github.com/flabat/llm-bedrock-meta)** by Fabian Labat adds support for Llama 2 and Llama 3 by Meta via Amazon Bedrock.
 - **[llm-together](https://github.com/wearedevx/llm-together)** adds support for the [Together AI](https://www.together.ai/) extensive family of hosted openly licensed models.
 - **[llm-deepseek](https://github.com/abrasumente233/llm-deepseek)** adds support for the [DeepSeek](https://deepseek.com)'s DeepSeek-Chat and DeepSeek-Coder models.


### PR DESCRIPTION
Adds llm-bedrock-converse to the Remote APIs section.

Plugin provides AWS Bedrock Converse API integration with tool calling support for all Claude models and Titan embeddings.

- PyPI: https://pypi.org/project/llm-bedrock-converse/
- GitHub: https://github.com/geehexx/llm-bedrock-converse

Relates to #1303