### PR TITLE
Fix embed_multi_with_metadata dedup by content_hash

### DIFF
--- a/llm/embeddings.py
+++ b/llm/embeddings.py
@@ -196,18 +196,22 @@ class Collection:
             # Calculate hashes first
             items_and_hashes = [(item, self.content_hash(item[1])) for item in batch]
             # Any of those hashes already exist?
-            existing_ids = [
-                row["id"]
+            existing_hashes = {
+                row["content_hash"]
                 for row in self.db.query(
                     """
-                    select id from embeddings
+                    select content_hash from embeddings
                     where collection_id = ? and content_hash in ({})
                     """.format(",".join("?" for _ in items_and_hashes)),
                     [collection_id]
                     + [item_and_hash[1] for item_and_hash in items_and_hashes],
                 )
+            }
+            filtered_batch = [
+                item
+                for item, content_hash in items_and_hashes
+                if content_hash not in existing_hashes
             ]
-            filtered_batch = [item for item in batch if item[0] not in existing_ids]
             embeddings = list(
                 self.model().embed_multi(item[1] for item in filtered_batch)
             )

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -185,3 +185,26 @@ def test_binary_only_and_text_only_embedding_models():
         list(text_only.embed_multi([b"hello world"]))
 
     list(text_only.embed_multi(["hello world"]))
+
+
+def test_embed_multi_dedup_same_content_different_ids():
+    """
+    Regression test for https://github.com/simonw/llm/issues/1397
+
+    embed_multi_with_metadata should deduplicate by content_hash, not by id.
+    When the same content is embedded under a different ID, the second call
+    should skip re-embedding because the content already exists.
+    """
+    collection = llm.Collection("dedup-test", model_id="embed-demo")
+    # First embed with id "a"
+    collection.embed_multi_with_metadata(
+        [("a", "hello world", None)], store=True
+    )
+    assert collection.db["embeddings"].count == 1
+
+    # Now embed the same content with a different id "b"
+    collection.embed_multi_with_metadata(
+        [("b", "hello world", None)], store=True
+    )
+    # Should still be 1 row because content_hash is identical
+    assert collection.db["embeddings"].count == 1


### PR DESCRIPTION
## Summary

- Fixes the deduplication logic in `embed_multi_with_metadata()` to filter by `content_hash` set membership instead of `id` set membership
- The existing code queried rows by `content_hash` but then selected `id` and filtered the batch by ID — so when the same content arrived under a different ID, it bypassed dedup and created duplicate embeddings
- This aligns the bulk path with the single-item `embed()` method, which correctly deduplicates by `content_hash` alone
- Adds a regression test that embeds the same content under two different IDs and asserts only one row is stored

Fixes #1397

## Test plan

- [x] New test `test_embed_multi_dedup_same_content_different_ids` passes
- [x] All 16 existing tests in `tests/test_embed.py` continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)