### PR TITLE
Add support for `xhigh` as a `reasoning_effort` parameter

### DIFF
--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -487,6 +487,7 @@ class ReasoningEffortEnum(str, Enum):
     low = "low"
     medium = "medium"
     high = "high"
+    xhigh = "xhigh"
 
 
 class OptionsForReasoning(SharedOptions):
@@ -497,8 +498,9 @@ class OptionsForReasoning(SharedOptions):
     reasoning_effort: Optional[ReasoningEffortEnum] = Field(
         description=(
             "Constraints effort on reasoning for reasoning models. Currently supported "
-            "values are low, medium, and high. Reducing reasoning effort can result in "
-            "faster responses and fewer tokens used on reasoning in a response."
+            "values are `low`, `medium`, `high`, and, for some models, `xhigh`. Reducing "
+            "reasoning effort can result in faster responses and fewer tokens used on "
+            "reasoning in a response."
         ),
         default=None,
     )


### PR DESCRIPTION
The associated parameter's help message has also been updated. No validation beyond string-checking "xhigh" is performed.