### PR TITLE
fix: deduplicate attachments to prevent IntegrityError on repeated --attachment

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -788,6 +788,19 @@ def prompt(
 
     resolved_attachments = [*attachments, *attachment_types]
 
+    # Deduplicate attachments by content hash, preserving order.  The same
+    # file passed twice (e.g. `--attachment a.png --attachment a.png`) would
+    # otherwise cause an IntegrityError when writing to the database because
+    # prompt_attachments has a composite primary key (response_id, attachment_id).
+    seen_attachment_ids: set = set()
+    unique_resolved_attachments = []
+    for att in resolved_attachments:
+        att_id = att.id()
+        if att_id not in seen_attachment_ids:
+            seen_attachment_ids.add(att_id)
+            unique_resolved_attachments.append(att)
+    resolved_attachments = unique_resolved_attachments
+
     should_stream = model.can_stream and not no_stream
     if not should_stream:
         kwargs["stream"] = False

--- a/llm/models.py
+++ b/llm/models.py
@@ -910,6 +910,7 @@ class _BaseResponse:
                     "attachment_id": attachment_id,
                     "order": index,
                 },
+                ignore=True,
             )
 
         # Persist any tools, tool calls and tool results

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -61,6 +61,40 @@ def test_prompt_attachment(mock_model, logs_db, attachment_type, attachment_cont
     assert prompt_attachment["response_id"] == response["id"]
 
 
+def test_duplicate_attachment_does_not_error(mock_model, logs_db, tmp_path):
+    """Passing the same file twice via --attachment should not raise an IntegrityError.
+
+    Regression test for https://github.com/simonw/llm/issues/1354
+    """
+    runner = CliRunner()
+    png_file = tmp_path / "image.png"
+    png_file.write_bytes(TINY_PNG)
+
+    mock_model.enqueue(["ok"])
+    result = runner.invoke(
+        cli.cli,
+        [
+            "prompt", "-m", "mock", "describe",
+            "-a", str(png_file),
+            "-a", str(png_file),  # same file, passed twice
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+
+    # The attachment should be recorded exactly once in the database even
+    # though it was supplied twice on the command line.
+    attachments = list(logs_db["attachments"].rows)
+    assert len(attachments) == 1, "duplicate attachment should be de-duplicated"
+
+    prompt_attachments = list(logs_db["prompt_attachments"].rows)
+    assert len(prompt_attachments) == 1, "prompt_attachments should have one row"
+
+    # The model should also have received only one attachment.
+    prompt_obj = mock_model.history[0][0]
+    assert len(prompt_obj.attachments) == 1
+
+
 def _count_open_fds():
     """Count open file descriptors (macOS and Linux only)."""
     if sys.platform == "darwin":


### PR DESCRIPTION
## Summary

Closes #1354.

Passing the same file twice via `--attachment` (e.g. `llm "..." --attachment a.png --attachment a.png`) crashed with an unhandled `sqlite3.IntegrityError` because `prompt_attachments` has a composite primary key `(response_id, attachment_id)` — and both copies of the same file resolve to the same content hash.

## Changes

**`llm/cli.py`** — deduplicate `resolved_attachments` by content ID (SHA-256 hash) before passing them to the model, preserving order:

```python
seen_attachment_ids: set = set()
unique_resolved_attachments = []
for att in resolved_attachments:
    att_id = att.id()
    if att_id not in seen_attachment_ids:
        seen_attachment_ids.add(att_id)
        unique_resolved_attachments.append(att)
resolved_attachments = unique_resolved_attachments
```

This means:
- The AI receives each unique file exactly once (avoids wasted tokens)
- No crash when the same file is passed multiple times

**`llm/models.py`** — added `ignore=True` to the `prompt_attachments` insert in `log_to_db` as a belt-and-suspenders defence for any duplicate attachment IDs that could arrive via other paths (e.g. fragments).

## Test plan

- [x] New test `test_duplicate_attachment_does_not_error` in `tests/test_attachments.py` — passes the same PNG file twice and verifies:
  - `exit_code == 0` (no crash)
  - exactly 1 row in `attachments` table
  - exactly 1 row in `prompt_attachments` table
  - model received exactly 1 attachment
- [x] All existing attachment tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)