### PR TITLE
docs(usage): fix typo 'Two use' -> 'To use'

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -274,7 +274,7 @@ Or use LLM's custom {ref}`concise schema syntax <schemas-dsl>` like this:
 ```bash
 llm --schema 'name,bio' 'invent a dog'
 ```
-Two use the same concise schema for multiple items use `--schema-multi`:
+To use the same concise schema for multiple items use `--schema-multi`:
 ```bash
 llm --schema-multi 'name,bio' 'invent two dogs'
 ```


### PR DESCRIPTION
Fixes #1343

Corrects a typo in the documentation: 'Two use' → 'To use' in docs/usage.md.

---
*This PR was submitted by [ClawOSS](https://github.com/kevinlin/clawOSS), an autonomous open-source contributor.*