### PR TITLE
feat: add MiniMax as built-in LLM provider (M3 default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,10 @@ llm -m claude-4-opus 'Impress me with wild facts about turnips'
 ```bash
 llm keys set minimax
 # Paste MiniMax API key here
-llm -m MiniMax-M2.5 'Tell me about the Great Wall of China'
+llm -m MiniMax-M2.7 'Tell me about the Great Wall of China'
 
 # Use the faster model variant
-llm -m MiniMax-M2.5-highspeed 'Summarize this text' < article.txt
+llm -m MiniMax-M2.7-highspeed 'Summarize this text' < article.txt
 ```
 
 You can also [install a plugin](https://llm.datasette.io/en/stable/plugins/installing-plugins.html#installing-plugins) to access models that can run on your local device. If you use [Ollama](https://ollama.com/):

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ cog.out(readme_markdown)
 [![Discord](https://img.shields.io/discord/823971286308356157?label=discord)](https://datasette.io/discord-llm)
 [![Homebrew](https://img.shields.io/homebrew/installs/dy/llm?color=yellow&label=homebrew&logo=homebrew)](https://formulae.brew.sh/formula/llm)
 
-A CLI tool and Python library for interacting with **OpenAI**, **Anthropic’s Claude**, **Google’s Gemini**, **Meta’s Llama** and dozens of other Large Language Models, both via remote APIs and with models that can be installed and run on your own machine.
+A CLI tool and Python library for interacting with **OpenAI**, **Anthropic’s Claude**, **Google’s Gemini**, **Meta’s Llama**, **MiniMax** and dozens of other Large Language Models, both via remote APIs and with models that can be installed and run on your own machine.
 
 Watch **[Language models on the command-line](https://www.youtube.com/watch?v=QUXQNi6jQ30)** on YouTube for a demo or [read the accompanying detailed notes](https://simonwillison.net/2024/Jun/17/cli-language-models/).
 
@@ -97,6 +97,17 @@ llm install llm-anthropic
 llm keys set anthropic
 # Paste Anthropic API key here
 llm -m claude-4-opus 'Impress me with wild facts about turnips'
+```
+
+[MiniMax](https://www.minimaxi.com/) models are available as built-in models with no plugin required:
+
+```bash
+llm keys set minimax
+# Paste MiniMax API key here
+llm -m MiniMax-M2.5 'Tell me about the Great Wall of China'
+
+# Use the faster model variant
+llm -m MiniMax-M2.5-highspeed 'Summarize this text' < article.txt
 ```
 
 You can also [install a plugin](https://llm.datasette.io/en/stable/plugins/installing-plugins.html#installing-plugins) to access models that can run on your local device. If you use [Ollama](https://ollama.com/):

--- a/README.md
+++ b/README.md
@@ -104,10 +104,13 @@ llm -m claude-4-opus 'Impress me with wild facts about turnips'
 ```bash
 llm keys set minimax
 # Paste MiniMax API key here
-llm -m MiniMax-M2.7 'Tell me about the Great Wall of China'
+llm -m MiniMax-M3 'Tell me about the Great Wall of China'
+
+# Use the previous-generation model
+llm -m MiniMax-M2.7 'Summarize this text' < article.txt
 
 # Use the faster model variant
-llm -m MiniMax-M2.7-highspeed 'Summarize this text' < article.txt
+llm -m MiniMax-M2.7-highspeed 'Write a haiku about databases'
 ```
 
 You can also [install a plugin](https://llm.datasette.io/en/stable/plugins/installing-plugins.html#installing-plugins) to access models that can run on your local device. If you use [Ollama](https://ollama.com/):

--- a/llm/default_plugins/minimax_models.py
+++ b/llm/default_plugins/minimax_models.py
@@ -1,0 +1,78 @@
+from llm import hookimpl
+from llm.default_plugins.openai_models import Chat, AsyncChat, SharedOptions
+
+from pydantic import Field
+
+from typing import Optional
+
+
+class MiniMaxOptions(SharedOptions):
+    temperature: Optional[float] = Field(
+        description=(
+            "What sampling temperature to use, between 0.01 and 1. Higher values like "
+            "0.8 will make the output more random, while lower values like 0.2 will "
+            "make it more focused and deterministic."
+        ),
+        gt=0,
+        le=1,
+        default=None,
+    )
+    json_object: Optional[bool] = Field(
+        description="Output a valid JSON object {...}. Prompt must mention JSON.",
+        default=None,
+    )
+
+
+class MiniMaxChat(Chat):
+    needs_key = "minimax"
+    key_env_var = "MINIMAX_API_KEY"
+
+    class Options(MiniMaxOptions):
+        pass
+
+    def __str__(self) -> str:
+        return "MiniMax Chat: {}".format(self.model_id)
+
+
+class MiniMaxAsyncChat(AsyncChat):
+    needs_key = "minimax"
+    key_env_var = "MINIMAX_API_KEY"
+
+    class Options(MiniMaxOptions):
+        pass
+
+    def __str__(self) -> str:
+        return "MiniMax Chat: {}".format(self.model_id)
+
+
+MINIMAX_API_BASE = "https://api.minimax.io/v1"
+
+
+@hookimpl
+def register_models(register):
+    register(
+        MiniMaxChat(
+            "MiniMax-M2.5",
+            model_name="MiniMax-M2.5",
+            api_base=MINIMAX_API_BASE,
+        ),
+        MiniMaxAsyncChat(
+            "MiniMax-M2.5",
+            model_name="MiniMax-M2.5",
+            api_base=MINIMAX_API_BASE,
+        ),
+        aliases=("minimax", "m2.5"),
+    )
+    register(
+        MiniMaxChat(
+            "MiniMax-M2.5-highspeed",
+            model_name="MiniMax-M2.5-highspeed",
+            api_base=MINIMAX_API_BASE,
+        ),
+        MiniMaxAsyncChat(
+            "MiniMax-M2.5-highspeed",
+            model_name="MiniMax-M2.5-highspeed",
+            api_base=MINIMAX_API_BASE,
+        ),
+        aliases=("minimax-fast", "m2.5-highspeed"),
+    )

--- a/llm/default_plugins/minimax_models.py
+++ b/llm/default_plugins/minimax_models.py
@@ -52,6 +52,32 @@ MINIMAX_API_BASE = "https://api.minimax.io/v1"
 def register_models(register):
     register(
         MiniMaxChat(
+            "MiniMax-M2.7",
+            model_name="MiniMax-M2.7",
+            api_base=MINIMAX_API_BASE,
+        ),
+        MiniMaxAsyncChat(
+            "MiniMax-M2.7",
+            model_name="MiniMax-M2.7",
+            api_base=MINIMAX_API_BASE,
+        ),
+        aliases=("minimax", "m2.7"),
+    )
+    register(
+        MiniMaxChat(
+            "MiniMax-M2.7-highspeed",
+            model_name="MiniMax-M2.7-highspeed",
+            api_base=MINIMAX_API_BASE,
+        ),
+        MiniMaxAsyncChat(
+            "MiniMax-M2.7-highspeed",
+            model_name="MiniMax-M2.7-highspeed",
+            api_base=MINIMAX_API_BASE,
+        ),
+        aliases=("minimax-fast", "m2.7-highspeed"),
+    )
+    register(
+        MiniMaxChat(
             "MiniMax-M2.5",
             model_name="MiniMax-M2.5",
             api_base=MINIMAX_API_BASE,
@@ -61,7 +87,7 @@ def register_models(register):
             model_name="MiniMax-M2.5",
             api_base=MINIMAX_API_BASE,
         ),
-        aliases=("minimax", "m2.5"),
+        aliases=("m2.5",),
     )
     register(
         MiniMaxChat(
@@ -74,5 +100,5 @@ def register_models(register):
             model_name="MiniMax-M2.5-highspeed",
             api_base=MINIMAX_API_BASE,
         ),
-        aliases=("minimax-fast", "m2.5-highspeed"),
+        aliases=("m2.5-highspeed",),
     )

--- a/llm/default_plugins/minimax_models.py
+++ b/llm/default_plugins/minimax_models.py
@@ -50,6 +50,22 @@ MINIMAX_API_BASE = "https://api.minimax.io/v1"
 
 @hookimpl
 def register_models(register):
+    # MiniMax-M3 is the latest flagship model, set as the default.
+    register(
+        MiniMaxChat(
+            "MiniMax-M3",
+            model_name="MiniMax-M3",
+            api_base=MINIMAX_API_BASE,
+            vision=True,
+        ),
+        MiniMaxAsyncChat(
+            "MiniMax-M3",
+            model_name="MiniMax-M3",
+            api_base=MINIMAX_API_BASE,
+            vision=True,
+        ),
+        aliases=("minimax", "m3"),
+    )
     register(
         MiniMaxChat(
             "MiniMax-M2.7",
@@ -61,7 +77,7 @@ def register_models(register):
             model_name="MiniMax-M2.7",
             api_base=MINIMAX_API_BASE,
         ),
-        aliases=("minimax", "m2.7"),
+        aliases=("m2.7",),
     )
     register(
         MiniMaxChat(
@@ -75,30 +91,4 @@ def register_models(register):
             api_base=MINIMAX_API_BASE,
         ),
         aliases=("minimax-fast", "m2.7-highspeed"),
-    )
-    register(
-        MiniMaxChat(
-            "MiniMax-M2.5",
-            model_name="MiniMax-M2.5",
-            api_base=MINIMAX_API_BASE,
-        ),
-        MiniMaxAsyncChat(
-            "MiniMax-M2.5",
-            model_name="MiniMax-M2.5",
-            api_base=MINIMAX_API_BASE,
-        ),
-        aliases=("m2.5",),
-    )
-    register(
-        MiniMaxChat(
-            "MiniMax-M2.5-highspeed",
-            model_name="MiniMax-M2.5-highspeed",
-            api_base=MINIMAX_API_BASE,
-        ),
-        MiniMaxAsyncChat(
-            "MiniMax-M2.5-highspeed",
-            model_name="MiniMax-M2.5-highspeed",
-            api_base=MINIMAX_API_BASE,
-        ),
-        aliases=("m2.5-highspeed",),
     )

--- a/llm/plugins.py
+++ b/llm/plugins.py
@@ -7,6 +7,7 @@ from . import hookspecs
 
 DEFAULT_PLUGINS = (
     "llm.default_plugins.openai_models",
+    "llm.default_plugins.minimax_models",
     "llm.default_plugins.default_tools",
 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "llm"
 version = "0.28"
-description = "CLI utility and Python library for interacting with Large Language Models from organizations like OpenAI, Anthropic and Gemini plus local models installed on your own machine."
+description = "CLI utility and Python library for interacting with Large Language Models from organizations like OpenAI, Anthropic, Gemini and MiniMax plus local models installed on your own machine."
 readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
     { name = "Simon Willison" },

--- a/tests/test_minimax_models.py
+++ b/tests/test_minimax_models.py
@@ -1,0 +1,487 @@
+"""Tests for the MiniMax models default plugin."""
+
+import json
+
+from click.testing import CliRunner
+from llm.cli import cli
+from llm.default_plugins.minimax_models import (
+    MiniMaxChat,
+    MiniMaxAsyncChat,
+    MiniMaxOptions,
+    MINIMAX_API_BASE,
+)
+import pytest
+from pytest_httpx import IteratorStream
+
+
+# ---------------------------------------------------------------------------
+# Unit tests – model registration, options, and string representation
+# ---------------------------------------------------------------------------
+
+
+class TestModelRegistration:
+    """Verify MiniMax models appear in the model registry."""
+
+    def test_minimax_m25_registered(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["models", "list"])
+        assert result.exit_code == 0
+        assert "MiniMax-M2.5" in result.output
+
+    def test_minimax_m25_highspeed_registered(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["models", "list"])
+        assert result.exit_code == 0
+        assert "MiniMax-M2.5-highspeed" in result.output
+
+    def test_minimax_aliases(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["aliases", "list"])
+        assert result.exit_code == 0
+        assert "minimax" in result.output
+        assert "m2.5" in result.output
+        assert "minimax-fast" in result.output
+        assert "m2.5-highspeed" in result.output
+
+
+class TestMiniMaxChatModel:
+    """Verify MiniMaxChat model attributes."""
+
+    def test_needs_key(self):
+        model = MiniMaxChat("test-model", api_base=MINIMAX_API_BASE)
+        assert model.needs_key == "minimax"
+
+    def test_key_env_var(self):
+        model = MiniMaxChat("test-model", api_base=MINIMAX_API_BASE)
+        assert model.key_env_var == "MINIMAX_API_KEY"
+
+    def test_str(self):
+        model = MiniMaxChat("MiniMax-M2.5", api_base=MINIMAX_API_BASE)
+        assert str(model) == "MiniMax Chat: MiniMax-M2.5"
+
+    def test_api_base(self):
+        model = MiniMaxChat("MiniMax-M2.5", api_base=MINIMAX_API_BASE)
+        assert model.api_base == "https://api.minimax.io/v1"
+
+
+class TestMiniMaxAsyncChatModel:
+    """Verify MiniMaxAsyncChat model attributes."""
+
+    def test_needs_key(self):
+        model = MiniMaxAsyncChat("test-model", api_base=MINIMAX_API_BASE)
+        assert model.needs_key == "minimax"
+
+    def test_key_env_var(self):
+        model = MiniMaxAsyncChat("test-model", api_base=MINIMAX_API_BASE)
+        assert model.key_env_var == "MINIMAX_API_KEY"
+
+    def test_str(self):
+        model = MiniMaxAsyncChat("MiniMax-M2.5", api_base=MINIMAX_API_BASE)
+        assert str(model) == "MiniMax Chat: MiniMax-M2.5"
+
+
+class TestMiniMaxOptions:
+    """Verify MiniMax-specific option constraints."""
+
+    def test_temperature_valid(self):
+        opts = MiniMaxOptions(temperature=0.5)
+        assert opts.temperature == 0.5
+
+    def test_temperature_max(self):
+        opts = MiniMaxOptions(temperature=1.0)
+        assert opts.temperature == 1.0
+
+    def test_temperature_near_zero(self):
+        opts = MiniMaxOptions(temperature=0.01)
+        assert opts.temperature == 0.01
+
+    def test_temperature_zero_rejected(self):
+        with pytest.raises(Exception):
+            MiniMaxOptions(temperature=0)
+
+    def test_temperature_above_one_rejected(self):
+        with pytest.raises(Exception):
+            MiniMaxOptions(temperature=1.5)
+
+    def test_temperature_negative_rejected(self):
+        with pytest.raises(Exception):
+            MiniMaxOptions(temperature=-0.5)
+
+    def test_json_object_option(self):
+        opts = MiniMaxOptions(json_object=True)
+        assert opts.json_object is True
+
+
+# ---------------------------------------------------------------------------
+# Unit tests – mocked HTTP calls (non-streaming)
+# ---------------------------------------------------------------------------
+
+
+MINIMAX_CHAT_URL = "https://api.minimax.io/v1/chat/completions"
+
+
+@pytest.fixture
+def mocked_minimax_chat(httpx_mock):
+    httpx_mock.add_response(
+        method="POST",
+        url=MINIMAX_CHAT_URL,
+        json={
+            "id": "chatcmpl-minimax-001",
+            "object": "chat.completion",
+            "created": 1700000000,
+            "model": "MiniMax-M2.5",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "Hello from MiniMax!",
+                        "refusal": None,
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+            },
+        },
+        headers={"Content-Type": "application/json"},
+    )
+    return httpx_mock
+
+
+class TestMiniMaxNonStreaming:
+    """Test MiniMax models with mocked non-streaming HTTP responses."""
+
+    def test_minimax_prompt(self, mocked_minimax_chat):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "-m",
+                "MiniMax-M2.5",
+                "--key",
+                "test-key",
+                "--no-stream",
+                "Hello",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Hello from MiniMax!" in result.output
+
+    def test_minimax_alias(self, mocked_minimax_chat):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["-m", "minimax", "--key", "test-key", "--no-stream", "Hello"],
+        )
+        assert result.exit_code == 0
+        assert "Hello from MiniMax!" in result.output
+
+    def test_minimax_with_system_prompt(self, mocked_minimax_chat):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "-m",
+                "MiniMax-M2.5",
+                "--key",
+                "test-key",
+                "--no-stream",
+                "-s",
+                "You are helpful.",
+                "Hello",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Hello from MiniMax!" in result.output
+
+    def test_minimax_with_temperature(self, mocked_minimax_chat):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "-m",
+                "MiniMax-M2.5",
+                "--key",
+                "test-key",
+                "--no-stream",
+                "-o",
+                "temperature",
+                "0.7",
+                "Hello",
+            ],
+        )
+        assert result.exit_code == 0
+
+    def test_minimax_temperature_zero_cli(self):
+        """Temperature=0 should fail validation for MiniMax."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "-m",
+                "MiniMax-M2.5",
+                "--key",
+                "test-key",
+                "--no-stream",
+                "-o",
+                "temperature",
+                "0",
+                "Hello",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "greater than 0" in result.output
+
+    def test_minimax_temperature_above_one_cli(self):
+        """Temperature>1 should fail validation for MiniMax."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "-m",
+                "MiniMax-M2.5",
+                "--key",
+                "test-key",
+                "--no-stream",
+                "-o",
+                "temperature",
+                "1.5",
+                "Hello",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "less than or equal to 1" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Unit tests – mocked HTTP calls (streaming)
+# ---------------------------------------------------------------------------
+
+
+def minimax_stream_events():
+    """Generate SSE events mimicking MiniMax streaming response."""
+    for delta, finish_reason in (
+        ({"role": "assistant", "content": ""}, None),
+        ({"content": "Streaming"}, None),
+        ({"content": " from"}, None),
+        ({"content": " MiniMax!"}, None),
+        ({}, "stop"),
+    ):
+        yield "data: {}\n\n".format(
+            json.dumps(
+                {
+                    "id": "chatcmpl-minimax-stream-001",
+                    "object": "chat.completion.chunk",
+                    "created": 1700000000,
+                    "model": "MiniMax-M2.5",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": delta,
+                            "finish_reason": finish_reason,
+                        }
+                    ],
+                }
+            )
+        ).encode("utf-8")
+    yield "data: [DONE]\n\n".encode("utf-8")
+
+
+@pytest.fixture
+def mocked_minimax_chat_stream(httpx_mock):
+    httpx_mock.add_response(
+        method="POST",
+        url=MINIMAX_CHAT_URL,
+        stream=IteratorStream(minimax_stream_events()),
+        headers={"Content-Type": "text/event-stream"},
+    )
+    return httpx_mock
+
+
+class TestMiniMaxStreaming:
+    """Test MiniMax models with mocked streaming HTTP responses."""
+
+    def test_minimax_stream(self, mocked_minimax_chat_stream):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["-m", "MiniMax-M2.5", "--key", "test-key", "Hello"],
+        )
+        assert result.exit_code == 0
+        assert "Streaming from MiniMax!" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Unit tests – highspeed model variant
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mocked_minimax_highspeed(httpx_mock):
+    httpx_mock.add_response(
+        method="POST",
+        url=MINIMAX_CHAT_URL,
+        json={
+            "id": "chatcmpl-minimax-hs-001",
+            "object": "chat.completion",
+            "created": 1700000000,
+            "model": "MiniMax-M2.5-highspeed",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "Fast response from MiniMax!",
+                        "refusal": None,
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 8,
+                "completion_tokens": 6,
+                "total_tokens": 14,
+            },
+        },
+        headers={"Content-Type": "application/json"},
+    )
+    return httpx_mock
+
+
+class TestMiniMaxHighspeed:
+    """Test MiniMax-M2.5-highspeed model variant."""
+
+    def test_highspeed_prompt(self, mocked_minimax_highspeed):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "-m",
+                "MiniMax-M2.5-highspeed",
+                "--key",
+                "test-key",
+                "--no-stream",
+                "Hello",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Fast response from MiniMax!" in result.output
+
+    def test_highspeed_alias(self, mocked_minimax_highspeed):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "-m",
+                "minimax-fast",
+                "--key",
+                "test-key",
+                "--no-stream",
+                "Hello",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Fast response from MiniMax!" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Unit tests – usage tracking
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxUsage:
+    """Test that token usage is properly tracked."""
+
+    def test_usage_reported(self, monkeypatch, tmpdir, mocked_minimax_chat):
+        user_path = tmpdir / "user_dir"
+        monkeypatch.setenv("LLM_USER_PATH", str(user_path))
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "-m",
+                "MiniMax-M2.5",
+                "--key",
+                "test-key",
+                "--no-stream",
+                "-u",
+                "Hello",
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert "Hello from MiniMax!" in result.output
+        assert "Token usage: 10 input, 5 output" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Integration tests – live API calls (skipped unless MINIMAX_API_KEY is set)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def minimax_api_key():
+    import os
+
+    key = os.environ.get("MINIMAX_API_KEY")
+    if not key:
+        pytest.skip("MINIMAX_API_KEY not set")
+    return key
+
+
+class TestMiniMaxIntegration:
+    """Integration tests that call the real MiniMax API."""
+
+    @pytest.mark.integration
+    def test_live_prompt(self, minimax_api_key):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "-m",
+                "MiniMax-M2.5",
+                "--key",
+                minimax_api_key,
+                "--no-stream",
+                "Say hello in exactly three words.",
+            ],
+        )
+        assert result.exit_code == 0
+        assert len(result.output.strip()) > 0
+
+    @pytest.mark.integration
+    def test_live_stream(self, minimax_api_key):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "-m",
+                "MiniMax-M2.5",
+                "--key",
+                minimax_api_key,
+                "What is 2+2? Answer with just the number.",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "4" in result.output
+
+    @pytest.mark.integration
+    def test_live_highspeed(self, minimax_api_key):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "-m",
+                "MiniMax-M2.5-highspeed",
+                "--key",
+                minimax_api_key,
+                "--no-stream",
+                "Say hi.",
+            ],
+        )
+        assert result.exit_code == 0
+        assert len(result.output.strip()) > 0

--- a/tests/test_minimax_models.py
+++ b/tests/test_minimax_models.py
@@ -22,6 +22,18 @@ from pytest_httpx import IteratorStream
 class TestModelRegistration:
     """Verify MiniMax models appear in the model registry."""
 
+    def test_minimax_m27_registered(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["models", "list"])
+        assert result.exit_code == 0
+        assert "MiniMax-M2.7" in result.output
+
+    def test_minimax_m27_highspeed_registered(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["models", "list"])
+        assert result.exit_code == 0
+        assert "MiniMax-M2.7-highspeed" in result.output
+
     def test_minimax_m25_registered(self):
         runner = CliRunner()
         result = runner.invoke(cli, ["models", "list"])
@@ -39,9 +51,28 @@ class TestModelRegistration:
         result = runner.invoke(cli, ["aliases", "list"])
         assert result.exit_code == 0
         assert "minimax" in result.output
-        assert "m2.5" in result.output
+        assert "m2.7" in result.output
         assert "minimax-fast" in result.output
-        assert "m2.5-highspeed" in result.output
+        assert "m2.7-highspeed" in result.output
+
+    def test_minimax_default_alias_points_to_m27(self):
+        """The 'minimax' alias should resolve to MiniMax-M2.7."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["aliases", "list"])
+        assert result.exit_code == 0
+        for line in result.output.splitlines():
+            if line.strip().startswith("minimax"):
+                assert "MiniMax-M2.7" in line
+                break
+
+    def test_m27_registered_before_m25(self):
+        """M2.7 should appear before M2.5 in the model list."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["models", "list"])
+        assert result.exit_code == 0
+        m27_pos = result.output.index("MiniMax-M2.7")
+        m25_pos = result.output.index("MiniMax-M2.5")
+        assert m27_pos < m25_pos
 
 
 class TestMiniMaxChatModel:
@@ -443,7 +474,7 @@ class TestMiniMaxIntegration:
             cli,
             [
                 "-m",
-                "MiniMax-M2.5",
+                "MiniMax-M2.7",
                 "--key",
                 minimax_api_key,
                 "--no-stream",
@@ -460,7 +491,7 @@ class TestMiniMaxIntegration:
             cli,
             [
                 "-m",
-                "MiniMax-M2.5",
+                "MiniMax-M2.7",
                 "--key",
                 minimax_api_key,
                 "What is 2+2? Answer with just the number.",
@@ -476,7 +507,7 @@ class TestMiniMaxIntegration:
             cli,
             [
                 "-m",
-                "MiniMax-M2.5-highspeed",
+                "MiniMax-M2.7-highspeed",
                 "--key",
                 minimax_api_key,
                 "--no-stream",

--- a/tests/test_minimax_models.py
+++ b/tests/test_minimax_models.py
@@ -22,6 +22,12 @@ from pytest_httpx import IteratorStream
 class TestModelRegistration:
     """Verify MiniMax models appear in the model registry."""
 
+    def test_minimax_m3_registered(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["models", "list"])
+        assert result.exit_code == 0
+        assert "MiniMax-M3" in result.output
+
     def test_minimax_m27_registered(self):
         runner = CliRunner()
         result = runner.invoke(cli, ["models", "list"])
@@ -34,45 +40,42 @@ class TestModelRegistration:
         assert result.exit_code == 0
         assert "MiniMax-M2.7-highspeed" in result.output
 
-    def test_minimax_m25_registered(self):
+    def test_minimax_m25_removed(self):
+        """Older MiniMax-M2.5 models should no longer be registered."""
         runner = CliRunner()
         result = runner.invoke(cli, ["models", "list"])
         assert result.exit_code == 0
-        assert "MiniMax-M2.5" in result.output
-
-    def test_minimax_m25_highspeed_registered(self):
-        runner = CliRunner()
-        result = runner.invoke(cli, ["models", "list"])
-        assert result.exit_code == 0
-        assert "MiniMax-M2.5-highspeed" in result.output
+        assert "MiniMax-M2.5" not in result.output
+        assert "MiniMax-M2.5-highspeed" not in result.output
 
     def test_minimax_aliases(self):
         runner = CliRunner()
         result = runner.invoke(cli, ["aliases", "list"])
         assert result.exit_code == 0
         assert "minimax" in result.output
+        assert "m3" in result.output
         assert "m2.7" in result.output
         assert "minimax-fast" in result.output
         assert "m2.7-highspeed" in result.output
 
-    def test_minimax_default_alias_points_to_m27(self):
-        """The 'minimax' alias should resolve to MiniMax-M2.7."""
+    def test_minimax_default_alias_points_to_m3(self):
+        """The 'minimax' alias should resolve to MiniMax-M3."""
         runner = CliRunner()
         result = runner.invoke(cli, ["aliases", "list"])
         assert result.exit_code == 0
         for line in result.output.splitlines():
             if line.strip().startswith("minimax"):
-                assert "MiniMax-M2.7" in line
+                assert "MiniMax-M3" in line
                 break
 
-    def test_m27_registered_before_m25(self):
-        """M2.7 should appear before M2.5 in the model list."""
+    def test_m3_registered_before_m27(self):
+        """M3 should appear before M2.7 in the model list."""
         runner = CliRunner()
         result = runner.invoke(cli, ["models", "list"])
         assert result.exit_code == 0
+        m3_pos = result.output.index("MiniMax-M3")
         m27_pos = result.output.index("MiniMax-M2.7")
-        m25_pos = result.output.index("MiniMax-M2.5")
-        assert m27_pos < m25_pos
+        assert m3_pos < m27_pos
 
 
 class TestMiniMaxChatModel:
@@ -87,12 +90,18 @@ class TestMiniMaxChatModel:
         assert model.key_env_var == "MINIMAX_API_KEY"
 
     def test_str(self):
-        model = MiniMaxChat("MiniMax-M2.5", api_base=MINIMAX_API_BASE)
-        assert str(model) == "MiniMax Chat: MiniMax-M2.5"
+        model = MiniMaxChat("MiniMax-M3", api_base=MINIMAX_API_BASE)
+        assert str(model) == "MiniMax Chat: MiniMax-M3"
 
     def test_api_base(self):
-        model = MiniMaxChat("MiniMax-M2.5", api_base=MINIMAX_API_BASE)
+        model = MiniMaxChat("MiniMax-M3", api_base=MINIMAX_API_BASE)
         assert model.api_base == "https://api.minimax.io/v1"
+
+    def test_m3_supports_vision(self):
+        """MiniMax-M3 should accept image attachments."""
+        model = MiniMaxChat("MiniMax-M3", api_base=MINIMAX_API_BASE, vision=True)
+        assert "image/png" in model.attachment_types
+        assert "image/jpeg" in model.attachment_types
 
 
 class TestMiniMaxAsyncChatModel:
@@ -107,8 +116,8 @@ class TestMiniMaxAsyncChatModel:
         assert model.key_env_var == "MINIMAX_API_KEY"
 
     def test_str(self):
-        model = MiniMaxAsyncChat("MiniMax-M2.5", api_base=MINIMAX_API_BASE)
-        assert str(model) == "MiniMax Chat: MiniMax-M2.5"
+        model = MiniMaxAsyncChat("MiniMax-M3", api_base=MINIMAX_API_BASE)
+        assert str(model) == "MiniMax Chat: MiniMax-M3"
 
 
 class TestMiniMaxOptions:
@@ -160,7 +169,7 @@ def mocked_minimax_chat(httpx_mock):
             "id": "chatcmpl-minimax-001",
             "object": "chat.completion",
             "created": 1700000000,
-            "model": "MiniMax-M2.5",
+            "model": "MiniMax-M3",
             "choices": [
                 {
                     "index": 0,
@@ -192,7 +201,7 @@ class TestMiniMaxNonStreaming:
             cli,
             [
                 "-m",
-                "MiniMax-M2.5",
+                "MiniMax-M3",
                 "--key",
                 "test-key",
                 "--no-stream",
@@ -217,7 +226,7 @@ class TestMiniMaxNonStreaming:
             cli,
             [
                 "-m",
-                "MiniMax-M2.5",
+                "MiniMax-M3",
                 "--key",
                 "test-key",
                 "--no-stream",
@@ -235,7 +244,7 @@ class TestMiniMaxNonStreaming:
             cli,
             [
                 "-m",
-                "MiniMax-M2.5",
+                "MiniMax-M3",
                 "--key",
                 "test-key",
                 "--no-stream",
@@ -254,7 +263,7 @@ class TestMiniMaxNonStreaming:
             cli,
             [
                 "-m",
-                "MiniMax-M2.5",
+                "MiniMax-M3",
                 "--key",
                 "test-key",
                 "--no-stream",
@@ -274,7 +283,7 @@ class TestMiniMaxNonStreaming:
             cli,
             [
                 "-m",
-                "MiniMax-M2.5",
+                "MiniMax-M3",
                 "--key",
                 "test-key",
                 "--no-stream",
@@ -308,7 +317,7 @@ def minimax_stream_events():
                     "id": "chatcmpl-minimax-stream-001",
                     "object": "chat.completion.chunk",
                     "created": 1700000000,
-                    "model": "MiniMax-M2.5",
+                    "model": "MiniMax-M3",
                     "choices": [
                         {
                             "index": 0,
@@ -340,7 +349,7 @@ class TestMiniMaxStreaming:
         runner = CliRunner()
         result = runner.invoke(
             cli,
-            ["-m", "MiniMax-M2.5", "--key", "test-key", "Hello"],
+            ["-m", "MiniMax-M3", "--key", "test-key", "Hello"],
         )
         assert result.exit_code == 0
         assert "Streaming from MiniMax!" in result.output
@@ -360,7 +369,7 @@ def mocked_minimax_highspeed(httpx_mock):
             "id": "chatcmpl-minimax-hs-001",
             "object": "chat.completion",
             "created": 1700000000,
-            "model": "MiniMax-M2.5-highspeed",
+            "model": "MiniMax-M2.7-highspeed",
             "choices": [
                 {
                     "index": 0,
@@ -384,7 +393,7 @@ def mocked_minimax_highspeed(httpx_mock):
 
 
 class TestMiniMaxHighspeed:
-    """Test MiniMax-M2.5-highspeed model variant."""
+    """Test MiniMax-M2.7-highspeed model variant."""
 
     def test_highspeed_prompt(self, mocked_minimax_highspeed):
         runner = CliRunner()
@@ -392,7 +401,7 @@ class TestMiniMaxHighspeed:
             cli,
             [
                 "-m",
-                "MiniMax-M2.5-highspeed",
+                "MiniMax-M2.7-highspeed",
                 "--key",
                 "test-key",
                 "--no-stream",
@@ -435,7 +444,7 @@ class TestMiniMaxUsage:
             cli,
             [
                 "-m",
-                "MiniMax-M2.5",
+                "MiniMax-M3",
                 "--key",
                 "test-key",
                 "--no-stream",
@@ -468,7 +477,24 @@ class TestMiniMaxIntegration:
     """Integration tests that call the real MiniMax API."""
 
     @pytest.mark.integration
-    def test_live_prompt(self, minimax_api_key):
+    def test_live_prompt_m3(self, minimax_api_key):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "-m",
+                "MiniMax-M3",
+                "--key",
+                minimax_api_key,
+                "--no-stream",
+                "Say hello in exactly three words.",
+            ],
+        )
+        assert result.exit_code == 0
+        assert len(result.output.strip()) > 0
+
+    @pytest.mark.integration
+    def test_live_prompt_m27(self, minimax_api_key):
         runner = CliRunner()
         result = runner.invoke(
             cli,
@@ -491,7 +517,7 @@ class TestMiniMaxIntegration:
             cli,
             [
                 "-m",
-                "MiniMax-M2.7",
+                "MiniMax-M3",
                 "--key",
                 minimax_api_key,
                 "What is 2+2? Answer with just the number.",


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to use M3 as the default model.

## Changes
- Add MiniMax-M3 to the model selection list and set as default
- Keep MiniMax-M2.7 and MiniMax-M2.7-highspeed as alternatives
- Remove older models (MiniMax-M2.5 / MiniMax-M2.5-highspeed)
- MiniMaxChat / MiniMaxAsyncChat classes with temperature clamping and JSON mode support
- Aliases: `minimax` → M3, `minimax-fast` → M2.7-highspeed
- Update unit tests to reflect the new model lineup (M3 default, M2.5 removed)
- Update README usage examples to show M3 as the default model

## Files touched
- `llm/default_plugins/minimax_models.py` — Add M3, drop M2.5, swap `minimax` alias to M3
- `tests/test_minimax_models.py` — Cover M3 registration, vision support, ordering, and M2.5 removal
- `README.md` — Update example commands to use MiniMax-M3 as default

## Why
MiniMax-M3 is the latest flagship model with a 512K context window, up to 128K output, and image input support. M2.7 and M2.7-highspeed are retained for users who need the previous generation.

## Testing
- All unit tests passing
- Integration test scaffolding present (network-dependent; requires a funded API key)