### PR TITLE
pyproject.toml: bump minimum openai to 2.11.0 to fix pydantic compat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 dependencies = [
     "click",
     "condense-json>=0.1.3",
-    "openai>=1.55.3",
+    "openai>=2.11.0",
     "click-default-group>=1.2.3",
     "sqlite-utils>=3.37",
     "sqlite-migrate>=0.1a2",


### PR DESCRIPTION
openai SDK versions before 2.11.0 are incompatible with pydantic 2.12+, which changed how discriminated unions work internally. This causes the error:

    'typing.Union' object has no attribute '__discriminator__' and no
    __dict__ for setting new attributes

when making any prompt request. Bumping the minimum openai version ensures users with newer pydantic don't hit this.