### PR TITLE
Fix MIME type detection fallback when puremagic returns empty string

### DIFF
--- a/llm/utils.py
+++ b/llm/utils.py
@@ -3,6 +3,7 @@ import hashlib
 import httpx
 import itertools
 import json
+import mimetypes
 import pathlib
 import puremagic
 import re
@@ -37,17 +38,23 @@ class Fragment(str):
 def mimetype_from_string(content) -> Optional[str]:
     try:
         type_ = puremagic.from_string(content, mime=True)
-        return MIME_TYPE_FIXES.get(type_, type_)
+        if type_:
+            return MIME_TYPE_FIXES.get(type_, type_)
     except puremagic.PureError:
-        return None
+        pass
+    return None
 
 
 def mimetype_from_path(path) -> Optional[str]:
     try:
         type_ = puremagic.from_file(path, mime=True)
-        return MIME_TYPE_FIXES.get(type_, type_)
+        if type_:
+            return MIME_TYPE_FIXES.get(type_, type_)
     except puremagic.PureError:
-        return None
+        pass
+    # Fallback to mimetypes module
+    guessed, _ = mimetypes.guess_type(str(path))
+    return guessed
 
 
 def dicts_to_table_string(


### PR DESCRIPTION
Closes #1340

## Problem
When puremagic cannot detect a file type, it can return an empty string instead of raising a PureError. The current code only catches the exception, so the empty string passes through as the MIME type and causes attachment validation to fail.

## Fix
- Check for empty/falsy return from puremagic before using the result
- Add mimetypes.guess_type() fallback in mimetype_from_path() for when puremagic fails
- Added import mimetypes (stdlib, no new dependency)