### PR TITLE
Add `llm-latchkey` to the plugin directory.

### DIFF
--- a/docs/plugins/directory.md
+++ b/docs/plugins/directory.md
@@ -55,6 +55,7 @@ The following plugins add new {ref}`tools <tools>` that can be used by models:
 - **[llm-tools-datasette](https://github.com/simonw/llm-tools-datasette)** can run SQL queries against a remote [Datasette](https://datasette.io/) instance.
 - **[llm-tools-exa](https://github.com/daturkel/llm-tools-exa)** by Dan Turkel can perform web searches and question-answering using [exa.ai](https://exa.ai/).
 - **[llm-tools-rag](https://github.com/daturkel/llm-tools-rag)** by Dan Turkel can perform searches over your LLM embedding collections for simple RAG.
+- **[llm-latchkey](https://github.com/imbue-ai/latchkey/integrations/llm-latchkey)** integrates with the Latchkey CLI tool to be able to send authenticated HTTP requests.
 
 (plugin-directory-loaders)=
 ## Fragments and template loaders


### PR DESCRIPTION
Add the `llm-latchkey` tool plugin to the list. It makes it possible to call third-party APIs using the [Latchkey](https://github.com/imbue-ai/latchkey) tool.