### PR TITLE
Templates support interpolation in fragments

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -4027,7 +4027,11 @@ def _gather_tools(
         tool for tool in tool_specs if tool.split("(")[0] not in registered_tools
     ]
     if bad_tools:
-        raise click.ClickException("Tool(s) {} not found. Available tools: {}".format(", ".join(bad_tools), ", ".join(registered_tools.keys())))
+        raise click.ClickException(
+            "Tool(s) {} not found. Available tools: {}".format(
+                ", ".join(bad_tools), ", ".join(registered_tools.keys())
+            )
+        )
     for tool_spec in tool_specs:
         if not tool_spec[0].isupper():
             # It's a function

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -675,11 +675,6 @@ def prompt(
             raise click.ClickException(str(ex))
         extract = template_obj.extract
         extract_last = template_obj.extract_last
-        # Combine with template fragments/system_fragments
-        if template_obj.fragments:
-            fragments = [*template_obj.fragments, *fragments]
-        if template_obj.system_fragments:
-            system_fragments = [*template_obj.system_fragments, *system_fragments]
         if template_obj.schema_object:
             schema = template_obj.schema_object
         if template_obj.tools:
@@ -711,6 +706,12 @@ def prompt(
             raise click.ClickException(str(ex))
         if model_id is None and template_obj.model:
             model_id = template_obj.model
+        # Combine with template fragments/system_fragments AFTER evaluation
+        # so that any variables in the fragments have been interpolated
+        if template_obj.fragments:
+            fragments = [*template_obj.fragments, *fragments]
+        if template_obj.system_fragments:
+            system_fragments = [*template_obj.system_fragments, *system_fragments]
         # Merge in any attachments
         if template_obj.attachments:
             attachments = [
@@ -4026,11 +4027,7 @@ def _gather_tools(
         tool for tool in tool_specs if tool.split("(")[0] not in registered_tools
     ]
     if bad_tools:
-        raise click.ClickException(
-            "Tool(s) {} not found. Available tools: {}".format(
-                ", ".join(bad_tools), ", ".join(registered_tools.keys())
-            )
-        )
+        raise click.ClickException("Tool(s) {} not found. Available tools: {}".format(", ".join(bad_tools), ", ".join(registered_tools.keys())))
     for tool_spec in tool_specs:
         if not tool_spec[0].isupper():
             # It's a function

--- a/llm/templates.py
+++ b/llm/templates.py
@@ -53,14 +53,29 @@ class Template(BaseModel):
         else:
             prompt = self.interpolate(self.prompt, params)
             system = self.interpolate(self.system, params)
+
+        # Interpolate fragments
+        if self.fragments:
+            self.fragments = [interpolated for fragment in self.fragments if (interpolated := self.interpolate(fragment, params)) is not None]
+        if self.system_fragments:
+            self.system_fragments = [interpolated for fragment in self.system_fragments if (interpolated := self.interpolate(fragment, params)) is not None]
+
         return prompt, system
 
     def vars(self) -> set:
         all_vars = set()
+        # Check prompt and system
         for text in [self.prompt, self.system]:
             if not text:
                 continue
             all_vars.update(self.extract_vars(string.Template(text)))
+        # Check fragments and system_fragments
+        for fragment_list in [self.fragments, self.system_fragments]:
+            if not fragment_list:
+                continue
+            for fragment in fragment_list:
+                if fragment:
+                    all_vars.update(self.extract_vars(string.Template(fragment)))
         return all_vars
 
     @classmethod


### PR DESCRIPTION
With this change, you can have a template with

```yaml
fragments:
- $input
```

or 

```yaml
fragments:
- github:$input
```

This works beautifully for a url summarization template, which can be as simple as this:
```yaml
system: You are a summarization assistant
fragments:
- $input
```