### PR TITLE
Add llm-prompt-lint to plugin directory

### DIFF
--- a/docs/plugins/directory.md
+++ b/docs/plugins/directory.md
@@ -89,6 +89,7 @@ The following plugins add new {ref}`tools <tools>` that can be used by models:
 - **[llm-python](https://github.com/simonw/llm-python)** adds a `llm python` command for running a Python interpreter in the same virtual environment as LLM. This is useful for debugging, and also provides a convenient way to interact with the LLM {ref}`python-api` if you installed LLM using Homebrew or `pipx`.
 - **[llm-cluster](https://github.com/simonw/llm-cluster)** adds a `llm cluster` command for calculating clusters for a collection of embeddings. Calculated clusters can then be passed to a Large Language Model to generate a summary description.
 - **[llm-jq](https://github.com/simonw/llm-jq)** lets you pipe in JSON data and a prompt describing a `jq` program, then executes the generated program against the JSON.
+- **[llm-prompt-lint](https://github.com/HadiFrt20/llm-prompt-lint)** adds `prompt-lint`, `prompt-score`, and `prompt-diff` commands for linting system prompts (conflicting constraints, vague language, role confusion), scoring quality 0-100, and semantic diffing between prompt versions.
 
 (plugin-directory-fun)=
 ## Just for fun


### PR DESCRIPTION
Adds [llm-prompt-lint](https://github.com/HadiFrt20/llm-prompt-lint) to the Extra commands section of the plugin directory.

**What it does:**

- `llm prompt-lint <file>` — static analysis with 8 rules (conflicting constraints, role confusion, vague language, missing examples, no injection guard, etc.)
- `llm prompt-score <file>` — quality score 0-100 across 5 dimensions (structure, specificity, examples, safety, completeness)
- `llm prompt-diff <a> <b>` — semantic diff that matches sections by type, classifies changes, and rates impact

All commands support `--json` for CI pipelines.

Works with `.prompt` files (YAML frontmatter + labeled sections) and plain text system prompts.

**Example:**

```bash
llm install llm-prompt-lint
llm prompt-lint my-agent.prompt
llm prompt-score my-agent.prompt
llm prompt-diff v1.prompt v2.prompt
```

GitHub: https://github.com/HadiFrt20/llm-prompt-lint