### PR TITLE
fix: fall back to stdlib mimetypes when puremagic returns empty

### DIFF
--- a/llm/utils.py
+++ b/llm/utils.py
@@ -3,6 +3,7 @@ import hashlib
 import httpx
 import itertools
 import json
+import mimetypes
 import pathlib
 import puremagic
 import re
@@ -37,17 +38,23 @@ class Fragment(str):
 def mimetype_from_string(content) -> Optional[str]:
     try:
         type_ = puremagic.from_string(content, mime=True)
-        return MIME_TYPE_FIXES.get(type_, type_)
+        if type_:
+            return MIME_TYPE_FIXES.get(type_, type_)
     except puremagic.PureError:
-        return None
+        pass
+    return None
 
 
 def mimetype_from_path(path) -> Optional[str]:
     try:
         type_ = puremagic.from_file(path, mime=True)
-        return MIME_TYPE_FIXES.get(type_, type_)
+        if type_:
+            return MIME_TYPE_FIXES.get(type_, type_)
     except puremagic.PureError:
-        return None
+        pass
+    # Fall back to stdlib mimetypes when puremagic returns empty or raises
+    guessed, _ = mimetypes.guess_type(str(path))
+    return guessed
 
 
 def dicts_to_table_string(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@ from llm.utils import (
     extract_fenced_code_block,
     instantiate_from_spec,
     maybe_fenced_code,
+    mimetype_from_path,
     schema_dsl,
     simplify_usage_dict,
     truncate_string,
@@ -516,3 +517,26 @@ def test_toolbox_config_capture():
         pass
 
     assert Tool6()._config == {}
+
+
+def test_mimetype_from_path_falls_back_to_stdlib(tmp_path):
+    """When puremagic returns empty string, fall back to mimetypes.guess_type().
+
+    Regression test for https://github.com/simonw/llm/issues/1340
+    """
+    # Create a file with a known extension but content that puremagic may
+    # not recognise (e.g. an empty .mp4 file).
+    mp4_file = tmp_path / "video.mp4"
+    mp4_file.write_bytes(b"\x00" * 16)
+
+    result = mimetype_from_path(str(mp4_file))
+    assert result == "video/mp4"
+
+
+def test_mimetype_from_path_returns_none_for_unknown(tmp_path):
+    """Unknown extension and unrecognisable content returns None."""
+    unknown = tmp_path / "data.xyzzy123"
+    unknown.write_bytes(b"\x00" * 16)
+
+    result = mimetype_from_path(str(unknown))
+    assert result is None


### PR DESCRIPTION
## Summary

Closes #1340.

When `puremagic` cannot identify a file type it may return an empty string instead of raising `PureError`. This empty string was passed through as the MIME type, causing attachment validation to fail with:

```
Error: This model does not support attachments of type ''
```

## Changes

**`llm/utils.py`**:
- `mimetype_from_path()`: treat empty `puremagic` results the same as `PureError`, then fall back to Python's `mimetypes.guess_type()` which handles common extensions (.mp4, .jpg, etc.) reliably
- `mimetype_from_string()`: treat empty `puremagic` results as detection failure (returns `None`)

## Test plan

- [x] `test_mimetype_from_path_falls_back_to_stdlib` — empty .mp4 file correctly detected as `video/mp4`
- [x] `test_mimetype_from_path_returns_none_for_unknown` — truly unknown extension returns `None`

🤖 Generated with [Claude Code](https://claude.com/claude-code)