### PR TITLE
`llm logs list`: Work around regression in SQLite 3.51 with EXIST UNION query

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1699,21 +1699,21 @@ def logs_list(
 
         for i, fragment_hash in enumerate(fragment_hashes):
             exists_clause = f"""
-            exists (
+            (exists (
                 select 1 from prompt_fragments
                 where prompt_fragments.response_id = responses.id
                 and prompt_fragments.fragment_id in (
                     select fragments.id from fragments
                     where hash = :f{i}
                 )
-                union
+            ) or exists (
                 select 1 from system_fragments
                 where system_fragments.response_id = responses.id
                 and system_fragments.fragment_id in (
                     select fragments.id from fragments
                     where hash = :f{i}
                 )
-            )
+            ))
             """
             exists_clauses.append(exists_clause)
             sql_params["f{}".format(i)] = fragment_hash


### PR DESCRIPTION
Hi,

distro packagers have noticed a test failure (https://github.com/NixOS/nixpkgs/issues/476258, `test_expand_fragment_json`) that appears with the recent Python 3.13.11 release.
This coincides with a bump in SQLite that seems to have broken the queries used by the `logs list` subcommand: https://sqlite.org/forum/forumpost/787796d66c

This slightly changes the underlying query to avoid the `union` inside of the `exists` expression.
Feel free to leave the PR open if you want to keep the original code -- I'm assuming that this'll be fixed upstream at some point. :upside_down_face: 

Edit: The SQLite author has fixed the regression (https://github.com/sqlite/sqlite/commit/904abc85cf264d50b0a0bbcbf36eaa7cccb379e1), so builds with version 3.51.2 or 3.52.0 shouldn't require this workaround.