### PR TITLE
Fix mimetype_from_path returning empty string when puremagic cannot detect type

### DIFF
--- a/llm/utils.py
+++ b/llm/utils.py
@@ -3,6 +3,7 @@ import hashlib
 import httpx
 import itertools
 import json
+import mimetypes
 import pathlib
 import puremagic
 import re
@@ -38,7 +39,9 @@ class Fragment(str):
 def mimetype_from_string(content) -> Optional[str]:
     try:
         type_ = puremagic.from_string(content, mime=True)
-        return MIME_TYPE_FIXES.get(type_, type_)
+        if type_:
+            return MIME_TYPE_FIXES.get(type_, type_)
+        return None
     except puremagic.PureError:
         return None
 
@@ -46,9 +49,12 @@ def mimetype_from_string(content) -> Optional[str]:
 def mimetype_from_path(path) -> Optional[str]:
     try:
         type_ = puremagic.from_file(path, mime=True)
-        return MIME_TYPE_FIXES.get(type_, type_)
+        if type_:
+            return MIME_TYPE_FIXES.get(type_, type_)
     except puremagic.PureError:
-        return None
+        pass
+    guessed, _ = mimetypes.guess_type(str(path))
+    return guessed
 
 
 def dicts_to_table_string(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,13 @@
 import json
+import pathlib
 import pytest
+from unittest.mock import patch
 from llm.utils import (
     extract_fenced_code_block,
     instantiate_from_spec,
     maybe_fenced_code,
+    mimetype_from_path,
+    mimetype_from_string,
     schema_dsl,
     simplify_usage_dict,
     truncate_string,
@@ -516,3 +520,60 @@ def test_toolbox_config_capture():
         pass
 
     assert Tool6()._config == {}
+
+
+class TestMimetypeFromPath:
+    def test_puremagic_returns_valid_type(self, tmp_path):
+        f = tmp_path / "image.png"
+        f.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+        result = mimetype_from_path(str(f))
+        assert result == "image/png"
+
+    def test_puremagic_returns_empty_string_falls_back_to_mimetypes(self, tmp_path):
+        f = tmp_path / "video.mp4"
+        f.write_bytes(b"\x00" * 16)
+        with patch("puremagic.from_file", return_value=""):
+            result = mimetype_from_path(str(f))
+        assert result == "video/mp4"
+
+    def test_puremagic_raises_falls_back_to_mimetypes(self, tmp_path):
+        import mimetypes
+        import puremagic
+        f = tmp_path / "audio.wav"
+        f.write_bytes(b"\x00" * 16)
+        with patch("puremagic.from_file", side_effect=puremagic.PureError):
+            result = mimetype_from_path(str(f))
+        expected, _ = mimetypes.guess_type("audio.wav")
+        assert result == expected
+
+    def test_unknown_extension_returns_none(self, tmp_path):
+        f = tmp_path / "file.unknownxyz"
+        f.write_bytes(b"\x00" * 16)
+        with patch("puremagic.from_file", return_value=""):
+            result = mimetype_from_path(str(f))
+        assert result is None
+
+    def test_mime_type_fix_applied(self, tmp_path):
+        f = tmp_path / "sound.wav"
+        f.write_bytes(b"\x00" * 16)
+        with patch("puremagic.from_file", return_value="audio/wave"):
+            result = mimetype_from_path(str(f))
+        assert result == "audio/wav"
+
+
+class TestMimetypeFromString:
+    def test_puremagic_returns_valid_type(self):
+        png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 8
+        result = mimetype_from_string(png_bytes)
+        assert result == "image/png"
+
+    def test_puremagic_returns_empty_string_returns_none(self):
+        with patch("puremagic.from_string", return_value=""):
+            result = mimetype_from_string(b"\x00" * 16)
+        assert result is None
+
+    def test_puremagic_raises_returns_none(self):
+        import puremagic
+        with patch("puremagic.from_string", side_effect=puremagic.PureError):
+            result = mimetype_from_string(b"\x00" * 16)
+        assert result is None


### PR DESCRIPTION
Fixes #1340.

## Problem

`puremagic.from_file()` can return an empty string `''` (instead of raising `PureError`) when it cannot identify a file type. The previous code only handled the exception case, so the empty string passed through as the MIME type. This produced errors like:

```
Error: This model does not support attachments of type '', only audio/flac, image/heif, ...
```

## Fix

Added a `mimetypes.guess_type()` fallback in `mimetype_from_path()` for both cases: empty string return and `PureError`. This covers common extensions (e.g. `.mp4`, `.wav`, `.pdf`) when magic number detection fails.

Applied the same empty-string guard to `mimetype_from_string()` so it returns `None` instead of `''` when puremagic comes up empty (no path available there for a fallback).

## Changes

`llm/utils.py` (5 lines changed):
- Added `import mimetypes`
- `mimetype_from_path`: returns `mimetypes.guess_type()` result when puremagic returns `''` or raises `PureError`
- `mimetype_from_string`: returns `None` when puremagic returns `''`

`tests/test_utils.py` (65 lines added):
- 8 new tests covering both functions across puremagic success, empty string, PureError, unknown extension, and MIME_TYPE_FIXES cases

## Tests

```
tests/test_utils.py::TestMimetypeFromPath::test_puremagic_returns_valid_type PASSED
tests/test_utils.py::TestMimetypeFromPath::test_puremagic_returns_empty_string_falls_back_to_mimetypes PASSED
tests/test_utils.py::TestMimetypeFromPath::test_puremagic_raises_falls_back_to_mimetypes PASSED
tests/test_utils.py::TestMimetypeFromPath::test_unknown_extension_returns_none PASSED
tests/test_utils.py::TestMimetypeFromPath::test_mime_type_fix_applied PASSED
tests/test_utils.py::TestMimetypeFromString::test_puremagic_returns_valid_type PASSED
tests/test_utils.py::TestMimetypeFromString::test_puremagic_returns_empty_string_returns_none PASSED
tests/test_utils.py::TestMimetypeFromString::test_puremagic_raises_returns_none PASSED

93 passed in 0.69s
```