### PR TITLE
Making llm models resilient to backend discovery failures

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -21,6 +21,8 @@ from llm import (
     Toolbox,
     UnknownModelError,
     KeyModel,
+    ModelError,
+    ModelWithAliases,
     encode,
     get_async_model,
     get_default_model,
@@ -168,6 +170,50 @@ def resolve_fragments(
                 else:
                     raise FragmentNotFound(f"Fragment '{fragment}' not found")
     return resolved
+
+
+def _get_models_with_aliases_resilient() -> List[ModelWithAliases]:
+    model_aliases = []
+
+    # Include aliases from aliases.json
+    aliases_path = user_dir() / "aliases.json"
+    extra_model_aliases: Dict[str, list] = {}
+    if aliases_path.exists():
+        configured_aliases = json.loads(aliases_path.read_text())
+        for alias, model_id in configured_aliases.items():
+            extra_model_aliases.setdefault(model_id, []).append(alias)
+
+    def register(model, async_model=None, aliases=None):
+        alias_list = list(aliases or [])
+        if model.model_id in extra_model_aliases:
+            alias_list.extend(extra_model_aliases[model.model_id])
+        model_aliases.append(ModelWithAliases(model, async_model, alias_list))
+
+    load_plugins()
+
+    errors = []
+    for plugin in pm.get_plugins():
+        # Only attempt to call if the plugin implements register_models
+        # We use subset_hook_caller to isolate the dispatch while respecting pluggy contracts
+        caller = pm.subset_hook_caller(
+            "register_models",
+            remove_plugins=[p for p in pm.get_plugins() if p is not plugin],
+        )
+        try:
+            caller(register=register)
+        except (pydantic.ValidationError, httpx.HTTPError, ModelError) as ex:
+            errors.append(ex)
+            # We skip the failing backend and report it as a warning
+            click.secho(
+                f"Warning: model backend '{pm.get_name(plugin)}' failed during discovery: {ex}",
+                err=True,
+                fg="yellow",
+            )
+
+    if not model_aliases and errors:
+        raise click.ClickException("All model backends failed during discovery")
+
+    return model_aliases
 
 
 def process_fragments_in_chat(
@@ -546,7 +592,7 @@ def prompt(
     if queries and not model_id:
         # Use -q options to find model with shortest model_id
         matches = []
-        for model_with_aliases in get_models_with_aliases():
+        for model_with_aliases in _get_models_with_aliases_resilient():
             if all(model_with_aliases.matches(q) for q in queries):
                 matches.append(model_with_aliases.model.model_id)
         if not matches:
@@ -2235,7 +2281,7 @@ _type_lookup = {
 def models_list(options, async_, schemas, tools, query, model_ids):
     "List available models"
     models_that_have_shown_options = set()
-    for model_with_aliases in get_models_with_aliases():
+    for model_with_aliases in _get_models_with_aliases_resilient():
         if async_ and not model_with_aliases.async_model:
             continue
         if query:
@@ -2747,7 +2793,7 @@ def aliases_set(alias, model_id, query):
             )
         # Search for the first model matching all query strings
         found = None
-        for model_with_aliases in get_models_with_aliases():
+        for model_with_aliases in _get_models_with_aliases_resilient():
             if all(model_with_aliases.matches(q) for q in query):
                 found = model_with_aliases
                 break

--- a/tests/test_resilient_discovery.py
+++ b/tests/test_resilient_discovery.py
@@ -1,0 +1,107 @@
+import llm
+from llm.cli import cli
+from click.testing import CliRunner
+from llm.plugins import pm
+import pydantic
+from pydantic import BaseModel
+import pytest
+
+class SmallModel(BaseModel):
+    required_field: str
+
+def test_resilient_model_discovery():
+    class PoisonedPlugin:
+        __name__ = "PoisonedPlugin"
+        @llm.hookimpl
+        def register_models(self, register):
+            SmallModel() # Raises ValidationError
+
+    class HealthyModel(llm.Model):
+        model_id = "healthy-model"
+        
+        def execute(self, prompt, stream, response, conversation):
+            return ["response"]
+
+    class HealthyPlugin:
+        __name__ = "HealthyPlugin"
+        @llm.hookimpl
+        def register_models(self, register):            
+            register(HealthyModel())
+
+    # Register both
+    pm.register(PoisonedPlugin(), name="poisoned")
+    pm.register(HealthyPlugin(), name="healthy")
+    
+    try:
+        runner = CliRunner(mix_stderr=False)
+        # Using -q to make sure we are testing the discovery part which happens before filtering
+        result = runner.invoke(cli, ["models", "-q", "healthy-model"])
+        print(f"STDOUT: {result.stdout}")
+        print(f"STDERR: {result.stderr}")
+        print(f"EXIT CODE: {result.exit_code}")
+        
+        # Verify healthy model is present in stdout
+        assert "healthy-model" in result.stdout, f"STDOUT: {result.stdout}\nSTDERR: {result.stderr}"
+        # Verify warning is in stderr
+        assert "Warning: model backend 'poisoned' failed during discovery" in result.stderr, f"STDERR: {result.stderr}"
+        assert "required_field" in result.stderr, f"STDERR: {result.stderr}"
+        
+        # Verify exit code 0
+        assert result.exit_code == 0, f"STDOUT: {result.stdout}\nSTDERR: {result.stderr}"
+    finally:
+        pm.unregister(name="poisoned")
+        pm.unregister(name="healthy")
+
+def test_library_remains_strict():
+    class PoisonedPlugin:
+        __name__ = "PoisonedPluginLibrary"
+        @llm.hookimpl
+        def register_models(self, register):
+            SmallModel() # Raises ValidationError
+
+    pm.register(PoisonedPlugin(), name="poisoned-lib")
+    
+    try:
+        # Calling the library function should still raise ValidationError
+        with pytest.raises(pydantic.ValidationError):
+            llm.get_models_with_aliases()
+    finally:
+        pm.unregister(name="poisoned-lib")
+
+def test_resilient_discovery_all_fail():
+    class PoisonedPlugin1:
+        __name__ = "PoisonedPlugin1"
+        @llm.hookimpl
+        def register_models(self, register):
+            SmallModel()
+
+    # In tests, there are usually default models registered (echo, mock).
+    # To truly test "all fail", we would need to unregister everything.
+    # Instead, we can verify that the ClickException is raised IF the helper returns nothing and had errors.
+    
+    # We'll unregister the standard test models for this specific test
+    # Note: this might be risky if tests run in parallel, but standard pytest is fine.
+    
+    # Find and unregister all plugins that implement register_models
+    to_unregister = []
+    for plugin in pm.get_plugins():
+        if hasattr(plugin, "register_models"):
+            to_unregister.append((plugin, pm.get_name(plugin)))
+    
+    for plugin, name in to_unregister:
+        pm.unregister(plugin)
+        
+    pm.register(PoisonedPlugin1(), name="p1")
+    
+    try:
+        runner = CliRunner(mix_stderr=False)
+        result = runner.invoke(cli, ["models"])
+        
+        assert result.exit_code != 0
+        assert "Error: All model backends failed during discovery" in result.stderr
+        assert "Warning: model backend 'p1' failed during discovery" in result.stderr
+    finally:
+        pm.unregister(name="p1")
+        # Restore them
+        for plugin, name in to_unregister:
+            pm.register(plugin, name=name)


### PR DESCRIPTION
### Summary

Before this patch, `llm models` would crash with a `pydantic.ValidationError` if any single backend failed during model discovery. For example, certain Ollama models with missing metadata caused the entire command to terminate, preventing all other models from being listed.

After this change, backend failures are properly isolated in the CLI layer. Errors from individual backends are downgraded to warnings, and model discovery continues as long as at least one backend succeeds. The command now completes successfully, lists all healthy models, and reports backend failures without aborting execution.

Fixes #1330 