### PR TITLE
Fall back to guessed MIME types when puremagic is empty

### DIFF
--- a/llm/utils.py
+++ b/llm/utils.py
@@ -3,6 +3,7 @@ import hashlib
 import httpx
 import itertools
 import json
+import mimetypes
 import pathlib
 import puremagic
 import re
@@ -42,12 +43,21 @@ def mimetype_from_string(content) -> Optional[str]:
         return None
 
 
+def _guess_mimetype_from_path(path) -> Optional[str]:
+    guessed_type, _ = mimetypes.guess_type(path)
+    if not guessed_type:
+        return None
+    return MIME_TYPE_FIXES.get(guessed_type, guessed_type)
+
+
 def mimetype_from_path(path) -> Optional[str]:
     try:
         type_ = puremagic.from_file(path, mime=True)
-        return MIME_TYPE_FIXES.get(type_, type_)
+        if type_:
+            return MIME_TYPE_FIXES.get(type_, type_)
     except puremagic.PureError:
-        return None
+        pass
+    return _guess_mimetype_from_path(path)
 
 
 def dicts_to_table_string(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,10 @@
 import json
 import pytest
+import puremagic
 from llm.utils import (
     extract_fenced_code_block,
     instantiate_from_spec,
+    mimetype_from_path,
     maybe_fenced_code,
     schema_dsl,
     simplify_usage_dict,
@@ -51,6 +53,27 @@ from llm import get_key, Toolbox
 def test_simplify_usage_dict(input_data, expected_output):
     # This utility function is used by at least one plugin - llm-openai-plugin
     assert simplify_usage_dict(input_data) == expected_output
+
+
+def test_mimetype_from_path_falls_back_to_extension_when_puremagic_returns_empty(tmp_path, monkeypatch):
+    path = tmp_path / "video.mp4"
+    path.write_bytes(b"not really an mp4")
+
+    monkeypatch.setattr("llm.utils.puremagic.from_file", lambda *args, **kwargs: "")
+
+    assert mimetype_from_path(str(path)) == "video/mp4"
+
+
+def test_mimetype_from_path_falls_back_to_extension_on_puremagic_error(tmp_path, monkeypatch):
+    path = tmp_path / "image.jpg"
+    path.write_bytes(b"not really a jpeg")
+
+    def raise_pureerror(*args, **kwargs):
+        raise puremagic.PureError("no match")
+
+    monkeypatch.setattr("llm.utils.puremagic.from_file", raise_pureerror)
+
+    assert mimetype_from_path(str(path)) == "image/jpeg"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #1340.

puremagic can return an empty string for some files. In that case this falls back to Python's mimetypes guess, which is the same fallback path now used when puremagic raises PureError.

I added regression tests for both the empty string case and the exception case.

Verification
python -m pytest tests/test_utils.py -k mimetype_from_path