### PR TITLE
Add `llm-webchat` to the plugin directory.

### DIFF
--- a/docs/plugins/directory.md
+++ b/docs/plugins/directory.md
@@ -89,7 +89,7 @@ The following plugins add new {ref}`tools <tools>` that can be used by models:
 - **[llm-python](https://github.com/simonw/llm-python)** adds a `llm python` command for running a Python interpreter in the same virtual environment as LLM. This is useful for debugging, and also provides a convenient way to interact with the LLM {ref}`python-api` if you installed LLM using Homebrew or `pipx`.
 - **[llm-cluster](https://github.com/simonw/llm-cluster)** adds a `llm cluster` command for calculating clusters for a collection of embeddings. Calculated clusters can then be passed to a Large Language Model to generate a summary description.
 - **[llm-jq](https://github.com/simonw/llm-jq)** lets you pipe in JSON data and a prompt describing a `jq` program, then executes the generated program against the JSON.
-- **[llm-webchat](https://github.com/imbue-ai/llm-webchat)** adds a `llm webchat` command for running a local web server with a simple visual chat UI to interact with the models.
+- **[llm-webchat](https://github.com/imbue-ai/llm-webchat)** adds a `llm webchat` command for running a local web server with a simple visual chat UI to interact with the models. Designed to be easily extensible.
 
 (plugin-directory-fun)=
 ## Just for fun

--- a/docs/plugins/directory.md
+++ b/docs/plugins/directory.md
@@ -89,6 +89,7 @@ The following plugins add new {ref}`tools <tools>` that can be used by models:
 - **[llm-python](https://github.com/simonw/llm-python)** adds a `llm python` command for running a Python interpreter in the same virtual environment as LLM. This is useful for debugging, and also provides a convenient way to interact with the LLM {ref}`python-api` if you installed LLM using Homebrew or `pipx`.
 - **[llm-cluster](https://github.com/simonw/llm-cluster)** adds a `llm cluster` command for calculating clusters for a collection of embeddings. Calculated clusters can then be passed to a Large Language Model to generate a summary description.
 - **[llm-jq](https://github.com/simonw/llm-jq)** lets you pipe in JSON data and a prompt describing a `jq` program, then executes the generated program against the JSON.
+- **[llm-webchat](https://github.com/imbue-ai/llm-webchat)** adds a `llm webchat` command for running a local web server with a simple visual chat UI to interact with the models.
 
 (plugin-directory-fun)=
 ## Just for fun


### PR DESCRIPTION
This PR adds the [llm-webchat](https://github.com/imbue-ai/llm-webchat/tree/main) plugin to the directory. It's a simple web UI on top of `llm` which shows the list of most recent conversations, lets you start new ones or continue old ones. It supports model selection, response streaming, and is highly extensible.