### PR TITLE
Honor CLI --extract/--xl flags over template defaults

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -677,8 +677,9 @@ def prompt(
             template_obj = load_template(template)
         except LoadTemplateError as ex:
             raise click.ClickException(str(ex))
-        extract = template_obj.extract
-        extract_last = template_obj.extract_last
+        if not extract and not extract_last:
+            extract = bool(template_obj.extract)
+            extract_last = bool(template_obj.extract_last)
         # Combine with template fragments/system_fragments
         if template_obj.fragments:
             fragments = [*template_obj.fragments, *fragments]

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -413,6 +413,57 @@ def test_execute_prompt_from_template_path():
         }
 
 
+@pytest.mark.parametrize(
+    "template,extra_args,expected",
+    (
+        (
+            "prompt: hi",
+            ["--xl"],
+            "second code",
+        ),
+        (
+            "extract_last: true\nprompt: hi",
+            [],
+            "second code",
+        ),
+        (
+            "extract_last: true\nprompt: hi",
+            ["--extract"],
+            "first code",
+        ),
+    ),
+)
+def test_template_extract_precedence(template, extra_args, expected, httpx_mock, templates_path):
+    (templates_path / "template.yaml").write_text(template, "utf-8")
+    httpx_mock.add_response(
+        method="POST",
+        url="https://api.openai.com/v1/chat/completions",
+        json={
+            "model": "gpt-4o-mini",
+            "usage": {},
+            "choices": [
+                {
+                    "message": {
+                        "content": (
+                            "Start\n```text\nfirst code\n```\n"
+                            "Middle\n```python\nsecond code\n```\nEnd"
+                        )
+                    }
+                }
+            ],
+        },
+        headers={"Content-Type": "application/json"},
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["-m", "gpt-4o-mini", "--key", "x", "-t", "template"] + extra_args,
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert result.output.strip() == expected
+
+
 FUNCTIONS_EXAMPLE = """
 def greet(name: str) -> str:
     return f"Hello, {name}!"


### PR DESCRIPTION
## Summary
- Fixes #1296 — the `--xl` and `--extract` CLI flags were silently overwritten by template `extract`/`extract_last` values, so they had no effect when using `-t`.
- Only applies template extract settings when no CLI extract flag was passed.

## Test plan
- [x] `test_template_extract_precedence` — parameterized test covering:
  - CLI `--xl` with plain template → extracts last block
  - Template `extract_last: true`, no CLI flag → extracts last block
  - Template `extract_last: true` + CLI `--extract` → extracts first block (CLI wins)
- [ ] Manual: `llm "Create an SVG of a pelican riding a bicycle." --save pelican && llm -t pelican --xl`