### PR TITLE
fix: Call after_call callback when tool doesn't exist

### DIFF
--- a/llm/models.py
+++ b/llm/models.py
@@ -1073,14 +1073,20 @@ class Response(_BaseResponse):
 
             if tool is None:
                 msg = 'tool "{}" does not exist'.format(tool_call.name)
-                tool_results.append(
-                    ToolResult(
-                        name=tool_call.name,
-                        output="Error: " + msg,
-                        tool_call_id=tool_call.tool_call_id,
-                        exception=KeyError(msg),
-                    )
+                tool_result_obj = ToolResult(
+                    name=tool_call.name,
+                    output="Error: " + msg,
+                    tool_call_id=tool_call.tool_call_id,
+                    exception=KeyError(msg),
                 )
+                if after_call:
+                    cb_result = after_call(tool, tool_call, tool_result_obj)
+                    if inspect.isawaitable(cb_result):
+                        raise TypeError(
+                            "Asynchronous 'after_call' callback provided to a synchronous tool execution context. "
+                            "Please use an async chain/response or a synchronous callback."
+                        )
+                tool_results.append(tool_result_obj)
                 continue
 
             if not tool.implementation:
@@ -1258,9 +1264,31 @@ class AsyncResponse(_BaseResponse):
             if tool is None:
                 output = f'Error: tool "{tc.name}" does not exist'
                 exception = KeyError(tc.name)
+                tr = ToolResult(
+                    name=tc.name,
+                    output=output,
+                    tool_call_id=tc.tool_call_id,
+                    exception=exception,
+                )
+                if after_call:
+                    cb2 = after_call(tool, tc, tr)
+                    if inspect.isawaitable(cb2):
+                        await cb2
+                indexed_results.append((idx, tr))
             elif not tool.implementation:
                 output = f'Error: tool "{tc.name}" has no implementation'
                 exception = KeyError(tc.name)
+                tr = ToolResult(
+                    name=tc.name,
+                    output=output,
+                    tool_call_id=tc.tool_call_id,
+                    exception=exception,
+                )
+                if after_call:
+                    cb2 = after_call(tool, tc, tr)
+                    if inspect.isawaitable(cb2):
+                        await cb2
+                indexed_results.append((idx, tr))
             elif inspect.iscoroutinefunction(tool.implementation):
 
                 async def run_async(tc=tc, tool=tool, idx=idx):
@@ -1341,6 +1369,17 @@ class AsyncResponse(_BaseResponse):
                 if tool is None:
                     output = f'Error: tool "{tc.name}" does not exist'
                     exception = KeyError(tc.name)
+                    tr = ToolResult(
+                        name=tc.name,
+                        output=output,
+                        tool_call_id=tc.tool_call_id,
+                        exception=exception,
+                    )
+                    if after_call:
+                        cb2 = after_call(tool, tc, tr)
+                        if inspect.isawaitable(cb2):
+                            await cb2
+                    indexed_results.append((idx, tr))
                 else:
                     try:
                         res = tool.implementation(**tc.arguments)
@@ -1367,7 +1406,7 @@ class AsyncResponse(_BaseResponse):
                         exception=exception,
                     )
 
-                    if tool is not None and after_call:
+                    if after_call:
                         cb2 = after_call(tool, tc, tr)
                         if inspect.isawaitable(cb2):
                             await cb2

--- a/tests/test_tools_debug_missing.py
+++ b/tests/test_tools_debug_missing.py
@@ -1,0 +1,78 @@
+"""Test for issue #1151: No tool debug output when tool doesn't exist"""
+import json
+import textwrap
+from click.testing import CliRunner
+import llm
+import llm.cli
+from llm.plugins import pm
+
+
+def test_chat_tools_debug_output_when_tool_missing(logs_db):
+    """Test that --td flag produces debug output when model calls a non-existent tool.
+    
+    This is a regression test for https://github.com/simonw/llm/issues/1151
+    When a model tries to call a tool that doesn't exist, the --td flag should
+    still show the attempted tool call and the error.
+    """
+    runner = CliRunner()
+    
+    # Define a tool function
+    functions = textwrap.dedent(
+        """
+    def upper(text: str) -> str:
+        "Convert text to upper case"
+        return text.upper()                         
+    """
+    )
+    
+    # Run chat with --td (tools debug) flag
+    # The model will try to call "nonexistent_tool" which is not registered
+    result = runner.invoke(
+        llm.cli.cli,
+        ["chat", "-m", "echo", "--functions", functions, "--td"],
+        input="\n".join([
+            json.dumps({
+                "prompt": "Test",
+                "tool_calls": [{"name": "nonexistent_tool", "arguments": {"text": "hello"}}]
+            }),
+            "quit",
+        ]),
+        catch_exceptions=False,
+    )
+    
+    assert result.exit_code == 0
+    # The debug output should show the attempted tool call even though it doesn't exist
+    assert "Tool call: nonexistent_tool" in result.output
+    assert "does not exist" in result.output
+
+
+def test_prompt_tools_debug_output_when_tool_missing():
+    """Test that --td flag produces debug output when model calls a non-existent tool via prompt."""
+    runner = CliRunner()
+    
+    functions = textwrap.dedent(
+        """
+    def upper(text: str) -> str:
+        "Convert text to upper case"
+        return text.upper()                         
+    """
+    )
+    
+    result = runner.invoke(
+        llm.cli.cli,
+        [
+            "prompt",
+            "-m", "echo",
+            "--functions", functions,
+            "--td",
+            json.dumps({
+                "prompt": "Test",
+                "tool_calls": [{"name": "nonexistent_tool", "arguments": {"text": "hello"}}]
+            }),
+        ],
+        catch_exceptions=False,
+    )
+    
+    assert result.exit_code == 0
+    assert "Tool call: nonexistent_tool" in result.output
+    assert "does not exist" in result.output


### PR DESCRIPTION
Fixes #1151

The --td (tool debug) flag was not showing debug output when a model tried to call a tool that doesn't exist. This happened because the after_call callback was not being invoked when:
1. The tool doesn't exist (tool is None)
2. The tool has no implementation

Changes:
- Response.execute_tool_calls(): Call after_call when tool is None
- AsyncResponse.execute_tool_calls(): Call after_call when tool is None or has no implementation in both sync and async branches

This ensures that users always see debug output when using --td, even when the model calls a tool incorrectly (e.g., using the wrong tool name).