### PR TITLE
fix: --continue uses last logged conversation id

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1251,9 +1251,10 @@ def load_conversation(
     migrate(db)
     if conversation_id is None:
         # Return the most recent conversation, or None if there are none
-        matches = list(db["conversations"].rows_where(order_by="id desc", limit=1))
+        # Find the conversation with the most recent response
+        matches = list(db["responses"].rows_where(order_by="datetime_utc desc", limit=1))
         if matches:
-            conversation_id = matches[0]["id"]
+            conversation_id = matches[0]["conversation_id"]
         else:
             return None
     try:


### PR DESCRIPTION
Fixes #1140.

When using `--continue` without specifying a conversation ID, the code was ordering conversations by `id desc` which doesn't reflect the chronological order of activity. Conversation IDs are user-defined strings (like "foo", "bar") and not timestamps.

This fix queries the responses table ordered by `datetime_utc` to find the conversation with the most recent activity, which is the expected behavior for continuing the last conversation.

The change:
- Queries `responses` instead of `conversations`
- Orders by `datetime_utc desc` instead of `id desc`
- Gets `conversation_id` from the most recent response