### PR TITLE
Fix MIME type detection when puremagic returns empty string

### DIFF
--- a/llm/utils.py
+++ b/llm/utils.py
@@ -3,6 +3,7 @@ import hashlib
 import httpx
 import itertools
 import json
+import mimetypes
 import pathlib
 import puremagic
 import re
@@ -38,6 +39,9 @@ class Fragment(str):
 def mimetype_from_string(content) -> Optional[str]:
     try:
         type_ = puremagic.from_string(content, mime=True)
+        # puremagic can return empty string if it can't detect the type
+        if not type_:
+            return None
         return MIME_TYPE_FIXES.get(type_, type_)
     except puremagic.PureError:
         return None
@@ -46,9 +50,17 @@ def mimetype_from_string(content) -> Optional[str]:
 def mimetype_from_path(path) -> Optional[str]:
     try:
         type_ = puremagic.from_file(path, mime=True)
+        # puremagic can return empty string if it can't detect the type
+        if not type_:
+            # Fall back to Python's standard mimetypes module
+            type_, _ = mimetypes.guess_type(path)
+            if not type_:
+                return None
         return MIME_TYPE_FIXES.get(type_, type_)
     except puremagic.PureError:
-        return None
+        # Fall back to Python's standard mimetypes module
+        type_, _ = mimetypes.guess_type(path)
+        return MIME_TYPE_FIXES.get(type_, type_) if type_ else None
 
 
 def dicts_to_table_string(


### PR DESCRIPTION
Fixes the issue where `puremagic.from_file()` can return an empty string instead of raising an exception when it fails to detect a MIME type, causing attachment validation to fail.

## Changes

- Added fallback to Python's standard `mimetypes.guess_type()` when `puremagic` returns an empty string or raises an exception
- Added check for empty string return value from `puremagic`
- Updated both `mimetype_from_path()` and `mimetype_from_string()` for consistency

This ensures that common file types (like `.mp4`, `.jpg`, etc.) are correctly detected even when `puremagic` fails, while maintaining backward compatibility.

## Testing

Tested with files that previously failed MIME type detection (e.g., `.mp4` files) and now correctly returns `video/mp4` using the fallback mechanism.

fixes #1340 