### PR TITLE
fix(openai_models): Use correct options for o3 and o3-mini models

### DIFF
--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -140,15 +140,15 @@ def register_models(register):
         AsyncChat("o1-mini", allows_system_prompt=False),
     )
     register(
-        Chat("o3-mini", reasoning=True, supports_schema=True, supports_tools=True),
-        AsyncChat("o3-mini", reasoning=True, supports_schema=True, supports_tools=True),
+        Chat("o3-mini", is_o3=True, supports_schema=True, supports_tools=True),
+        AsyncChat("o3-mini", is_o3=True, supports_schema=True, supports_tools=True),
     )
     register(
         Chat(
-            "o3", vision=True, reasoning=True, supports_schema=True, supports_tools=True
+            "o3", vision=True, is_o3=True, supports_schema=True, supports_tools=True
         ),
         AsyncChat(
-            "o3", vision=True, reasoning=True, supports_schema=True, supports_tools=True
+            "o3", vision=True, is_o3=True, supports_schema=True, supports_tools=True
         ),
     )
     register(
@@ -504,6 +504,23 @@ class OptionsForReasoning(SharedOptions):
     )
 
 
+class OptionsForO3(llm.Options):
+    """Options for o3 and o3-mini models which only support max_completion_tokens and reasoning_effort."""
+
+    max_completion_tokens: Optional[int] = Field(
+        description="Maximum number of tokens to generate (including reasoning tokens).",
+        default=None,
+    )
+    reasoning_effort: Optional[ReasoningEffortEnum] = Field(
+        description=(
+            "Constraints effort on reasoning for reasoning models. Currently supported "
+            "values are low, medium, and high. Reducing reasoning effort can result in "
+            "faster responses and fewer tokens used on reasoning in a response."
+        ),
+        default=None,
+    )
+
+
 def _attachment(attachment):
     url = attachment.url
     base64_content = ""
@@ -551,6 +568,7 @@ class _Shared:
         supports_schema=False,
         supports_tools=False,
         allows_system_prompt=True,
+        is_o3=False,
     ):
         self.model_id = model_id
         self.key = key
@@ -568,7 +586,9 @@ class _Shared:
 
         self.attachment_types = set()
 
-        if reasoning:
+        if is_o3:
+            self.Options = OptionsForO3
+        elif reasoning:
             self.Options = OptionsForReasoning
 
         if vision:


### PR DESCRIPTION
## Summary

Fixes #731

The o3 and o3-mini models don't support `temperature`, `max_tokens`, `top_p`, `frequency_penalty`, and `presence_penalty` parameters. When these parameters are passed to the OpenAI API, it returns an error like:

```
Unsupported parameter: 'temperature' is not supported with this model.
```

This PR creates a new `OptionsForO3` class that only includes the supported parameters:
- `max_completion_tokens` - Maximum number of tokens to generate (including reasoning tokens)
- `reasoning_effort` - Constraints effort on reasoning (low, medium, high)

## Changes

- Added `OptionsForO3` class with only `max_completion_tokens` and `reasoning_effort` options
- Added `is_o3` parameter to `_Shared` class to distinguish o3 models from other reasoning models
- Updated o3 and o3-mini model registrations to use `is_o3=True` instead of `reasoning=True`

## Testing

- Verified that o3 and o3-mini models now only expose `max_completion_tokens` and `reasoning_effort` options
- Verified that other reasoning models (like o1) still use `OptionsForReasoning` with all standard options
- Ran existing tests to ensure no regressions