### PR TITLE
Fix --xl and --extract options being ignored when using templates

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -678,8 +678,8 @@ def prompt(
             template_obj = load_template(template)
         except LoadTemplateError as ex:
             raise click.ClickException(str(ex))
-        extract = template_obj.extract
-        extract_last = template_obj.extract_last
+        extract = extract or template_obj.extract
+        extract_last = extract_last or template_obj.extract_last
         # Combine with template fragments/system_fragments
         if template_obj.fragments:
             fragments = [*template_obj.fragments, *fragments]


### PR DESCRIPTION
## Summary

Fixes #1296

The `--xl` (`--extract-last`) and `-x` (`--extract`) command-line options were being completely overwritten when loading a template, instead of being combined with the template's settings. This meant that running:

```bash
llm --template my_template --xl
```

Would ignore the `--xl` flag if the template didn't have `extract_last: true` set.

## The Bug

In `cli.py`, when a template is loaded, the code was:

```python
extract = template_obj.extract
extract_last = template_obj.extract_last
```

This overwrites any CLI flags the user passed.

## The Fix

Changed to use `or` to combine CLI flags with template settings:

```python
extract = extract or template_obj.extract
extract_last = extract_last or template_obj.extract_last
```

Now the user can use `--xl` or `-x` with any template, regardless of whether the template has those options configured.

## Testing

- All 470 existing tests pass
- Verified linting (ruff) and formatting (black) pass

## Reproduction

Before this fix:
```bash
llm "Create an SVG of a pelican riding a bicycle." --save pelican
llm --template pelican --xl
# Returns full markdown response, ignoring --xl
```

After this fix:
```bash
llm --template pelican --xl
# Correctly extracts last fenced code block
```