### PR TITLE
feat: Allow aliases to include default prompt options

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ See also [the llm tag](https://simonwillison.net/tags/llm/) on my blog.
 * [Model aliases](https://llm.datasette.io/en/stable/aliases.html)
   * [Listing aliases](https://llm.datasette.io/en/stable/aliases.html#listing-aliases)
   * [Adding a new alias](https://llm.datasette.io/en/stable/aliases.html#adding-a-new-alias)
+  * [Alias with prompt options](https://llm.datasette.io/en/stable/aliases.html#aliases-with-options)
   * [Removing an alias](https://llm.datasette.io/en/stable/aliases.html#removing-an-alias)
   * [Viewing the aliases file](https://llm.datasette.io/en/stable/aliases.html#viewing-the-aliases-file)
 * [Embeddings](https://llm.datasette.io/en/stable/embeddings/index.html)

--- a/docs/aliases.md
+++ b/docs/aliases.md
@@ -100,6 +100,70 @@ The `llm aliases remove <alias>` command will remove the specified alias:
 llm aliases remove mini
 ```
 
+## Aliases with options
+
+You can save default prompt options with an alias. For example, to create an alias `4o-creative` that always uses `gpt-4o` with a high temperature, you can do this:
+
+```bash
+llm aliases set 4o-creative gpt-4o -o temperature 1.5
+```
+
+Then you can use this alias like so:
+
+```bash
+llm -m 4o-creative 'Write a creative story about a robot'
+```
+
+The model will be called with the `temperature` option set to `1.5`.
+
+If you specify options both in the alias and on the command line, the command-line options will take precedence.
+
+For example:
+
+```bash
+llm -m 4o-creative -o temperature 1.0 'Write a creative story about a robot'
+```
+
+This will override the alias temperature setting.
+
+### OpenRouter plugin example
+
+You can also create aliases for plugin models. Here is an example with openrouter provider configurations:
+
+```bash
+llm aliases set maverick-lowlatency openrouter/meta-llama/llama-4-maverick -o provider '{
+  "order": [
+    "Baseten", 
+    "Parasail"
+  ],
+"allow_fallbacks": false
+}'
+```
+
+### Listing aliases with options
+
+To see only aliases that have options configured, use the `--options` flag:
+
+```bash
+llm aliases --options
+```
+
+Example output:
+```
+4o-creative: gpt-4o
+  Options:
+    temperature: 1.5
+maverick-lowlatency: openrouter/meta-llama/llama-4-maverick
+  Options:
+    provider: {"order": ["Baseten", "Parasail"], "allow_fallbacks": false}
+```
+
+Add `--json` to get that list back as JSON:
+
+```bash
+llm aliases --options --json
+```
+
 ## Viewing the aliases file
 
 Aliases are stored in an `aliases.json` file in the LLM configuration directory.

--- a/llm/__init__.py
+++ b/llm/__init__.py
@@ -98,7 +98,12 @@ def get_models_with_aliases() -> List["ModelWithAliases"]:
     extra_model_aliases: Dict[str, list] = {}
     if aliases_path.exists():
         configured_aliases = json.loads(aliases_path.read_text())
-        for alias, model_id in configured_aliases.items():
+        for alias, model_id_or_config in configured_aliases.items():
+            # Handle both old format (string) and new format (dict with model and options)
+            if isinstance(model_id_or_config, dict) and "model" in model_id_or_config:
+                model_id = model_id_or_config["model"]
+            else:
+                model_id = model_id_or_config
             extra_model_aliases.setdefault(model_id, []).append(alias)
 
     def register(model, async_model=None, aliases=None):
@@ -223,7 +228,12 @@ def get_embedding_models_with_aliases() -> List["EmbeddingModelWithAliases"]:
     extra_model_aliases: Dict[str, list] = {}
     if aliases_path.exists():
         configured_aliases = json.loads(aliases_path.read_text())
-        for alias, model_id in configured_aliases.items():
+        for alias, model_id_or_config in configured_aliases.items():
+            # Handle both old format (string) and new format (dict with model and options)
+            if isinstance(model_id_or_config, dict) and "model" in model_id_or_config:
+                model_id = model_id_or_config["model"]
+            else:
+                model_id = model_id_or_config
             extra_model_aliases.setdefault(model_id, []).append(alias)
 
     def register(model, aliases=None):
@@ -429,6 +439,86 @@ def set_alias(alias, model_id_or_alias):
             model_id = model_id_or_alias
     current[alias] = model_id
     path.write_text(json.dumps(current, indent=4) + "\n")
+
+
+def set_alias_with_options(alias, model_id_or_alias, options):
+    """
+    Set an alias to point to the specified model with default options.
+    """
+    path = user_dir() / "aliases.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not path.exists():
+        path.write_text("{}\n")
+    try:
+        current = json.loads(path.read_text())
+    except json.decoder.JSONDecodeError:
+        # We're going to write a valid JSON file in a moment:
+        current = {}
+    # Resolve model_id_or_alias to a model_id
+    try:
+        model = get_model(model_id_or_alias)
+        model_id = model.model_id
+    except UnknownModelError:
+        # Try to resolve it to an embedding model
+        try:
+            model = get_embedding_model(model_id_or_alias)
+            model_id = model.model_id
+        except UnknownModelError:
+            # Set the alias to the exact string they provided instead
+            model_id = model_id_or_alias
+    # Store as a dictionary with model and options
+    current[alias] = {
+        "model": model_id,
+        "options": options
+    }
+    path.write_text(json.dumps(current, indent=4) + "\n")
+
+
+def resolve_alias_options(alias_or_model_id):
+    """
+    Resolve an alias to its model and options, if it exists.
+    Returns None if not an alias, or a dict with 'model' and 'options' keys.
+    """
+    path = user_dir() / "aliases.json"
+    if not path.exists():
+        return None
+    try:
+        current = json.loads(path.read_text())
+    except json.decoder.JSONDecodeError:
+        return None
+    
+    if alias_or_model_id not in current:
+        return None
+    
+    alias_value = current[alias_or_model_id]
+    
+    # Check if it's the new format (dict with model and options)
+    if isinstance(alias_value, dict) and "model" in alias_value:
+        return alias_value
+    
+    # Otherwise it's the old format (just a string), not relevant for options
+    return None
+
+
+def get_aliases_with_options():
+    """
+    Get all aliases that have options defined.
+    Returns a dict mapping alias name to {'model': model_id, 'options': {option: value}}.
+    """
+    path = user_dir() / "aliases.json"
+    if not path.exists():
+        return {}
+    try:
+        current = json.loads(path.read_text())
+    except json.decoder.JSONDecodeError:
+        return {}
+    
+    result = {}
+    for alias, value in current.items():
+        if isinstance(value, dict) and "model" in value and "options" in value:
+            if value["options"]:  # Only include if options are non-empty
+                result[alias] = value
+    return result
 
 
 def remove_alias(alias):

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -126,3 +126,156 @@ def test_cli_aliases_are_registered(user_path, args):
     assert result.exit_code == 0
     # Check for model line only, without keys, as --options is not used
     assert "gpt-3.5-turbo (aliases: 3.5, chatgpt, turbo)" in result.output
+
+
+def test_cli_aliases_set_with_options(user_path):
+    """Test setting aliases with options via CLI"""
+    runner = CliRunner()
+    
+    # Test setting alias with options
+    result = runner.invoke(cli, [
+        "aliases", "set", "test-alias", "mock", 
+        "-o", "temperature", "0.5",
+        "-o", "max_tokens", "100"
+    ])
+    assert result.exit_code == 0
+    
+    # Check that aliases.json contains the correct structure
+    aliases_file = user_path / "aliases.json"
+    assert aliases_file.exists()
+    aliases_data = json.loads(aliases_file.read_text("utf-8"))
+    
+    expected = {
+        "test-alias": {
+            "model": "mock",
+            "options": {
+                "temperature": "0.5",
+                "max_tokens": "100"
+            }
+        }
+    }
+    assert aliases_data == expected
+
+
+def test_cli_aliases_set_with_query_and_options(user_path):
+    """Test setting aliases with -q query and options"""
+    runner = CliRunner()
+    
+    # Test setting alias with query and options
+    result = runner.invoke(cli, [
+        "aliases", "set", "test-query-alias", 
+        "-q", "mock",
+        "-o", "temperature", "0.7"
+    ])
+    assert result.exit_code == 0
+    
+    # Check that aliases.json contains the correct structure
+    aliases_file = user_path / "aliases.json"
+    assert aliases_file.exists()
+    aliases_data = json.loads(aliases_file.read_text("utf-8"))
+    
+    expected = {
+        "test-query-alias": {
+            "model": "mock",
+            "options": {
+                "temperature": "0.7"
+            }
+        }
+    }
+    assert aliases_data == expected
+
+
+def test_set_alias_with_options_function(user_path):
+    """Test the set_alias_with_options function directly"""
+    import llm
+    
+    # Test the function directly
+    llm.set_alias_with_options("direct-test", "mock", {
+        "temperature": 0.3,
+        "max_tokens": 50
+    })
+    
+    # Check that aliases.json was created correctly
+    aliases_file = user_path / "aliases.json"
+    assert aliases_file.exists()
+    aliases_data = json.loads(aliases_file.read_text("utf-8"))
+    
+    expected = {
+        "direct-test": {
+            "model": "mock",
+            "options": {
+                "temperature": 0.3,
+                "max_tokens": 50
+            }
+        }
+    }
+    assert aliases_data == expected
+
+
+def test_resolve_alias_options_function(user_path):
+    """Test the resolve_alias_options function"""
+    import llm
+    
+    # First set an alias with options
+    llm.set_alias_with_options("resolve-test", "mock", {
+        "temperature": 0.8
+    })
+    
+    # Test resolving the alias
+    result = llm.resolve_alias_options("resolve-test")
+    expected = {
+        "model": "mock",
+        "options": {
+            "temperature": 0.8
+        }
+    }
+    assert result == expected
+    
+    # Test resolving a non-alias (should return None)
+    result = llm.resolve_alias_options("not-an-alias")
+    assert result is None
+
+
+def test_cli_aliases_list_with_options_flag(user_path):
+    """Test the --options flag for aliases list command"""
+    import llm
+    
+    # Set up aliases - one with options, one without
+    llm.set_alias("simple-alias", "mock")
+    llm.set_alias_with_options("opts-alias", "mock", {
+        "temperature": "0.5",
+        "max_tokens": "100"
+    })
+    
+    runner = CliRunner()
+    
+    # Test --options flag shows only aliases with options
+    result = runner.invoke(cli, ["aliases", "--options"])
+    assert result.exit_code == 0
+    assert "opts-alias: mock" in result.output
+    assert "temperature: 0.5" in result.output
+    assert "max_tokens: 100" in result.output
+    # Simple alias should NOT appear
+    assert "simple-alias" not in result.output
+    
+    # Test --options with --json
+    result = runner.invoke(cli, ["aliases", "--options", "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert "opts-alias" in data
+    assert data["opts-alias"]["model"] == "mock"
+    assert data["opts-alias"]["options"]["temperature"] == "0.5"
+    assert "simple-alias" not in data
+
+
+def test_cli_aliases_list_options_empty(user_path):
+    """Test --options flag when no aliases have options"""
+    import llm
+    
+    # Only set a simple alias without options
+    llm.set_alias("simple-only", "mock")
+    
+    runner = CliRunner()
+    result = runner.invoke(cli, ["aliases", "--options"])
+    assert result.exit_code == 0
+    assert "No aliases with options found" in result.output


### PR DESCRIPTION
# PR: Allow aliases to include default prompt options

## Summary

This PR adds the ability to define model aliases with embedded default prompt options. This enables users to pre-configure common model parameters with an alias, making it easy to reuse specific model configurations.

## Changes

### Core Implementation

1. **Modified `llm aliases set` command** (`llm/cli.py`)
   - Added `-o`/`--option` arguments to store options with an alias
   - Usage: `llm aliases set 4o-creative gpt-4o -o temperature 1.5`

2. **New `llm aliases --options` flag** (`llm/cli.py`)
   - Lists only aliases that have options configured
   - Supports `--json` output format
   - Similar display format to `llm models --options`

3. **Updated `llm prompt` and `llm chat` commands** (`llm/cli.py`)
   - Resolve and apply options defined within an alias
   - Command-line options take precedence over alias-defined options

4. **New helper functions** (`llm/__init__.py`)
   - `set_alias_with_options(alias, model_id, options)` - Set alias with options
   - `resolve_alias_options(alias)` - Get alias model and options if it exists
   - `get_aliases_with_options()` - Get all aliases that have options defined

5. **Backward compatibility**
   - Alias configuration parsing supports both the new dictionary format (`{model, options}`) and the old string format
   - Existing aliases continue to work without any changes

### Documentation

- Updated `docs/aliases.md` with comprehensive documentation for:
  - Setting aliases with options
  - Multiple options on a single alias
  - Overriding alias options on the command line
  - Using `--options` flag to list aliases with options
  - OpenRouter plugin example with complex JSON options

### Tests

Added comprehensive tests in `tests/test_aliases.py`:
- `test_cli_aliases_set_with_options` - Setting aliases with options via CLI
- `test_cli_aliases_set_with_query_and_options` - Setting aliases with -q query and options
- `test_set_alias_with_options_function` - Direct function testing
- `test_resolve_alias_options_function` - Resolve alias options testing
- `test_cli_aliases_list_with_options_flag` - Testing `--options` flag
- `test_cli_aliases_list_options_empty` - Testing `--options` when no aliases have options

## Manual Testing Evidence

### Test 1: Set alias with single option
```bash
$ llm aliases set test-temp gpt-4o-mini -o temperature 0.8
```

### Test 2: Set alias with multiple options
```bash
$ llm aliases set test-multi gpt-4o-mini -o temperature 0.5 -o max_tokens 50
```

### Test 3: View aliases with --options
```bash
$ llm aliases --options
test-temp: gpt-4o-mini
  Options:
    temperature: 0.8
test-multi: gpt-4o-mini
  Options:
    temperature: 0.5
    max_tokens: 50
```

### Test 4: View aliases with --options --json
```bash
$ llm aliases --options --json
{
    "test-temp": {
        "model": "gpt-4o-mini",
        "options": {
            "temperature": "0.8"
        }
    },
    "test-multi": {
        "model": "gpt-4o-mini",
        "options": {
            "temperature": "0.5",
            "max_tokens": "50"
        }
    }
}
```

### Test 5: Use alias with options
```bash
$ llm -m test-temp "say hello in one word"
Hello!
```

### Test 6: Verify options were logged
```bash
$ llm logs --json -n 1 | jq '.[] | {model: .model, options: .options_json}'
{
  "model": "gpt-4o-mini",
  "options": {
    "temperature": 0.8
  }
}
```

### Test 7: Override alias options with command-line
```bash
$ llm -m test-temp -o temperature 0.1 "say hello in one word"
Hello!
```

### Test 8: Verify override was applied
```bash
$ llm logs --json -n 1 | jq '.[] | {model: .model, options: .options_json}'
{
  "model": "gpt-4o-mini",
  "options": {
    "temperature": 0.1
  }
}
```

## Automated Test Results

```
tests/test_aliases.py::test_set_alias[gpt-3.5-turbo] PASSED
tests/test_aliases.py::test_set_alias[chatgpt] PASSED
tests/test_aliases.py::test_remove_alias PASSED
tests/test_aliases.py::test_cli_aliases_list[args0] PASSED
tests/test_aliases.py::test_cli_aliases_list[args1] PASSED
tests/test_aliases.py::test_cli_aliases_list_json[args0] PASSED
tests/test_aliases.py::test_cli_aliases_list_json[args1] PASSED
tests/test_aliases.py::test_cli_aliases_set[args0-expected0-None] PASSED
tests/test_aliases.py::test_cli_aliases_set[args1-expected1-None] PASSED
tests/test_aliases.py::test_cli_aliases_set[args2-None-No model found matching query: mog] PASSED
tests/test_aliases.py::test_cli_aliases_path PASSED
tests/test_aliases.py::test_cli_aliases_remove PASSED
tests/test_aliases.py::test_cli_aliases_remove_invalid PASSED
tests/test_aliases.py::test_cli_aliases_are_registered[args0] PASSED
tests/test_aliases.py::test_cli_aliases_are_registered[args1] PASSED
tests/test_aliases.py::test_cli_aliases_set_with_options PASSED
tests/test_aliases.py::test_cli_aliases_set_with_query_and_options PASSED
tests/test_aliases.py::test_set_alias_with_options_function PASSED
tests/test_aliases.py::test_resolve_alias_options_function PASSED
tests/test_aliases.py::test_cli_aliases_list_with_options_flag PASSED
tests/test_aliases.py::test_cli_aliases_list_options_empty PASSED

============================== 21 passed ==============================
```

## Files Changed

```
 README.md             |   1 +
 docs/aliases.md       |  64 +++++++++++++++++++++
 llm/__init__.py       |  94 +++++++++++++++++++++++++++++-
 llm/cli.py            |  64 +++++++++++++++++++--
 tests/test_aliases.py | 153 +++++++++++++++++++++++++++++++++++++++++++++++++
 5 files changed, 370 insertions(+), 6 deletions(-)
```

## Notes

1. **Pre-existing test failures**: There are 5 failing tests in `tests/test_llm_logs.py` that are pre-existing on the `main` branch and unrelated to this PR:
   - `test_logs_fragments[fragment_refs0-expected0]`
   - `test_logs_fragments[fragment_refs2-expected2]`
   - `test_expand_fragment_json[-e]`
   - `test_expand_fragment_json[--expand]`
   - `test_expand_fragment_markdown`

2. **Option value types**: Options are stored as strings in the aliases.json file but are properly converted to the correct types when validated by the model's Options pydantic model.

3. **OpenRouter example**: The documentation includes an example of setting complex JSON options for OpenRouter provider configurations, demonstrating that this feature works well with plugin models.

## Suggested Changelog Entry

```markdown
- Aliases can now include default prompt options. Use `llm aliases set myalias gpt-4o -o temperature 1.5` to create an alias with options. Use `llm aliases --options` to see all aliases with their configured options. Command-line options override alias options.
```
