### PR TITLE
docs: add llm-inception to plugin directory

### DIFF
--- a/docs/plugins/directory.md
+++ b/docs/plugins/directory.md
@@ -29,6 +29,7 @@ These plugins can be used to interact with remotely hosted models via their API:
 - **[llm-perplexity](https://github.com/hex/llm-perplexity)** by Alexandru Geana supports the [Perplexity Labs](https://docs.perplexity.ai/) API models, including `llama-3-sonar-large-32k-online` which can search for things online and `llama-3-70b-instruct`.
 - **[llm-groq](https://github.com/angerman/llm-groq)** by Moritz Angermann provides access to fast models hosted by [Groq](https://console.groq.com/docs/models).
 - **[llm-grok](https://github.com/Hiepler/llm-grok)** by Benedikt Hiepler providing access to Grok model using the xAI API [Grok](https://x.ai/api).
+- **[llm-inception](https://github.com/NickJLange/llm-inception-plugin)** adds support for [Inception Labs](https://www.inceptionlabs.ai/) Mercury diffusion models, including fill-in-the-middle code completion.
 - **[llm-anyscale-endpoints](https://github.com/simonw/llm-anyscale-endpoints)** supports models hosted on the [Anyscale Endpoints](https://app.endpoints.anyscale.com/) platform, including Llama 2 70B.
 - **[llm-replicate](https://github.com/simonw/llm-replicate)** adds support for remote models hosted on [Replicate](https://replicate.com/), including Llama 2 from Meta AI.
 - **[llm-fireworks](https://github.com/simonw/llm-fireworks)** supports models hosted by [Fireworks AI](https://fireworks.ai/).


### PR DESCRIPTION
## Auto-Gen Summary

- Adds **[llm-inception](https://github.com/NickJLange/llm-inception-plugin)** to the plugin directory under Remote APIs
- [Inception Labs](https://www.inceptionlabs.ai/) Mercury models are diffusion-based LLMs that generate text via parallel token refinement (~1,000 tok/s)
- Plugin supports `mercury-2` , plus a `diffusing` streaming option and fill-in-the-middle code completion

## Test plan

- [ ] Verify the entry renders correctly in the plugin directory docs
- [ ] Confirm the link to `https://github.com/NickJLange/llm-inception-plugin` resolves

