### PR TITLE
fix: --continue uses conversation with most recent response

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1249,10 +1249,17 @@ def load_conversation(
     db = sqlite_utils.Database(log_path)
     migrate(db)
     if conversation_id is None:
-        # Return the most recent conversation, or None if there are none
-        matches = list(db["conversations"].rows_where(order_by="id desc", limit=1))
-        if matches:
-            conversation_id = matches[0]["id"]
+        # Return the conversation with the most recent response
+        result = db.execute(
+            """
+            SELECT c.id FROM conversations c
+            JOIN responses r ON c.id = r.conversation_id
+            ORDER BY r.datetime_utc DESC
+            LIMIT 1
+            """
+        ).fetchone()
+        if result:
+            conversation_id = result[0]
         else:
             return None
     try:


### PR DESCRIPTION
Fixes #1140

Previously, `--continue` without a conversation ID would select the conversation with the highest ID (alphabetically last). This could select the wrong conversation when IDs are user-provided names like "foo" or "bar".

Now `--continue` selects the conversation that has the most recent response based on `datetime_utc`, matching user expectations for "continue the most recent conversation."

**Example scenario (from the issue):**
1. User runs `llm --continue --conversation foo` twice
2. User runs `llm --continue --conversation bar` once  
3. User runs `llm --continue` expecting to continue "foo" (most recently used)
4. **Before:** Would continue "bar" (alphabetically last ID)
5. **After:** Continues "foo" (has the most recent response)