### PR TITLE
Add GPT-5.4 OpenAI model support

### DIFF
--- a/docs/openai-models.md
+++ b/docs/openai-models.md
@@ -69,6 +69,9 @@ OpenAI Chat: gpt-5.1
 OpenAI Chat: gpt-5.1-chat-latest
 OpenAI Chat: gpt-5.2
 OpenAI Chat: gpt-5.2-chat-latest
+OpenAI Chat: gpt-5.3-chat-latest
+OpenAI Chat: gpt-5.4
+OpenAI Chat: gpt-5.4-2026-03-05
 OpenAI Completion: gpt-3.5-turbo-instruct (aliases: 3.5-instruct, chatgpt-instruct)
 ```
 <!-- [[[end]]] -->

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1295,6 +1295,72 @@ OpenAI Chat: gpt-5.2-chat-latest
   Keys:
     key: openai
     env_var: OPENAI_API_KEY
+OpenAI Chat: gpt-5.3-chat-latest
+  Options:
+    temperature: float
+    max_tokens: int
+    top_p: float
+    frequency_penalty: float
+    presence_penalty: float
+    stop: str
+    logit_bias: dict, str
+    seed: int
+    json_object: boolean
+    reasoning_effort: str
+  Attachment types:
+    application/pdf, image/gif, image/jpeg, image/png, image/webp
+  Features:
+  - streaming
+  - schemas
+  - tools
+  - async
+  Keys:
+    key: openai
+    env_var: OPENAI_API_KEY
+OpenAI Chat: gpt-5.4
+  Options:
+    temperature: float
+    max_tokens: int
+    top_p: float
+    frequency_penalty: float
+    presence_penalty: float
+    stop: str
+    logit_bias: dict, str
+    seed: int
+    json_object: boolean
+    reasoning_effort: str
+  Attachment types:
+    application/pdf, image/gif, image/jpeg, image/png, image/webp
+  Features:
+  - streaming
+  - schemas
+  - tools
+  - async
+  Keys:
+    key: openai
+    env_var: OPENAI_API_KEY
+OpenAI Chat: gpt-5.4-2026-03-05
+  Options:
+    temperature: float
+    max_tokens: int
+    top_p: float
+    frequency_penalty: float
+    presence_penalty: float
+    stop: str
+    logit_bias: dict, str
+    seed: int
+    json_object: boolean
+    reasoning_effort: str
+  Attachment types:
+    application/pdf, image/gif, image/jpeg, image/png, image/webp
+  Features:
+  - streaming
+  - schemas
+  - tools
+  - async
+  Keys:
+    key: openai
+    env_var: OPENAI_API_KEY
 OpenAI Completion: gpt-3.5-turbo-instruct (aliases: 3.5-instruct, chatgpt-instruct)
   Options:
     temperature: float

--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -231,7 +231,30 @@ def register_models(register):
                 supports_tools=True,
             ),
         )
-        # "gpt-5.2-pro" is Responses API only
+    # "gpt-5.2-pro" is Responses API only
+    # GPT-5.3 / GPT-5.4
+    for model_id in (
+        "gpt-5.3-chat-latest",
+        "gpt-5.4",
+        "gpt-5.4-2026-03-05",
+    ):
+        register(
+            Chat(
+                model_id,
+                vision=True,
+                reasoning=True,
+                supports_schema=True,
+                supports_tools=True,
+            ),
+            AsyncChat(
+                model_id,
+                vision=True,
+                reasoning=True,
+                supports_schema=True,
+                supports_tools=True,
+            ),
+        )
+    # "gpt-5.4-pro" is Responses API only
 
     # The -instruct completion model
     register(


### PR DESCRIPTION
## Summary
- register `gpt-5.3-chat-latest`, `gpt-5.4`, and `gpt-5.4-2026-03-05` in the default OpenAI plugin
- keep `gpt-5.4-pro` excluded because it is Responses API only
- regenerate the OpenAI model docs from the CLI output

## Testing
- `llm models | rg "gpt-5\.3-chat-latest|gpt-5\.4"`
