### PR TITLE
Add OpenResponses API client implementation

### DIFF
--- a/llm/responses.py
+++ b/llm/responses.py
@@ -1,0 +1,846 @@
+"""
+OpenResponses API client implementation for LLM.
+
+This module provides sync and async model classes that implement the
+OpenResponses API specification using httpx as the transport layer.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import (
+    Any,
+    AsyncGenerator,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Union,
+)
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field
+
+from llm import AsyncKeyModel, KeyModel, Prompt
+from llm.models import AsyncConversation, AsyncResponse, Conversation, Response, _Options
+
+
+# ============================================================================
+# Error Classes
+# ============================================================================
+
+
+class ResponsesAPIError(Exception):
+    """Base exception for OpenResponses API errors."""
+
+    def __init__(self, message: str, status_code: Optional[int] = None):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class ResponsesAuthenticationError(ResponsesAPIError):
+    """Raised when authentication fails (401)."""
+
+    def __init__(self, message: str):
+        super().__init__(message, status_code=401)
+
+
+class ResponsesRateLimitError(ResponsesAPIError):
+    """Raised when rate limit is exceeded (429)."""
+
+    def __init__(self, message: str):
+        super().__init__(message, status_code=429)
+
+
+class ResponsesInvalidRequestError(ResponsesAPIError):
+    """Raised for invalid requests (400)."""
+
+    def __init__(self, message: str):
+        super().__init__(message, status_code=400)
+
+
+# ============================================================================
+# Pydantic Models - Usage
+# ============================================================================
+
+
+class InputTokensDetails(BaseModel):
+    """Details about input token usage."""
+
+    cached_tokens: int = 0
+
+
+class OutputTokensDetails(BaseModel):
+    """Details about output token usage."""
+
+    reasoning_tokens: int = 0
+
+
+class Usage(BaseModel):
+    """Token usage statistics."""
+
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    input_tokens_details: Optional[InputTokensDetails] = None
+    output_tokens_details: Optional[OutputTokensDetails] = None
+
+
+# ============================================================================
+# Pydantic Models - Content
+# ============================================================================
+
+
+class OutputTextContent(BaseModel):
+    """Text content in an output message."""
+
+    type: str = "output_text"
+    text: str
+    annotations: List[Any] = Field(default_factory=list)
+
+
+class FunctionCallContent(BaseModel):
+    """Function call content in an output item."""
+
+    type: str = "function_call"
+    id: str
+    status: str
+    call_id: Optional[str] = None
+    name: str
+    arguments: str = ""
+
+
+# ============================================================================
+# Pydantic Models - Output Items
+# ============================================================================
+
+
+class OutputItem(BaseModel):
+    """An output item from the model (message or function call)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    type: str
+    id: Optional[str] = None
+    status: Optional[str] = None
+    role: Optional[str] = None
+    content: Optional[List[Any]] = None
+    # For function calls
+    call_id: Optional[str] = None
+    name: Optional[str] = None
+    arguments: Optional[str] = None
+
+
+# ============================================================================
+# Pydantic Models - Text Format
+# ============================================================================
+
+
+class TextFormat(BaseModel):
+    """Text format configuration."""
+
+    type: str = "text"
+
+
+class TextField(BaseModel):
+    """Text field configuration."""
+
+    model_config = ConfigDict(extra="allow")
+
+    format: Optional[TextFormat] = None
+
+
+# ============================================================================
+# Pydantic Models - Response Resource
+# ============================================================================
+
+
+class ResponseResource(BaseModel):
+    """The complete response object from the Responses API."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    object: str = "response"
+    created_at: int
+    completed_at: Optional[int] = None
+    status: str
+    model: str
+    incomplete_details: Optional[Any] = None
+    previous_response_id: Optional[str] = None
+    next_response_ids: List[str] = Field(default_factory=list)
+    instructions: Optional[Union[str, List[Any]]] = None
+    input: List[Any] = Field(default_factory=list)
+    output: List[OutputItem] = Field(default_factory=list)
+    error: Optional[Any] = None
+    tools: List[Any] = Field(default_factory=list)
+    tool_choice: Optional[Any] = None
+    truncation: Optional[str] = None
+    parallel_tool_calls: bool = True
+    text: Optional[TextField] = None
+    top_p: Optional[float] = None
+    presence_penalty: Optional[float] = None
+    frequency_penalty: Optional[float] = None
+    top_logprobs: Optional[int] = None
+    temperature: Optional[float] = None
+    reasoning: Optional[Any] = None
+    user: Optional[str] = None
+    usage: Optional[Usage] = None
+    cost_token: Optional[str] = None
+    max_output_tokens: Optional[int] = None
+    max_tool_calls: Optional[int] = None
+    store: bool = False
+    background: bool = False
+    service_tier: Optional[str] = None
+    context_edits: List[Any] = Field(default_factory=list)
+    metadata: Optional[Dict[str, Any]] = None
+    safety_identifier: Optional[str] = None
+    prompt_cache_key: Optional[str] = None
+    prompt_cache_retention: Optional[str] = None
+    conversation: Optional[Any] = None
+    billing: Optional[Any] = None
+
+
+# ============================================================================
+# Pydantic Models - Streaming Events
+# ============================================================================
+
+
+class ResponseStreamEvent(BaseModel):
+    """Base class for streaming events."""
+
+    model_config = ConfigDict(extra="allow")
+
+    type: str
+    sequence_number: int
+
+
+class ResponseCreatedEvent(ResponseStreamEvent):
+    """Event emitted when response is created."""
+
+    type: str = "response.created"
+    response: ResponseResource
+
+
+class ResponseInProgressEvent(ResponseStreamEvent):
+    """Event emitted when response is in progress."""
+
+    type: str = "response.in_progress"
+    response: ResponseResource
+
+
+class ResponseCompletedEvent(ResponseStreamEvent):
+    """Event emitted when response is completed."""
+
+    type: str = "response.completed"
+    response: ResponseResource
+
+
+class ResponseFailedEvent(ResponseStreamEvent):
+    """Event emitted when response fails."""
+
+    type: str = "response.failed"
+    response: ResponseResource
+
+
+class ResponseOutputItemAddedEvent(ResponseStreamEvent):
+    """Event emitted when an output item is added."""
+
+    type: str = "response.output_item.added"
+    output_index: int
+    item: OutputItem
+
+
+class ResponseOutputItemDoneEvent(ResponseStreamEvent):
+    """Event emitted when an output item is done."""
+
+    type: str = "response.output_item.done"
+    output_index: int
+    item: OutputItem
+
+
+class ResponseContentPartAddedEvent(ResponseStreamEvent):
+    """Event emitted when a content part is added."""
+
+    type: str = "response.content_part.added"
+    item_id: str
+    output_index: int
+    content_index: int
+    part: Any
+
+
+class ResponseContentPartDoneEvent(ResponseStreamEvent):
+    """Event emitted when a content part is done."""
+
+    type: str = "response.content_part.done"
+    item_id: str
+    output_index: int
+    content_index: int
+    part: Any
+
+
+class ResponseOutputTextDeltaEvent(ResponseStreamEvent):
+    """Event emitted when text is incrementally added."""
+
+    type: str = "response.output_text.delta"
+    item_id: str
+    output_index: int
+    content_index: int
+    delta: str
+    logprobs: List[Any] = Field(default_factory=list)
+    obfuscation: Optional[str] = None
+
+
+class ResponseOutputTextDoneEvent(ResponseStreamEvent):
+    """Event emitted when text output is complete."""
+
+    type: str = "response.output_text.done"
+    item_id: str
+    output_index: int
+    content_index: int
+    text: str
+
+
+class ResponseFunctionCallArgumentsDeltaEvent(ResponseStreamEvent):
+    """Event emitted when function call arguments are incrementally added."""
+
+    type: str = "response.function_call_arguments.delta"
+    item_id: str
+    output_index: int
+    delta: str
+    obfuscation: Optional[str] = None
+
+
+class ResponseFunctionCallArgumentsDoneEvent(ResponseStreamEvent):
+    """Event emitted when function call arguments are complete."""
+
+    type: str = "response.function_call_arguments.done"
+    item_id: str
+    output_index: int
+    arguments: str
+
+
+# ============================================================================
+# SSE Parser
+# ============================================================================
+
+
+# Map event types to their Pydantic models
+EVENT_TYPE_MAP = {
+    "response.created": ResponseCreatedEvent,
+    "response.in_progress": ResponseInProgressEvent,
+    "response.completed": ResponseCompletedEvent,
+    "response.failed": ResponseFailedEvent,
+    "response.output_item.added": ResponseOutputItemAddedEvent,
+    "response.output_item.done": ResponseOutputItemDoneEvent,
+    "response.content_part.added": ResponseContentPartAddedEvent,
+    "response.content_part.done": ResponseContentPartDoneEvent,
+    "response.output_text.delta": ResponseOutputTextDeltaEvent,
+    "response.output_text.done": ResponseOutputTextDoneEvent,
+    "response.function_call_arguments.delta": ResponseFunctionCallArgumentsDeltaEvent,
+    "response.function_call_arguments.done": ResponseFunctionCallArgumentsDoneEvent,
+}
+
+
+def parse_sse_event(line: str) -> Optional[ResponseStreamEvent]:
+    """
+    Parse a single SSE line and return the appropriate event object.
+
+    Args:
+        line: A single line from the SSE stream.
+
+    Returns:
+        A ResponseStreamEvent subclass instance, or None for empty/comment lines.
+
+    Raises:
+        json.JSONDecodeError: If the JSON data is invalid.
+    """
+    line = line.strip()
+
+    # Empty lines
+    if not line:
+        return None
+
+    # Comment lines
+    if line.startswith(":"):
+        return None
+
+    # Data lines
+    if line.startswith("data:"):
+        data = line[5:].strip()
+
+        # [DONE] marker
+        if data == "[DONE]":
+            return None
+
+        # Parse JSON
+        event_data = json.loads(data)
+        event_type = event_data.get("type", "")
+
+        # Get the appropriate event class
+        event_class = EVENT_TYPE_MAP.get(event_type, ResponseStreamEvent)
+        return event_class(**event_data)
+
+    return None
+
+
+# ============================================================================
+# Model Options
+# ============================================================================
+
+
+class ResponsesOptions(_Options):
+    """Options for OpenResponses API models."""
+
+    temperature: Optional[float] = Field(
+        description="Sampling temperature between 0 and 2.",
+        ge=0,
+        le=2,
+        default=None,
+    )
+    max_output_tokens: Optional[int] = Field(
+        description="Maximum number of tokens to generate.",
+        ge=1,
+        default=None,
+    )
+    top_p: Optional[float] = Field(
+        description="Nucleus sampling parameter between 0 and 1.",
+        ge=0,
+        le=1,
+        default=None,
+    )
+    frequency_penalty: Optional[float] = Field(
+        description="Frequency penalty between -2 and 2.",
+        ge=-2,
+        le=2,
+        default=None,
+    )
+    presence_penalty: Optional[float] = Field(
+        description="Presence penalty between -2 and 2.",
+        ge=-2,
+        le=2,
+        default=None,
+    )
+
+
+# ============================================================================
+# Shared Implementation
+# ============================================================================
+
+
+class _SharedResponses:
+    """Shared implementation for sync and async responses models."""
+
+    model_id: str
+    api_base: str
+    needs_key: str = "openresponses"
+    key_env_var: str = "OPENRESPONSES_API_KEY"
+    can_stream: bool = True
+    supports_schema: bool = False
+    supports_tools: bool = True
+
+    Options = ResponsesOptions
+
+    def __init__(
+        self,
+        model_id: str,
+        api_base: Optional[str] = None,
+        key: Optional[str] = None,
+    ):
+        self.model_id = model_id
+        self.api_base = api_base or "https://api.openai.com/v1"
+        self.key = key
+
+    def __str__(self) -> str:
+        return f"OpenResponses: {self.model_id}"
+
+    def _build_request_body(
+        self,
+        prompt: Prompt,
+        stream: bool,
+        conversation: Optional[Union[Conversation, AsyncConversation]],
+    ) -> Dict[str, Any]:
+        """Build the request body for the API call."""
+        body: Dict[str, Any] = {
+            "model": self.model_id,
+            "stream": stream,
+        }
+
+        # Build input from prompt
+        input_items = []
+
+        # Add system message if present
+        if prompt.system:
+            input_items.append({
+                "type": "message",
+                "role": "developer",
+                "content": [{"type": "input_text", "text": prompt.system}],
+            })
+
+        # Add conversation history if present
+        if conversation is not None:
+            for prev_response in conversation.responses:
+                # Add user message
+                if prev_response.prompt.prompt:
+                    input_items.append({
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": prev_response.prompt.prompt}],
+                    })
+                # Add assistant response
+                response_text = prev_response.text()
+                if response_text:
+                    input_items.append({
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": response_text}],
+                    })
+
+        # Add current user message
+        if prompt.prompt:
+            input_items.append({
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": prompt.prompt}],
+            })
+
+        if input_items:
+            body["input"] = input_items
+
+        # Add options
+        options = prompt.options
+        if options:
+            if hasattr(options, "temperature") and options.temperature is not None:
+                body["temperature"] = options.temperature
+            if hasattr(options, "max_output_tokens") and options.max_output_tokens is not None:
+                body["max_output_tokens"] = options.max_output_tokens
+            if hasattr(options, "top_p") and options.top_p is not None:
+                body["top_p"] = options.top_p
+            if hasattr(options, "frequency_penalty") and options.frequency_penalty is not None:
+                body["frequency_penalty"] = options.frequency_penalty
+            if hasattr(options, "presence_penalty") and options.presence_penalty is not None:
+                body["presence_penalty"] = options.presence_penalty
+
+        # Add tools if present
+        if prompt.tools:
+            tools = []
+            for tool in prompt.tools:
+                tools.append({
+                    "type": "function",
+                    "name": tool.name,
+                    "description": tool.description,
+                    "parameters": tool.input_schema,
+                })
+            body["tools"] = tools
+
+        # Add schema if present (for structured output)
+        if prompt.schema:
+            schema_dict = prompt.schema
+            if hasattr(prompt.schema, "model_json_schema"):
+                schema_dict = prompt.schema.model_json_schema()
+            body["text"] = {
+                "format": {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "response",
+                        "schema": schema_dict,
+                    },
+                }
+            }
+
+        return body
+
+    def _build_input_items(
+        self, conversation_messages: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        """Convert conversation messages to input items format."""
+        input_items = []
+        for msg in conversation_messages:
+            role = msg.get("role", "user")
+            content = msg.get("content", "")
+
+            # Map roles
+            if role == "system":
+                role = "developer"
+            elif role == "assistant":
+                content_type = "output_text"
+            else:
+                content_type = "input_text"
+
+            if role == "assistant":
+                input_items.append({
+                    "type": "message",
+                    "role": role,
+                    "content": [{"type": "output_text", "text": content}],
+                })
+            else:
+                input_items.append({
+                    "type": "message",
+                    "role": role,
+                    "content": [{"type": "input_text", "text": content}],
+                })
+
+        return input_items
+
+    def _get_headers(self, key: str) -> Dict[str, str]:
+        """Get request headers."""
+        return {
+            "Authorization": f"Bearer {key}",
+            "Content-Type": "application/json",
+        }
+
+    def _handle_error_response(self, response: httpx.Response) -> None:
+        """Handle error responses from the API."""
+        try:
+            error_data = response.json()
+            message = error_data.get("error", {}).get("message", response.text)
+        except (json.JSONDecodeError, KeyError):
+            message = response.text
+
+        if response.status_code == 401:
+            raise ResponsesAuthenticationError(message)
+        elif response.status_code == 429:
+            raise ResponsesRateLimitError(message)
+        elif response.status_code == 400:
+            raise ResponsesInvalidRequestError(message)
+        else:
+            raise ResponsesAPIError(message, status_code=response.status_code)
+
+    def _extract_text_from_response(self, response_resource: ResponseResource) -> str:
+        """Extract text content from a response resource."""
+        text_parts = []
+        for output_item in response_resource.output:
+            if output_item.type == "message" and output_item.content:
+                for content in output_item.content:
+                    if isinstance(content, dict) and content.get("type") == "output_text":
+                        text_parts.append(content.get("text", ""))
+                    elif hasattr(content, "type") and content.type == "output_text":
+                        text_parts.append(content.text)
+        return "".join(text_parts)
+
+    def _set_usage_from_response(
+        self, response: Union[Response, AsyncResponse], response_resource: ResponseResource
+    ) -> None:
+        """Set usage information on the llm response object."""
+        if response_resource.usage:
+            response.set_usage(
+                input=response_resource.usage.input_tokens,
+                output=response_resource.usage.output_tokens,
+            )
+
+    def _extract_tool_calls_from_response(
+        self, response: Union[Response, AsyncResponse], response_resource: ResponseResource
+    ) -> None:
+        """Extract and add tool calls from response resource."""
+        for output_item in response_resource.output:
+            if output_item.type == "function_call":
+                response.add_tool_call(
+                    name=output_item.name,
+                    arguments=json.loads(output_item.arguments or "{}"),
+                    tool_call_id=output_item.call_id,
+                )
+
+
+# ============================================================================
+# Sync Model
+# ============================================================================
+
+
+class ResponsesModel(_SharedResponses, KeyModel):
+    """Synchronous model for OpenResponses API."""
+
+    def execute(
+        self,
+        prompt: Prompt,
+        stream: bool,
+        response: Response,
+        conversation: Optional[Conversation],
+        key: Optional[str] = None,
+    ) -> Iterator[str]:
+        """
+        Execute the model and yield text chunks.
+
+        Args:
+            prompt: The prompt to send to the model.
+            stream: Whether to stream the response.
+            response: The llm Response object to populate.
+            conversation: Optional conversation for context.
+            key: API key to use.
+
+        Yields:
+            Text chunks from the model response.
+        """
+        api_key = key or self.key or self.get_key(key)
+        body = self._build_request_body(prompt, stream, conversation)
+        headers = self._get_headers(api_key)
+        url = f"{self.api_base}/responses"
+
+        with httpx.Client() as client:
+            if stream:
+                yield from self._execute_streaming(client, url, headers, body, response)
+            else:
+                yield from self._execute_non_streaming(client, url, headers, body, response)
+
+    def _execute_non_streaming(
+        self,
+        client: httpx.Client,
+        url: str,
+        headers: Dict[str, str],
+        body: Dict[str, Any],
+        response: Response,
+    ) -> Iterator[str]:
+        """Execute non-streaming request."""
+        http_response = client.post(url, headers=headers, json=body)
+
+        if http_response.status_code != 200:
+            self._handle_error_response(http_response)
+
+        response_resource = ResponseResource(**http_response.json())
+        response.response_json = http_response.json()
+
+        # Set usage
+        self._set_usage_from_response(response, response_resource)
+
+        # Extract tool calls
+        self._extract_tool_calls_from_response(response, response_resource)
+
+        # Yield the complete text
+        text = self._extract_text_from_response(response_resource)
+        if text:
+            yield text
+
+    def _execute_streaming(
+        self,
+        client: httpx.Client,
+        url: str,
+        headers: Dict[str, str],
+        body: Dict[str, Any],
+        response: Response,
+    ) -> Iterator[str]:
+        """Execute streaming request."""
+        with client.stream("POST", url, headers=headers, json=body) as http_response:
+            if http_response.status_code != 200:
+                # Read the full response for error handling
+                http_response.read()
+                self._handle_error_response(http_response)
+
+            for line in http_response.iter_lines():
+                if not line:
+                    continue
+
+                event = parse_sse_event(line)
+                if event is None:
+                    continue
+
+                # Handle text delta events
+                if isinstance(event, ResponseOutputTextDeltaEvent):
+                    yield event.delta
+
+                # Handle completed event - extract usage and tool calls
+                elif isinstance(event, ResponseCompletedEvent):
+                    response.response_json = event.response.model_dump()
+                    self._set_usage_from_response(response, event.response)
+                    self._extract_tool_calls_from_response(response, event.response)
+
+
+# ============================================================================
+# Async Model
+# ============================================================================
+
+
+class AsyncResponsesModel(_SharedResponses, AsyncKeyModel):
+    """Asynchronous model for OpenResponses API."""
+
+    async def execute(
+        self,
+        prompt: Prompt,
+        stream: bool,
+        response: AsyncResponse,
+        conversation: Optional[AsyncConversation],
+        key: Optional[str] = None,
+    ) -> AsyncGenerator[str, None]:
+        """
+        Execute the model and yield text chunks asynchronously.
+
+        Args:
+            prompt: The prompt to send to the model.
+            stream: Whether to stream the response.
+            response: The llm AsyncResponse object to populate.
+            conversation: Optional conversation for context.
+            key: API key to use.
+
+        Yields:
+            Text chunks from the model response.
+        """
+        api_key = key or self.key or self.get_key(key)
+        body = self._build_request_body(prompt, stream, conversation)
+        headers = self._get_headers(api_key)
+        url = f"{self.api_base}/responses"
+
+        async with httpx.AsyncClient() as client:
+            if stream:
+                async for chunk in self._execute_streaming_async(client, url, headers, body, response):
+                    yield chunk
+            else:
+                async for chunk in self._execute_non_streaming_async(client, url, headers, body, response):
+                    yield chunk
+
+    async def _execute_non_streaming_async(
+        self,
+        client: httpx.AsyncClient,
+        url: str,
+        headers: Dict[str, str],
+        body: Dict[str, Any],
+        response: AsyncResponse,
+    ) -> AsyncGenerator[str, None]:
+        """Execute non-streaming request asynchronously."""
+        http_response = await client.post(url, headers=headers, json=body)
+
+        if http_response.status_code != 200:
+            self._handle_error_response(http_response)
+
+        response_resource = ResponseResource(**http_response.json())
+        response.response_json = http_response.json()
+
+        # Set usage
+        self._set_usage_from_response(response, response_resource)
+
+        # Extract tool calls
+        self._extract_tool_calls_from_response(response, response_resource)
+
+        # Yield the complete text
+        text = self._extract_text_from_response(response_resource)
+        if text:
+            yield text
+
+    async def _execute_streaming_async(
+        self,
+        client: httpx.AsyncClient,
+        url: str,
+        headers: Dict[str, str],
+        body: Dict[str, Any],
+        response: AsyncResponse,
+    ) -> AsyncGenerator[str, None]:
+        """Execute streaming request asynchronously."""
+        async with client.stream("POST", url, headers=headers, json=body) as http_response:
+            if http_response.status_code != 200:
+                await http_response.aread()
+                self._handle_error_response(http_response)
+
+            async for line in http_response.aiter_lines():
+                if not line:
+                    continue
+
+                event = parse_sse_event(line)
+                if event is None:
+                    continue
+
+                # Handle text delta events
+                if isinstance(event, ResponseOutputTextDeltaEvent):
+                    yield event.delta
+
+                # Handle completed event - extract usage and tool calls
+                elif isinstance(event, ResponseCompletedEvent):
+                    response.response_json = event.response.model_dump()
+                    self._set_usage_from_response(response, event.response)
+                    self._extract_tool_calls_from_response(response, event.response)

--- a/llm/responses.py
+++ b/llm/responses.py
@@ -384,18 +384,20 @@ class _SharedResponses:
     model_id: str
     api_base: str
     can_stream: bool = True
-    supports_schema: bool = False
-    supports_tools: bool = True
 
     def __init__(
         self,
         model_id: str,
         api_base: Optional[str] = None,
         key: Optional[str] = None,
+        supports_schema: bool = False,
+        supports_tools: bool = True,
     ):
         self.model_id = model_id
         self.api_base = api_base or "https://api.openai.com/v1"
         self.key = key
+        self.supports_schema = supports_schema
+        self.supports_tools = supports_tools
 
     def __str__(self) -> str:
         return f"OpenResponses: {self.model_id}"

--- a/llm/responses.py
+++ b/llm/responses.py
@@ -450,6 +450,37 @@ class _SharedResponses:
                             "content": [{"type": "output_text", "text": response_text}],
                         }
                     )
+                # Add tool calls from assistant's response
+                tool_calls = resp.tool_calls()
+                if tool_calls:
+                    for tool_call in tool_calls:
+                        input_items.append(
+                            {
+                                "type": "function_call",
+                                "call_id": tool_call.tool_call_id,
+                                "name": tool_call.name,
+                                "arguments": json.dumps(tool_call.arguments),
+                            }
+                        )
+                # Add tool results for this response's tool calls
+                for tool_result in prev_response.prompt.tool_results:
+                    input_items.append(
+                        {
+                            "type": "function_call_output",
+                            "call_id": tool_result.tool_call_id,
+                            "output": tool_result.output,
+                        }
+                    )
+
+        # Add tool results from current prompt (for chain continuation)
+        for tool_result in prompt.tool_results:
+            input_items.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": tool_result.tool_call_id,
+                    "output": tool_result.output,
+                }
+            )
 
         if prompt.prompt:
             input_items.append(

--- a/llm/responses.py
+++ b/llm/responses.py
@@ -16,18 +16,21 @@ from typing import (
     List,
     Optional,
     Union,
+    cast,
 )
 
 import httpx
 from pydantic import BaseModel, ConfigDict, Field
 
 from llm import AsyncKeyModel, KeyModel, Prompt
-from llm.models import AsyncConversation, AsyncResponse, Conversation, Response, _Options
-
-
-# ============================================================================
-# Error Classes
-# ============================================================================
+from llm.models import (
+    AsyncConversation,
+    AsyncResponse,
+    Conversation,
+    Response,
+    ToolCall,
+    _Options,
+)
 
 
 class ResponsesAPIError(Exception):
@@ -59,11 +62,6 @@ class ResponsesInvalidRequestError(ResponsesAPIError):
         super().__init__(message, status_code=400)
 
 
-# ============================================================================
-# Pydantic Models - Usage
-# ============================================================================
-
-
 class InputTokensDetails(BaseModel):
     """Details about input token usage."""
 
@@ -86,11 +84,6 @@ class Usage(BaseModel):
     output_tokens_details: Optional[OutputTokensDetails] = None
 
 
-# ============================================================================
-# Pydantic Models - Content
-# ============================================================================
-
-
 class OutputTextContent(BaseModel):
     """Text content in an output message."""
 
@@ -110,11 +103,6 @@ class FunctionCallContent(BaseModel):
     arguments: str = ""
 
 
-# ============================================================================
-# Pydantic Models - Output Items
-# ============================================================================
-
-
 class OutputItem(BaseModel):
     """An output item from the model (message or function call)."""
 
@@ -125,15 +113,9 @@ class OutputItem(BaseModel):
     status: Optional[str] = None
     role: Optional[str] = None
     content: Optional[List[Any]] = None
-    # For function calls
     call_id: Optional[str] = None
     name: Optional[str] = None
     arguments: Optional[str] = None
-
-
-# ============================================================================
-# Pydantic Models - Text Format
-# ============================================================================
 
 
 class TextFormat(BaseModel):
@@ -148,11 +130,6 @@ class TextField(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     format: Optional[TextFormat] = None
-
-
-# ============================================================================
-# Pydantic Models - Response Resource
-# ============================================================================
 
 
 class ResponseResource(BaseModel):
@@ -199,11 +176,6 @@ class ResponseResource(BaseModel):
     prompt_cache_retention: Optional[str] = None
     conversation: Optional[Any] = None
     billing: Optional[Any] = None
-
-
-# ============================================================================
-# Pydantic Models - Streaming Events
-# ============================================================================
 
 
 class ResponseStreamEvent(BaseModel):
@@ -320,12 +292,6 @@ class ResponseFunctionCallArgumentsDoneEvent(ResponseStreamEvent):
     arguments: str
 
 
-# ============================================================================
-# SSE Parser
-# ============================================================================
-
-
-# Map event types to their Pydantic models
 EVENT_TYPE_MAP = {
     "response.created": ResponseCreatedEvent,
     "response.in_progress": ResponseInProgressEvent,
@@ -357,36 +323,25 @@ def parse_sse_event(line: str) -> Optional[ResponseStreamEvent]:
     """
     line = line.strip()
 
-    # Empty lines
     if not line:
         return None
 
-    # Comment lines
     if line.startswith(":"):
         return None
 
-    # Data lines
     if line.startswith("data:"):
         data = line[5:].strip()
 
-        # [DONE] marker
         if data == "[DONE]":
             return None
 
-        # Parse JSON
         event_data = json.loads(data)
         event_type = event_data.get("type", "")
 
-        # Get the appropriate event class
         event_class = EVENT_TYPE_MAP.get(event_type, ResponseStreamEvent)
         return event_class(**event_data)
 
     return None
-
-
-# ============================================================================
-# Model Options
-# ============================================================================
 
 
 class ResponsesOptions(_Options):
@@ -423,23 +378,14 @@ class ResponsesOptions(_Options):
     )
 
 
-# ============================================================================
-# Shared Implementation
-# ============================================================================
-
-
 class _SharedResponses:
     """Shared implementation for sync and async responses models."""
 
     model_id: str
     api_base: str
-    needs_key: str = "openresponses"
-    key_env_var: str = "OPENRESPONSES_API_KEY"
     can_stream: bool = True
     supports_schema: bool = False
     supports_tools: bool = True
-
-    Options = ResponsesOptions
 
     def __init__(
         self,
@@ -466,74 +412,90 @@ class _SharedResponses:
             "stream": stream,
         }
 
-        # Build input from prompt
         input_items = []
 
-        # Add system message if present
         if prompt.system:
-            input_items.append({
-                "type": "message",
-                "role": "developer",
-                "content": [{"type": "input_text", "text": prompt.system}],
-            })
+            input_items.append(
+                {
+                    "type": "message",
+                    "role": "developer",
+                    "content": [{"type": "input_text", "text": prompt.system}],
+                }
+            )
 
-        # Add conversation history if present
         if conversation is not None:
             for prev_response in conversation.responses:
-                # Add user message
                 if prev_response.prompt.prompt:
-                    input_items.append({
-                        "type": "message",
-                        "role": "user",
-                        "content": [{"type": "input_text", "text": prev_response.prompt.prompt}],
-                    })
-                # Add assistant response
-                response_text = prev_response.text()
+                    input_items.append(
+                        {
+                            "type": "message",
+                            "role": "user",
+                            "content": [
+                                {
+                                    "type": "input_text",
+                                    "text": prev_response.prompt.prompt,
+                                }
+                            ],
+                        }
+                    )
+                resp = cast(Response, prev_response)
+                response_text = resp.text()
                 if response_text:
-                    input_items.append({
-                        "type": "message",
-                        "role": "assistant",
-                        "content": [{"type": "output_text", "text": response_text}],
-                    })
+                    input_items.append(
+                        {
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [{"type": "output_text", "text": response_text}],
+                        }
+                    )
 
-        # Add current user message
         if prompt.prompt:
-            input_items.append({
-                "type": "message",
-                "role": "user",
-                "content": [{"type": "input_text", "text": prompt.prompt}],
-            })
+            input_items.append(
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": prompt.prompt}],
+                }
+            )
 
         if input_items:
             body["input"] = input_items
 
-        # Add options
         options = prompt.options
         if options:
             if hasattr(options, "temperature") and options.temperature is not None:
                 body["temperature"] = options.temperature
-            if hasattr(options, "max_output_tokens") and options.max_output_tokens is not None:
+            if (
+                hasattr(options, "max_output_tokens")
+                and options.max_output_tokens is not None
+            ):
                 body["max_output_tokens"] = options.max_output_tokens
             if hasattr(options, "top_p") and options.top_p is not None:
                 body["top_p"] = options.top_p
-            if hasattr(options, "frequency_penalty") and options.frequency_penalty is not None:
+            if (
+                hasattr(options, "frequency_penalty")
+                and options.frequency_penalty is not None
+            ):
                 body["frequency_penalty"] = options.frequency_penalty
-            if hasattr(options, "presence_penalty") and options.presence_penalty is not None:
+            if (
+                hasattr(options, "presence_penalty")
+                and options.presence_penalty is not None
+            ):
                 body["presence_penalty"] = options.presence_penalty
 
-        # Add tools if present
         if prompt.tools:
             tools = []
             for tool in prompt.tools:
-                tools.append({
-                    "type": "function",
-                    "name": tool.name,
-                    "description": tool.description,
-                    "parameters": tool.input_schema,
-                })
+                tools.append(
+                    {
+                        "type": "function",
+                        "name": tool.name,
+                        "description": tool.description,
+                        "parameters": tool.input_schema,
+                    }
+                )
             body["tools"] = tools
 
-        # Add schema if present (for structured output)
         if prompt.schema:
             schema_dict = prompt.schema
             if hasattr(prompt.schema, "model_json_schema"):
@@ -559,26 +521,25 @@ class _SharedResponses:
             role = msg.get("role", "user")
             content = msg.get("content", "")
 
-            # Map roles
             if role == "system":
                 role = "developer"
-            elif role == "assistant":
-                content_type = "output_text"
-            else:
-                content_type = "input_text"
 
             if role == "assistant":
-                input_items.append({
-                    "type": "message",
-                    "role": role,
-                    "content": [{"type": "output_text", "text": content}],
-                })
+                input_items.append(
+                    {
+                        "type": "message",
+                        "role": role,
+                        "content": [{"type": "output_text", "text": content}],
+                    }
+                )
             else:
-                input_items.append({
-                    "type": "message",
-                    "role": role,
-                    "content": [{"type": "input_text", "text": content}],
-                })
+                input_items.append(
+                    {
+                        "type": "message",
+                        "role": role,
+                        "content": [{"type": "input_text", "text": content}],
+                    }
+                )
 
         return input_items
 
@@ -612,14 +573,19 @@ class _SharedResponses:
         for output_item in response_resource.output:
             if output_item.type == "message" and output_item.content:
                 for content in output_item.content:
-                    if isinstance(content, dict) and content.get("type") == "output_text":
+                    if (
+                        isinstance(content, dict)
+                        and content.get("type") == "output_text"
+                    ):
                         text_parts.append(content.get("text", ""))
                     elif hasattr(content, "type") and content.type == "output_text":
                         text_parts.append(content.text)
         return "".join(text_parts)
 
     def _set_usage_from_response(
-        self, response: Union[Response, AsyncResponse], response_resource: ResponseResource
+        self,
+        response: Union[Response, AsyncResponse],
+        response_resource: ResponseResource,
     ) -> None:
         """Set usage information on the llm response object."""
         if response_resource.usage:
@@ -629,25 +595,29 @@ class _SharedResponses:
             )
 
     def _extract_tool_calls_from_response(
-        self, response: Union[Response, AsyncResponse], response_resource: ResponseResource
+        self,
+        response: Union[Response, AsyncResponse],
+        response_resource: ResponseResource,
     ) -> None:
         """Extract and add tool calls from response resource."""
         for output_item in response_resource.output:
             if output_item.type == "function_call":
-                response.add_tool_call(
-                    name=output_item.name,
+                tool_call = ToolCall(
+                    name=output_item.name or "",
                     arguments=json.loads(output_item.arguments or "{}"),
                     tool_call_id=output_item.call_id,
                 )
-
-
-# ============================================================================
-# Sync Model
-# ============================================================================
+                response.add_tool_call(tool_call)
 
 
 class ResponsesModel(_SharedResponses, KeyModel):
     """Synchronous model for OpenResponses API."""
+
+    needs_key = "openresponses"
+    key_env_var = "OPENRESPONSES_API_KEY"
+
+    class Options(ResponsesOptions):
+        pass
 
     def execute(
         self,
@@ -657,20 +627,10 @@ class ResponsesModel(_SharedResponses, KeyModel):
         conversation: Optional[Conversation],
         key: Optional[str] = None,
     ) -> Iterator[str]:
-        """
-        Execute the model and yield text chunks.
-
-        Args:
-            prompt: The prompt to send to the model.
-            stream: Whether to stream the response.
-            response: The llm Response object to populate.
-            conversation: Optional conversation for context.
-            key: API key to use.
-
-        Yields:
-            Text chunks from the model response.
-        """
+        """Execute the model and yield text chunks."""
         api_key = key or self.key or self.get_key(key)
+        if not api_key:
+            raise ResponsesAuthenticationError("No API key provided")
         body = self._build_request_body(prompt, stream, conversation)
         headers = self._get_headers(api_key)
         url = f"{self.api_base}/responses"
@@ -679,7 +639,9 @@ class ResponsesModel(_SharedResponses, KeyModel):
             if stream:
                 yield from self._execute_streaming(client, url, headers, body, response)
             else:
-                yield from self._execute_non_streaming(client, url, headers, body, response)
+                yield from self._execute_non_streaming(
+                    client, url, headers, body, response
+                )
 
     def _execute_non_streaming(
         self,
@@ -698,13 +660,9 @@ class ResponsesModel(_SharedResponses, KeyModel):
         response_resource = ResponseResource(**http_response.json())
         response.response_json = http_response.json()
 
-        # Set usage
         self._set_usage_from_response(response, response_resource)
-
-        # Extract tool calls
         self._extract_tool_calls_from_response(response, response_resource)
 
-        # Yield the complete text
         text = self._extract_text_from_response(response_resource)
         if text:
             yield text
@@ -720,7 +678,6 @@ class ResponsesModel(_SharedResponses, KeyModel):
         """Execute streaming request."""
         with client.stream("POST", url, headers=headers, json=body) as http_response:
             if http_response.status_code != 200:
-                # Read the full response for error handling
                 http_response.read()
                 self._handle_error_response(http_response)
 
@@ -732,24 +689,23 @@ class ResponsesModel(_SharedResponses, KeyModel):
                 if event is None:
                     continue
 
-                # Handle text delta events
                 if isinstance(event, ResponseOutputTextDeltaEvent):
                     yield event.delta
 
-                # Handle completed event - extract usage and tool calls
                 elif isinstance(event, ResponseCompletedEvent):
                     response.response_json = event.response.model_dump()
                     self._set_usage_from_response(response, event.response)
                     self._extract_tool_calls_from_response(response, event.response)
 
 
-# ============================================================================
-# Async Model
-# ============================================================================
-
-
 class AsyncResponsesModel(_SharedResponses, AsyncKeyModel):
     """Asynchronous model for OpenResponses API."""
+
+    needs_key = "openresponses"
+    key_env_var = "OPENRESPONSES_API_KEY"
+
+    class Options(ResponsesOptions):
+        pass
 
     async def execute(
         self,
@@ -759,30 +715,24 @@ class AsyncResponsesModel(_SharedResponses, AsyncKeyModel):
         conversation: Optional[AsyncConversation],
         key: Optional[str] = None,
     ) -> AsyncGenerator[str, None]:
-        """
-        Execute the model and yield text chunks asynchronously.
-
-        Args:
-            prompt: The prompt to send to the model.
-            stream: Whether to stream the response.
-            response: The llm AsyncResponse object to populate.
-            conversation: Optional conversation for context.
-            key: API key to use.
-
-        Yields:
-            Text chunks from the model response.
-        """
+        """Execute the model and yield text chunks asynchronously."""
         api_key = key or self.key or self.get_key(key)
+        if not api_key:
+            raise ResponsesAuthenticationError("No API key provided")
         body = self._build_request_body(prompt, stream, conversation)
         headers = self._get_headers(api_key)
         url = f"{self.api_base}/responses"
 
         async with httpx.AsyncClient() as client:
             if stream:
-                async for chunk in self._execute_streaming_async(client, url, headers, body, response):
+                async for chunk in self._execute_streaming_async(
+                    client, url, headers, body, response
+                ):
                     yield chunk
             else:
-                async for chunk in self._execute_non_streaming_async(client, url, headers, body, response):
+                async for chunk in self._execute_non_streaming_async(
+                    client, url, headers, body, response
+                ):
                     yield chunk
 
     async def _execute_non_streaming_async(
@@ -802,13 +752,9 @@ class AsyncResponsesModel(_SharedResponses, AsyncKeyModel):
         response_resource = ResponseResource(**http_response.json())
         response.response_json = http_response.json()
 
-        # Set usage
         self._set_usage_from_response(response, response_resource)
-
-        # Extract tool calls
         self._extract_tool_calls_from_response(response, response_resource)
 
-        # Yield the complete text
         text = self._extract_text_from_response(response_resource)
         if text:
             yield text
@@ -822,7 +768,9 @@ class AsyncResponsesModel(_SharedResponses, AsyncKeyModel):
         response: AsyncResponse,
     ) -> AsyncGenerator[str, None]:
         """Execute streaming request asynchronously."""
-        async with client.stream("POST", url, headers=headers, json=body) as http_response:
+        async with client.stream(
+            "POST", url, headers=headers, json=body
+        ) as http_response:
             if http_response.status_code != 200:
                 await http_response.aread()
                 self._handle_error_response(http_response)
@@ -835,11 +783,9 @@ class AsyncResponsesModel(_SharedResponses, AsyncKeyModel):
                 if event is None:
                     continue
 
-                # Handle text delta events
                 if isinstance(event, ResponseOutputTextDeltaEvent):
                     yield event.delta
 
-                # Handle completed event - extract usage and tool calls
                 elif isinstance(event, ResponseCompletedEvent):
                     response.response_json = event.response.model_dump()
                     self._set_usage_from_response(response, event.response)

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -1,0 +1,941 @@
+"""
+Tests for llm/responses.py - OpenResponses API client implementation.
+
+Using TDD approach: these tests are written first, then implementation follows.
+"""
+
+import json
+import pytest
+from unittest.mock import MagicMock
+from pytest_httpx import IteratorStream
+
+# These imports will fail until we implement the module
+from llm.responses import (
+    # Pydantic models
+    ResponseResource,
+    Usage,
+    OutputItem,
+    OutputTextContent,
+    # Streaming events
+    ResponseStreamEvent,
+    ResponseCreatedEvent,
+    ResponseCompletedEvent,
+    ResponseOutputTextDeltaEvent,
+    ResponseFunctionCallArgumentsDeltaEvent,
+    ResponseFunctionCallArgumentsDoneEvent,
+    ResponseOutputItemAddedEvent,
+    ResponseOutputItemDoneEvent,
+    # Error classes
+    ResponsesAPIError,
+    ResponsesAuthenticationError,
+    ResponsesRateLimitError,
+    ResponsesInvalidRequestError,
+    # Model classes
+    ResponsesModel,
+    AsyncResponsesModel,
+    # Utilities
+    parse_sse_event,
+)
+
+
+# ============================================================================
+# Test fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def sample_response_json():
+    """Sample non-streaming response from the API."""
+    return {
+        "id": "resp_123abc",
+        "object": "response",
+        "created_at": 1741476777,
+        "completed_at": 1741476778,
+        "status": "completed",
+        "model": "gpt-4o",
+        "incomplete_details": None,
+        "previous_response_id": None,
+        "instructions": None,
+        "input": [],
+        "output": [
+            {
+                "type": "message",
+                "id": "msg_123",
+                "status": "completed",
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": "Hello, world!",
+                        "annotations": [],
+                    }
+                ],
+            }
+        ],
+        "error": None,
+        "tools": [],
+        "tool_choice": "auto",
+        "truncation": "disabled",
+        "parallel_tool_calls": True,
+        "text": {"format": {"type": "text"}},
+        "top_p": 1.0,
+        "presence_penalty": 0.0,
+        "frequency_penalty": 0.0,
+        "top_logprobs": 0,
+        "temperature": 1.0,
+        "reasoning": None,
+        "user": None,
+        "usage": {
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "total_tokens": 15,
+            "input_tokens_details": {"cached_tokens": 0},
+            "output_tokens_details": {"reasoning_tokens": 0},
+        },
+        "max_output_tokens": None,
+        "max_tool_calls": None,
+        "store": False,
+        "background": False,
+        "service_tier": "default",
+        "metadata": {},
+        "safety_identifier": None,
+        "prompt_cache_key": None,
+    }
+
+
+@pytest.fixture
+def sample_streaming_events():
+    """Sample SSE streaming events from the API."""
+    return [
+        {
+            "type": "response.created",
+            "sequence_number": 0,
+            "response": {
+                "id": "resp_123abc",
+                "object": "response",
+                "created_at": 1741476777,
+                "completed_at": None,
+                "status": "in_progress",
+                "model": "gpt-4o",
+                "incomplete_details": None,
+                "previous_response_id": None,
+                "instructions": None,
+                "input": [],
+                "output": [],
+                "error": None,
+                "tools": [],
+                "tool_choice": "auto",
+                "truncation": "disabled",
+                "parallel_tool_calls": True,
+                "text": {"format": {"type": "text"}},
+                "top_p": 1.0,
+                "presence_penalty": 0.0,
+                "frequency_penalty": 0.0,
+                "top_logprobs": 0,
+                "temperature": 1.0,
+                "reasoning": None,
+                "user": None,
+                "usage": None,
+                "max_output_tokens": None,
+                "max_tool_calls": None,
+                "store": False,
+                "background": False,
+                "service_tier": "default",
+                "metadata": {},
+                "safety_identifier": None,
+                "prompt_cache_key": None,
+            },
+        },
+        {
+            "type": "response.output_item.added",
+            "sequence_number": 1,
+            "output_index": 0,
+            "item": {
+                "type": "message",
+                "id": "msg_123",
+                "status": "in_progress",
+                "role": "assistant",
+                "content": [],
+            },
+        },
+        {
+            "type": "response.output_text.delta",
+            "sequence_number": 2,
+            "item_id": "msg_123",
+            "output_index": 0,
+            "content_index": 0,
+            "delta": "Hello",
+            "logprobs": [],
+        },
+        {
+            "type": "response.output_text.delta",
+            "sequence_number": 3,
+            "item_id": "msg_123",
+            "output_index": 0,
+            "content_index": 0,
+            "delta": ", world!",
+            "logprobs": [],
+        },
+        {
+            "type": "response.completed",
+            "sequence_number": 4,
+            "response": {
+                "id": "resp_123abc",
+                "object": "response",
+                "created_at": 1741476777,
+                "completed_at": 1741476778,
+                "status": "completed",
+                "model": "gpt-4o",
+                "incomplete_details": None,
+                "previous_response_id": None,
+                "instructions": None,
+                "input": [],
+                "output": [
+                    {
+                        "type": "message",
+                        "id": "msg_123",
+                        "status": "completed",
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "output_text",
+                                "text": "Hello, world!",
+                                "annotations": [],
+                            }
+                        ],
+                    }
+                ],
+                "error": None,
+                "tools": [],
+                "tool_choice": "auto",
+                "truncation": "disabled",
+                "parallel_tool_calls": True,
+                "text": {"format": {"type": "text"}},
+                "top_p": 1.0,
+                "presence_penalty": 0.0,
+                "frequency_penalty": 0.0,
+                "top_logprobs": 0,
+                "temperature": 1.0,
+                "reasoning": None,
+                "user": None,
+                "usage": {
+                    "input_tokens": 10,
+                    "output_tokens": 5,
+                    "total_tokens": 15,
+                    "input_tokens_details": {"cached_tokens": 0},
+                    "output_tokens_details": {"reasoning_tokens": 0},
+                },
+                "max_output_tokens": None,
+                "max_tool_calls": None,
+                "store": False,
+                "background": False,
+                "service_tier": "default",
+                "metadata": {},
+                "safety_identifier": None,
+                "prompt_cache_key": None,
+            },
+        },
+    ]
+
+
+def make_sse_stream(events):
+    """Convert a list of event dicts to SSE format bytes generator."""
+    for event in events:
+        yield f"data: {json.dumps(event)}\n\n".encode("utf-8")
+
+
+# ============================================================================
+# Test Pydantic Models
+# ============================================================================
+
+
+class TestPydanticModels:
+    """Tests for Pydantic model parsing and validation."""
+
+    def test_usage_model(self):
+        """Test Usage model parsing."""
+        usage_data = {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "total_tokens": 150,
+            "input_tokens_details": {"cached_tokens": 10},
+            "output_tokens_details": {"reasoning_tokens": 5},
+        }
+        usage = Usage(**usage_data)
+        assert usage.input_tokens == 100
+        assert usage.output_tokens == 50
+        assert usage.total_tokens == 150
+
+    def test_output_text_content_model(self):
+        """Test OutputTextContent model parsing."""
+        content_data = {
+            "type": "output_text",
+            "text": "Hello, world!",
+            "annotations": [],
+        }
+        content = OutputTextContent(**content_data)
+        assert content.type == "output_text"
+        assert content.text == "Hello, world!"
+
+    def test_output_item_message(self):
+        """Test OutputItem model for message type."""
+        item_data = {
+            "type": "message",
+            "id": "msg_123",
+            "status": "completed",
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "output_text",
+                    "text": "Hello!",
+                    "annotations": [],
+                }
+            ],
+        }
+        item = OutputItem(**item_data)
+        assert item.type == "message"
+        assert item.id == "msg_123"
+        assert item.role == "assistant"
+
+    def test_response_resource_model(self, sample_response_json):
+        """Test ResponseResource model parsing."""
+        response = ResponseResource(**sample_response_json)
+        assert response.id == "resp_123abc"
+        assert response.object == "response"
+        assert response.status == "completed"
+        assert response.model == "gpt-4o"
+        assert len(response.output) == 1
+        assert response.output[0].type == "message"
+
+    def test_response_resource_with_usage(self, sample_response_json):
+        """Test ResponseResource with usage data."""
+        response = ResponseResource(**sample_response_json)
+        assert response.usage is not None
+        assert response.usage.input_tokens == 10
+        assert response.usage.output_tokens == 5
+
+
+# ============================================================================
+# Test Streaming Event Models
+# ============================================================================
+
+
+class TestStreamingEvents:
+    """Tests for streaming event model parsing."""
+
+    def test_response_created_event(self, sample_streaming_events):
+        """Test parsing response.created event."""
+        event_data = sample_streaming_events[0]
+        event = ResponseCreatedEvent(**event_data)
+        assert event.type == "response.created"
+        assert event.sequence_number == 0
+        assert event.response.id == "resp_123abc"
+
+    def test_response_output_text_delta_event(self, sample_streaming_events):
+        """Test parsing response.output_text.delta event."""
+        event_data = sample_streaming_events[2]
+        event = ResponseOutputTextDeltaEvent(**event_data)
+        assert event.type == "response.output_text.delta"
+        assert event.delta == "Hello"
+        assert event.item_id == "msg_123"
+        assert event.output_index == 0
+        assert event.content_index == 0
+
+    def test_response_completed_event(self, sample_streaming_events):
+        """Test parsing response.completed event."""
+        event_data = sample_streaming_events[4]
+        event = ResponseCompletedEvent(**event_data)
+        assert event.type == "response.completed"
+        assert event.response.status == "completed"
+        assert event.response.usage.input_tokens == 10
+
+    def test_parse_sse_event_text_delta(self):
+        """Test parse_sse_event with text delta."""
+        line = 'data: {"type": "response.output_text.delta", "sequence_number": 1, "item_id": "msg_1", "output_index": 0, "content_index": 0, "delta": "Hi", "logprobs": []}'
+        event = parse_sse_event(line)
+        assert isinstance(event, ResponseOutputTextDeltaEvent)
+        assert event.delta == "Hi"
+
+    def test_parse_sse_event_created(self, sample_streaming_events):
+        """Test parse_sse_event with response.created."""
+        line = f"data: {json.dumps(sample_streaming_events[0])}"
+        event = parse_sse_event(line)
+        assert isinstance(event, ResponseCreatedEvent)
+
+    def test_parse_sse_event_completed(self, sample_streaming_events):
+        """Test parse_sse_event with response.completed."""
+        line = f"data: {json.dumps(sample_streaming_events[4])}"
+        event = parse_sse_event(line)
+        assert isinstance(event, ResponseCompletedEvent)
+
+
+# ============================================================================
+# Test Function Call Events
+# ============================================================================
+
+
+class TestFunctionCallEvents:
+    """Tests for function call streaming events."""
+
+    def test_function_call_arguments_delta_event(self):
+        """Test parsing function call arguments delta event."""
+        event_data = {
+            "type": "response.function_call_arguments.delta",
+            "sequence_number": 5,
+            "item_id": "fc_123",
+            "output_index": 0,
+            "delta": '{"na',
+        }
+        event = ResponseFunctionCallArgumentsDeltaEvent(**event_data)
+        assert event.type == "response.function_call_arguments.delta"
+        assert event.delta == '{"na'
+        assert event.item_id == "fc_123"
+
+    def test_function_call_arguments_done_event(self):
+        """Test parsing function call arguments done event."""
+        event_data = {
+            "type": "response.function_call_arguments.done",
+            "sequence_number": 6,
+            "item_id": "fc_123",
+            "output_index": 0,
+            "arguments": '{"name": "test"}',
+        }
+        event = ResponseFunctionCallArgumentsDoneEvent(**event_data)
+        assert event.type == "response.function_call_arguments.done"
+        assert event.arguments == '{"name": "test"}'
+
+
+# ============================================================================
+# Test Error Classes
+# ============================================================================
+
+
+class TestErrorClasses:
+    """Tests for custom error classes."""
+
+    def test_responses_api_error(self):
+        """Test base ResponsesAPIError."""
+        error = ResponsesAPIError("Something went wrong", status_code=500)
+        assert str(error) == "Something went wrong"
+        assert error.status_code == 500
+
+    def test_responses_authentication_error(self):
+        """Test ResponsesAuthenticationError."""
+        error = ResponsesAuthenticationError("Invalid API key")
+        assert isinstance(error, ResponsesAPIError)
+        assert error.status_code == 401
+
+    def test_responses_rate_limit_error(self):
+        """Test ResponsesRateLimitError."""
+        error = ResponsesRateLimitError("Rate limit exceeded")
+        assert isinstance(error, ResponsesAPIError)
+        assert error.status_code == 429
+
+    def test_responses_invalid_request_error(self):
+        """Test ResponsesInvalidRequestError."""
+        error = ResponsesInvalidRequestError("Invalid parameter")
+        assert isinstance(error, ResponsesAPIError)
+        assert error.status_code == 400
+
+
+# ============================================================================
+# Test Sync Model
+# ============================================================================
+
+
+class TestResponsesModel:
+    """Tests for the synchronous ResponsesModel class."""
+
+    def test_model_init(self):
+        """Test model initialization."""
+        model = ResponsesModel(
+            model_id="gpt-4o",
+            api_base="https://api.example.com/v1",
+        )
+        assert model.model_id == "gpt-4o"
+        assert model.api_base == "https://api.example.com/v1"
+        assert model.needs_key == "openresponses"
+
+    def test_model_default_api_base(self):
+        """Test model uses default OpenAI API base."""
+        model = ResponsesModel(model_id="gpt-4o")
+        assert model.api_base == "https://api.openai.com/v1"
+
+    @pytest.fixture
+    def mocked_non_streaming_response(self, httpx_mock, sample_response_json):
+        """Mock a non-streaming response."""
+        httpx_mock.add_response(
+            method="POST",
+            url="https://api.openai.com/v1/responses",
+            json=sample_response_json,
+            headers={"Content-Type": "application/json"},
+        )
+        return httpx_mock
+
+    @pytest.fixture
+    def mocked_streaming_response(self, httpx_mock, sample_streaming_events):
+        """Mock a streaming response."""
+        httpx_mock.add_response(
+            method="POST",
+            url="https://api.openai.com/v1/responses",
+            stream=IteratorStream(make_sse_stream(sample_streaming_events)),
+            headers={"Content-Type": "text/event-stream"},
+        )
+        return httpx_mock
+
+    def test_execute_non_streaming(self, mocked_non_streaming_response):
+        """Test non-streaming execution."""
+        model = ResponsesModel(model_id="gpt-4o")
+
+        # Create a mock prompt and response
+        from llm import Prompt
+
+        prompt = Prompt(
+            prompt="Hello",
+            model=model,
+            options=model.Options(),
+        )
+
+        # Mock the llm Response object
+        mock_response = MagicMock()
+        mock_response.response_json = None
+
+        # Execute
+        chunks = list(model.execute(prompt, stream=False, response=mock_response, conversation=None, key="test-key"))
+
+        assert chunks == ["Hello, world!"]
+
+    def test_execute_streaming(self, mocked_streaming_response):
+        """Test streaming execution yields text deltas."""
+        model = ResponsesModel(model_id="gpt-4o")
+
+        from llm import Prompt
+
+        prompt = Prompt(
+            prompt="Hello",
+            model=model,
+            options=model.Options(),
+        )
+
+        mock_response = MagicMock()
+        mock_response.response_json = None
+
+        chunks = list(model.execute(prompt, stream=True, response=mock_response, conversation=None, key="test-key"))
+
+        # Should yield the text deltas
+        assert chunks == ["Hello", ", world!"]
+
+    def test_execute_sets_usage(self, mocked_non_streaming_response):
+        """Test that execution sets usage on response."""
+        model = ResponsesModel(model_id="gpt-4o")
+
+        from llm import Prompt
+
+        prompt = Prompt(
+            prompt="Hello",
+            model=model,
+            options=model.Options(),
+        )
+
+        mock_response = MagicMock()
+        mock_response.response_json = None
+
+        list(model.execute(prompt, stream=False, response=mock_response, conversation=None, key="test-key"))
+
+        # Check that set_usage was called
+        mock_response.set_usage.assert_called()
+
+    @pytest.fixture
+    def mocked_error_response(self, httpx_mock):
+        """Mock an error response."""
+        httpx_mock.add_response(
+            method="POST",
+            url="https://api.openai.com/v1/responses",
+            status_code=401,
+            json={"error": {"message": "Invalid API key", "type": "authentication_error"}},
+            headers={"Content-Type": "application/json"},
+        )
+        return httpx_mock
+
+    def test_execute_authentication_error(self, mocked_error_response):
+        """Test that authentication errors raise ResponsesAuthenticationError."""
+        model = ResponsesModel(model_id="gpt-4o")
+
+        from llm import Prompt
+
+        prompt = Prompt(
+            prompt="Hello",
+            model=model,
+            options=model.Options(),
+        )
+
+        mock_response = MagicMock()
+
+        with pytest.raises(ResponsesAuthenticationError):
+            list(model.execute(prompt, stream=False, response=mock_response, conversation=None, key="bad-key"))
+
+
+# ============================================================================
+# Test Async Model
+# ============================================================================
+
+
+class TestAsyncResponsesModel:
+    """Tests for the asynchronous AsyncResponsesModel class."""
+
+    def test_async_model_init(self):
+        """Test async model initialization."""
+        model = AsyncResponsesModel(
+            model_id="gpt-4o",
+            api_base="https://api.example.com/v1",
+        )
+        assert model.model_id == "gpt-4o"
+        assert model.api_base == "https://api.example.com/v1"
+        assert model.needs_key == "openresponses"
+
+    @pytest.fixture
+    def mocked_async_non_streaming_response(self, httpx_mock, sample_response_json):
+        """Mock an async non-streaming response."""
+        httpx_mock.add_response(
+            method="POST",
+            url="https://api.openai.com/v1/responses",
+            json=sample_response_json,
+            headers={"Content-Type": "application/json"},
+        )
+        return httpx_mock
+
+    @pytest.fixture
+    def mocked_async_streaming_response(self, httpx_mock, sample_streaming_events):
+        """Mock an async streaming response."""
+        httpx_mock.add_response(
+            method="POST",
+            url="https://api.openai.com/v1/responses",
+            stream=IteratorStream(make_sse_stream(sample_streaming_events)),
+            headers={"Content-Type": "text/event-stream"},
+        )
+        return httpx_mock
+
+    @pytest.mark.asyncio
+    async def test_async_execute_non_streaming(self, mocked_async_non_streaming_response):
+        """Test async non-streaming execution."""
+        model = AsyncResponsesModel(model_id="gpt-4o")
+
+        from llm import Prompt
+
+        prompt = Prompt(
+            prompt="Hello",
+            model=model,
+            options=model.Options(),
+        )
+
+        mock_response = MagicMock()
+        mock_response.response_json = None
+
+        chunks = []
+        async for chunk in model.execute(prompt, stream=False, response=mock_response, conversation=None, key="test-key"):
+            chunks.append(chunk)
+
+        assert chunks == ["Hello, world!"]
+
+    @pytest.mark.asyncio
+    async def test_async_execute_streaming(self, mocked_async_streaming_response):
+        """Test async streaming execution yields text deltas."""
+        model = AsyncResponsesModel(model_id="gpt-4o")
+
+        from llm import Prompt
+
+        prompt = Prompt(
+            prompt="Hello",
+            model=model,
+            options=model.Options(),
+        )
+
+        mock_response = MagicMock()
+        mock_response.response_json = None
+
+        chunks = []
+        async for chunk in model.execute(prompt, stream=True, response=mock_response, conversation=None, key="test-key"):
+            chunks.append(chunk)
+
+        assert chunks == ["Hello", ", world!"]
+
+
+# ============================================================================
+# Test Tool Calls
+# ============================================================================
+
+
+class TestToolCalls:
+    """Tests for tool call handling."""
+
+    @pytest.fixture
+    def tool_call_streaming_events(self):
+        """Sample streaming events with a tool call."""
+        return [
+            {
+                "type": "response.created",
+                "sequence_number": 0,
+                "response": {
+                    "id": "resp_456",
+                    "object": "response",
+                    "created_at": 1741476777,
+                    "completed_at": None,
+                    "status": "in_progress",
+                    "model": "gpt-4o",
+                    "incomplete_details": None,
+                    "previous_response_id": None,
+                    "instructions": None,
+                    "input": [],
+                    "output": [],
+                    "error": None,
+                    "tools": [
+                        {
+                            "type": "function",
+                            "name": "get_weather",
+                            "description": "Get weather for a location",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {"location": {"type": "string"}},
+                            },
+                        }
+                    ],
+                    "tool_choice": "auto",
+                    "truncation": "disabled",
+                    "parallel_tool_calls": True,
+                    "text": {"format": {"type": "text"}},
+                    "top_p": 1.0,
+                    "presence_penalty": 0.0,
+                    "frequency_penalty": 0.0,
+                    "top_logprobs": 0,
+                    "temperature": 1.0,
+                    "reasoning": None,
+                    "user": None,
+                    "usage": None,
+                    "max_output_tokens": None,
+                    "max_tool_calls": None,
+                    "store": False,
+                    "background": False,
+                    "service_tier": "default",
+                    "metadata": {},
+                    "safety_identifier": None,
+                    "prompt_cache_key": None,
+                },
+            },
+            {
+                "type": "response.output_item.added",
+                "sequence_number": 1,
+                "output_index": 0,
+                "item": {
+                    "type": "function_call",
+                    "id": "fc_789",
+                    "status": "in_progress",
+                    "call_id": "call_abc",
+                    "name": "get_weather",
+                    "arguments": "",
+                },
+            },
+            {
+                "type": "response.function_call_arguments.delta",
+                "sequence_number": 2,
+                "item_id": "fc_789",
+                "output_index": 0,
+                "delta": '{"loc',
+            },
+            {
+                "type": "response.function_call_arguments.delta",
+                "sequence_number": 3,
+                "item_id": "fc_789",
+                "output_index": 0,
+                "delta": 'ation": "NYC"}',
+            },
+            {
+                "type": "response.function_call_arguments.done",
+                "sequence_number": 4,
+                "item_id": "fc_789",
+                "output_index": 0,
+                "arguments": '{"location": "NYC"}',
+            },
+            {
+                "type": "response.output_item.done",
+                "sequence_number": 5,
+                "output_index": 0,
+                "item": {
+                    "type": "function_call",
+                    "id": "fc_789",
+                    "status": "completed",
+                    "call_id": "call_abc",
+                    "name": "get_weather",
+                    "arguments": '{"location": "NYC"}',
+                },
+            },
+            {
+                "type": "response.completed",
+                "sequence_number": 6,
+                "response": {
+                    "id": "resp_456",
+                    "object": "response",
+                    "created_at": 1741476777,
+                    "completed_at": 1741476778,
+                    "status": "completed",
+                    "model": "gpt-4o",
+                    "incomplete_details": None,
+                    "previous_response_id": None,
+                    "instructions": None,
+                    "input": [],
+                    "output": [
+                        {
+                            "type": "function_call",
+                            "id": "fc_789",
+                            "status": "completed",
+                            "call_id": "call_abc",
+                            "name": "get_weather",
+                            "arguments": '{"location": "NYC"}',
+                        }
+                    ],
+                    "error": None,
+                    "tools": [],
+                    "tool_choice": "auto",
+                    "truncation": "disabled",
+                    "parallel_tool_calls": True,
+                    "text": {"format": {"type": "text"}},
+                    "top_p": 1.0,
+                    "presence_penalty": 0.0,
+                    "frequency_penalty": 0.0,
+                    "top_logprobs": 0,
+                    "temperature": 1.0,
+                    "reasoning": None,
+                    "user": None,
+                    "usage": {
+                        "input_tokens": 20,
+                        "output_tokens": 10,
+                        "total_tokens": 30,
+                        "input_tokens_details": {"cached_tokens": 0},
+                        "output_tokens_details": {"reasoning_tokens": 0},
+                    },
+                    "max_output_tokens": None,
+                    "max_tool_calls": None,
+                    "store": False,
+                    "background": False,
+                    "service_tier": "default",
+                    "metadata": {},
+                    "safety_identifier": None,
+                    "prompt_cache_key": None,
+                },
+            },
+        ]
+
+    @pytest.fixture
+    def mocked_tool_call_response(self, httpx_mock, tool_call_streaming_events):
+        """Mock a streaming response with tool calls."""
+        httpx_mock.add_response(
+            method="POST",
+            url="https://api.openai.com/v1/responses",
+            stream=IteratorStream(make_sse_stream(tool_call_streaming_events)),
+            headers={"Content-Type": "text/event-stream"},
+        )
+        return httpx_mock
+
+    def test_tool_call_streaming(self, mocked_tool_call_response):
+        """Test that tool calls are properly extracted from streaming response."""
+        model = ResponsesModel(model_id="gpt-4o")
+
+        from llm import Prompt
+
+        prompt = Prompt(
+            prompt="What's the weather in NYC?",
+            model=model,
+            options=model.Options(),
+        )
+
+        mock_response = MagicMock()
+        mock_response.response_json = None
+
+        # Consume all chunks
+        chunks = list(model.execute(prompt, stream=True, response=mock_response, conversation=None, key="test-key"))
+
+        # Tool calls don't yield text, so chunks should be empty
+        assert chunks == []
+
+        # But tool_calls should be set on the response
+        mock_response.add_tool_call.assert_called()
+
+
+# ============================================================================
+# Test Options
+# ============================================================================
+
+
+class TestModelOptions:
+    """Tests for model options."""
+
+    def test_temperature_option(self):
+        """Test temperature option."""
+        model = ResponsesModel(model_id="gpt-4o")
+        options = model.Options(temperature=0.5)
+        assert options.temperature == 0.5
+
+    def test_max_tokens_option(self):
+        """Test max_output_tokens option."""
+        model = ResponsesModel(model_id="gpt-4o")
+        options = model.Options(max_output_tokens=100)
+        assert options.max_output_tokens == 100
+
+    def test_top_p_option(self):
+        """Test top_p option."""
+        model = ResponsesModel(model_id="gpt-4o")
+        options = model.Options(top_p=0.9)
+        assert options.top_p == 0.9
+
+
+# ============================================================================
+# Test Conversation/Multi-turn
+# ============================================================================
+
+
+class TestConversation:
+    """Tests for conversation/multi-turn support."""
+
+    def test_build_input_from_conversation(self):
+        """Test building input array from conversation history."""
+        model = ResponsesModel(model_id="gpt-4o")
+
+        # This tests the internal method that converts conversation to input items
+        # The actual implementation will use previous_response_id or input array
+        conversation_messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+            {"role": "user", "content": "How are you?"},
+        ]
+
+        input_items = model._build_input_items(conversation_messages)
+
+        assert len(input_items) == 3
+        assert input_items[0]["type"] == "message"
+        assert input_items[0]["role"] == "user"
+
+
+# ============================================================================
+# Test SSE Parser
+# ============================================================================
+
+
+class TestSSEParser:
+    """Tests for SSE parsing utilities."""
+
+    def test_parse_empty_line(self):
+        """Test that empty lines return None."""
+        assert parse_sse_event("") is None
+        assert parse_sse_event("\n") is None
+
+    def test_parse_comment_line(self):
+        """Test that comment lines return None."""
+        assert parse_sse_event(": this is a comment") is None
+
+    def test_parse_done_event(self):
+        """Test that [DONE] event returns None."""
+        assert parse_sse_event("data: [DONE]") is None
+
+    def test_parse_invalid_json(self):
+        """Test that invalid JSON raises an error."""
+        with pytest.raises(json.JSONDecodeError):
+            parse_sse_event("data: {invalid json}")

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -1,7 +1,7 @@
 """
 Tests for llm/responses.py - OpenResponses API client implementation.
 
-Using TDD approach: these tests are written first, then implementation follows.
+Tests for the OpenResponses API client.
 """
 
 import json
@@ -9,7 +9,6 @@ import pytest
 from unittest.mock import MagicMock
 from pytest_httpx import IteratorStream
 
-# These imports will fail until we implement the module
 from llm.responses import (
     # Pydantic models
     ResponseResource,
@@ -17,14 +16,11 @@ from llm.responses import (
     OutputItem,
     OutputTextContent,
     # Streaming events
-    ResponseStreamEvent,
     ResponseCreatedEvent,
     ResponseCompletedEvent,
     ResponseOutputTextDeltaEvent,
     ResponseFunctionCallArgumentsDeltaEvent,
     ResponseFunctionCallArgumentsDoneEvent,
-    ResponseOutputItemAddedEvent,
-    ResponseOutputItemDoneEvent,
     # Error classes
     ResponsesAPIError,
     ResponsesAuthenticationError,
@@ -38,9 +34,7 @@ from llm.responses import (
 )
 
 
-# ============================================================================
 # Test fixtures
-# ============================================================================
 
 
 @pytest.fixture
@@ -244,9 +238,7 @@ def make_sse_stream(events):
         yield f"data: {json.dumps(event)}\n\n".encode("utf-8")
 
 
-# ============================================================================
 # Test Pydantic Models
-# ============================================================================
 
 
 class TestPydanticModels:
@@ -315,9 +307,7 @@ class TestPydanticModels:
         assert response.usage.output_tokens == 5
 
 
-# ============================================================================
 # Test Streaming Event Models
-# ============================================================================
 
 
 class TestStreamingEvents:
@@ -369,9 +359,7 @@ class TestStreamingEvents:
         assert isinstance(event, ResponseCompletedEvent)
 
 
-# ============================================================================
 # Test Function Call Events
-# ============================================================================
 
 
 class TestFunctionCallEvents:
@@ -405,9 +393,7 @@ class TestFunctionCallEvents:
         assert event.arguments == '{"name": "test"}'
 
 
-# ============================================================================
 # Test Error Classes
-# ============================================================================
 
 
 class TestErrorClasses:
@@ -438,9 +424,7 @@ class TestErrorClasses:
         assert error.status_code == 400
 
 
-# ============================================================================
 # Test Sync Model
-# ============================================================================
 
 
 class TestResponsesModel:
@@ -501,7 +485,15 @@ class TestResponsesModel:
         mock_response.response_json = None
 
         # Execute
-        chunks = list(model.execute(prompt, stream=False, response=mock_response, conversation=None, key="test-key"))
+        chunks = list(
+            model.execute(
+                prompt,
+                stream=False,
+                response=mock_response,
+                conversation=None,
+                key="test-key",
+            )
+        )
 
         assert chunks == ["Hello, world!"]
 
@@ -520,7 +512,15 @@ class TestResponsesModel:
         mock_response = MagicMock()
         mock_response.response_json = None
 
-        chunks = list(model.execute(prompt, stream=True, response=mock_response, conversation=None, key="test-key"))
+        chunks = list(
+            model.execute(
+                prompt,
+                stream=True,
+                response=mock_response,
+                conversation=None,
+                key="test-key",
+            )
+        )
 
         # Should yield the text deltas
         assert chunks == ["Hello", ", world!"]
@@ -540,7 +540,15 @@ class TestResponsesModel:
         mock_response = MagicMock()
         mock_response.response_json = None
 
-        list(model.execute(prompt, stream=False, response=mock_response, conversation=None, key="test-key"))
+        list(
+            model.execute(
+                prompt,
+                stream=False,
+                response=mock_response,
+                conversation=None,
+                key="test-key",
+            )
+        )
 
         # Check that set_usage was called
         mock_response.set_usage.assert_called()
@@ -552,7 +560,9 @@ class TestResponsesModel:
             method="POST",
             url="https://api.openai.com/v1/responses",
             status_code=401,
-            json={"error": {"message": "Invalid API key", "type": "authentication_error"}},
+            json={
+                "error": {"message": "Invalid API key", "type": "authentication_error"}
+            },
             headers={"Content-Type": "application/json"},
         )
         return httpx_mock
@@ -572,12 +582,18 @@ class TestResponsesModel:
         mock_response = MagicMock()
 
         with pytest.raises(ResponsesAuthenticationError):
-            list(model.execute(prompt, stream=False, response=mock_response, conversation=None, key="bad-key"))
+            list(
+                model.execute(
+                    prompt,
+                    stream=False,
+                    response=mock_response,
+                    conversation=None,
+                    key="bad-key",
+                )
+            )
 
 
-# ============================================================================
 # Test Async Model
-# ============================================================================
 
 
 class TestAsyncResponsesModel:
@@ -616,7 +632,9 @@ class TestAsyncResponsesModel:
         return httpx_mock
 
     @pytest.mark.asyncio
-    async def test_async_execute_non_streaming(self, mocked_async_non_streaming_response):
+    async def test_async_execute_non_streaming(
+        self, mocked_async_non_streaming_response
+    ):
         """Test async non-streaming execution."""
         model = AsyncResponsesModel(model_id="gpt-4o")
 
@@ -632,7 +650,13 @@ class TestAsyncResponsesModel:
         mock_response.response_json = None
 
         chunks = []
-        async for chunk in model.execute(prompt, stream=False, response=mock_response, conversation=None, key="test-key"):
+        async for chunk in model.execute(
+            prompt,
+            stream=False,
+            response=mock_response,
+            conversation=None,
+            key="test-key",
+        ):
             chunks.append(chunk)
 
         assert chunks == ["Hello, world!"]
@@ -654,15 +678,19 @@ class TestAsyncResponsesModel:
         mock_response.response_json = None
 
         chunks = []
-        async for chunk in model.execute(prompt, stream=True, response=mock_response, conversation=None, key="test-key"):
+        async for chunk in model.execute(
+            prompt,
+            stream=True,
+            response=mock_response,
+            conversation=None,
+            key="test-key",
+        ):
             chunks.append(chunk)
 
         assert chunks == ["Hello", ", world!"]
 
 
-# ============================================================================
 # Test Tool Calls
-# ============================================================================
 
 
 class TestToolCalls:
@@ -851,7 +879,15 @@ class TestToolCalls:
         mock_response.response_json = None
 
         # Consume all chunks
-        chunks = list(model.execute(prompt, stream=True, response=mock_response, conversation=None, key="test-key"))
+        chunks = list(
+            model.execute(
+                prompt,
+                stream=True,
+                response=mock_response,
+                conversation=None,
+                key="test-key",
+            )
+        )
 
         # Tool calls don't yield text, so chunks should be empty
         assert chunks == []
@@ -860,9 +896,7 @@ class TestToolCalls:
         mock_response.add_tool_call.assert_called()
 
 
-# ============================================================================
 # Test Options
-# ============================================================================
 
 
 class TestModelOptions:
@@ -887,9 +921,7 @@ class TestModelOptions:
         assert options.top_p == 0.9
 
 
-# ============================================================================
 # Test Conversation/Multi-turn
-# ============================================================================
 
 
 class TestConversation:
@@ -914,9 +946,7 @@ class TestConversation:
         assert input_items[0]["role"] == "user"
 
 
-# ============================================================================
 # Test SSE Parser
-# ============================================================================
 
 
 class TestSSEParser:


### PR DESCRIPTION
This adds llm/responses.py with sync and async model classes that
implement the OpenResponses API using httpx as the transport layer:

- ResponsesModel (sync) and AsyncResponsesModel (async) extending
  KeyModel/AsyncKeyModel for integration with the llm framework
- Pydantic models for ResponseResource and streaming events
- SSE streaming parser for real-time text deltas
- Custom error classes (ResponsesAPIError, ResponsesAuthenticationError,
  ResponsesRateLimitError, ResponsesInvalidRequestError)
- Support for tool/function calls
- Comprehensive test suite (35 tests) using TDD approach