### PR TITLE
Fix MIME detection fallback when puremagic returns empty string

### DIFF
--- a/llm/utils.py
+++ b/llm/utils.py
@@ -3,6 +3,7 @@ import hashlib
 import httpx
 import itertools
 import json
+import mimetypes
 import pathlib
 import puremagic
 import re
@@ -19,6 +20,7 @@ from ulid import ULID
 
 MIME_TYPE_FIXES = {
     "audio/wave": "audio/wav",
+    "audio/x-wav": "audio/wav",
 }
 
 
@@ -46,9 +48,11 @@ def mimetype_from_string(content) -> Optional[str]:
 def mimetype_from_path(path) -> Optional[str]:
     try:
         type_ = puremagic.from_file(path, mime=True)
-        return MIME_TYPE_FIXES.get(type_, type_)
     except puremagic.PureError:
-        return None
+        type_ = None
+    if not type_:
+        type_, _ = mimetypes.guess_type(path)
+    return MIME_TYPE_FIXES.get(type_, type_) if type_ else None
 
 
 def dicts_to_table_string(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@ import pytest
 from llm.utils import (
     extract_fenced_code_block,
     instantiate_from_spec,
+    mimetype_from_path,
     maybe_fenced_code,
     schema_dsl,
     simplify_usage_dict,
@@ -10,6 +11,7 @@ from llm.utils import (
     monotonic_ulid,
 )
 from llm import get_key, Toolbox
+import llm.utils as utils_module
 
 
 @pytest.mark.parametrize(
@@ -516,3 +518,35 @@ def test_toolbox_config_capture():
         pass
 
     assert Tool6()._config == {}
+
+
+def test_mimetype_from_path_fallback_on_empty_string(tmp_path, monkeypatch):
+    path = tmp_path / "video.mp4"
+    path.write_bytes(b"not really a video")
+    monkeypatch.setattr(utils_module.puremagic, "from_file", lambda *args, **kwargs: "")
+    assert mimetype_from_path(str(path)) == "video/mp4"
+
+
+def test_mimetype_from_path_fallback_on_puremagic_error(tmp_path, monkeypatch):
+    path = tmp_path / "image.jpg"
+    path.write_bytes(b"not really an image")
+
+    def raise_pureerror(*args, **kwargs):
+        raise utils_module.puremagic.PureError("no match")
+
+    monkeypatch.setattr(utils_module.puremagic, "from_file", raise_pureerror)
+    assert mimetype_from_path(str(path)) == "image/jpeg"
+
+
+def test_mimetype_from_path_fallback_normalizes_wav(tmp_path, monkeypatch):
+    path = tmp_path / "audio.wav"
+    path.write_bytes(b"not really audio")
+    monkeypatch.setattr(utils_module.puremagic, "from_file", lambda *args, **kwargs: "")
+    assert mimetype_from_path(str(path)) == "audio/wav"
+
+
+def test_mimetype_from_path_returns_none_if_no_detection(tmp_path, monkeypatch):
+    path = tmp_path / "no_extension"
+    path.write_bytes(b"unknown data")
+    monkeypatch.setattr(utils_module.puremagic, "from_file", lambda *args, **kwargs: "")
+    assert mimetype_from_path(str(path)) is None


### PR DESCRIPTION
## Summary
- Fixes #1340 — `puremagic.from_file()` can return an empty string `""` instead of raising `PureError`, which passed through as an invalid MIME type causing attachment validation errors.
- Adds `mimetypes.guess_type()` as a fallback when `puremagic` returns empty string or raises an exception.
- Adds `"audio/x-wav": "audio/wav"` to `MIME_TYPE_FIXES` since `mimetypes` returns `audio/x-wav` for `.wav` files.
- Applies `MIME_TYPE_FIXES` normalization regardless of which detection method succeeded.

## Test plan
- [x] `test_mimetype_from_path_fallback_on_empty_string` — puremagic returns `""`, falls back to extension
- [x] `test_mimetype_from_path_fallback_on_puremagic_error` — puremagic raises, falls back to extension
- [x] `test_mimetype_from_path_fallback_normalizes_wav` — fallback result goes through MIME_TYPE_FIXES
- [x] `test_mimetype_from_path_returns_none_if_no_detection` — both methods fail → `None`