### PR TITLE
docs: add Kelly Intelligence example to other-models.md

### DIFF
--- a/docs/other-models.md
+++ b/docs/other-models.md
@@ -75,3 +75,37 @@ Some providers such as [openrouter.ai](https://openrouter.ai/docs) may require t
     HTTP-Referer: "https://llm.datasette.io/"
     X-Title: LLM
 ```
+
+### Example: Kelly Intelligence
+
+[Kelly Intelligence](https://api.thedailylesson.com) is a free OpenAI-compatible API with a built-in vocabulary RAG layer (162,000 words across 47 languages) and an AI tutor persona, built on Claude. It's operated by [Lesson of the Day, PBC](https://lotdpbc.com), a public benefit corporation, and the free tier (500 calls/month) requires no credit card.
+
+Add it to `extra-openai-models.yaml`:
+
+```yaml
+- model_id: kelly-haiku
+  model_name: kelly-haiku
+  api_base: "https://api.thedailylesson.com/v1"
+  api_key_name: kelly
+- model_id: kelly-sonnet
+  model_name: kelly-sonnet
+  api_base: "https://api.thedailylesson.com/v1"
+  api_key_name: kelly
+```
+
+Then store your key and try it:
+
+```bash
+llm keys set kelly
+# paste your KELLY_API_KEY
+
+llm -m kelly-haiku "Teach me the word 'serendipity'."
+```
+
+You can try the API with no signup at all using its public `/v1/demo` endpoint:
+
+```bash
+curl -X POST https://api.thedailylesson.com/v1/demo \
+  -H "Content-Type: application/json" \
+  -d '{"messages":[{"role":"user","content":"What does ephemeral mean?"}]}'
+```


### PR DESCRIPTION
## What this adds

A small example block in the existing OpenAI-compatible models section of `docs/other-models.md`, showing how to use [Kelly Intelligence](https://api.thedailylesson.com) via `extra-openai-models.yaml`.

Kelly Intelligence is a free OpenAI-compatible API with a built-in 162,000-word vocabulary RAG layer (601K translations across 47 languages) and an opinionated AI tutor persona ("Kelly"), built on top of Claude. It's operated by [Lesson of the Day, PBC](https://lotdpbc.com), a public benefit corporation. The free tier (500 calls/month) requires no credit card.

## Why this is useful for `llm` users

`llm` users building education, language-learning, and writing-assistant tools frequently want a vocabulary RAG layer alongside their model calls. Because Kelly Intelligence is OpenAI-compatible, it's already supported by `llm` via the existing `extra-openai-models.yaml` mechanism — this PR just makes that more discoverable by adding a working example.

The example mirrors the shape of the existing LocalAI and OpenRouter examples already on this page.

## Try it without an API key (for review)

Kelly Intelligence has a public `/v1/demo` endpoint, IP-rate-limited at 5 requests per hour, that you can hit with no signup at all:

```bash
curl -X POST https://api.thedailylesson.com/v1/demo \
  -H "Content-Type: application/json" \
  -d '{"messages":[{"role":"user","content":"What does ephemeral mean?"}]}'
```

This is the same wire format `llm` would use against Kelly via the documented yaml config.

## Changes

- **Modified:** `docs/other-models.md` (+34 lines, 0 deletions) — adds an "Example: Kelly Intelligence" subsection in the existing "Extra HTTP headers" area, parallel to the OpenRouter example.

No code changes. No new files. The doc page already has a section dedicated to OpenAI-compatible models, so this slots in.

## Checklist

- [x] No code changes — docs-only
- [x] No API keys or secrets in any file (verified via gitleaks-style scan)
- [x] All URLs in this PR body and added file return HTTP 200
- [x] Example mirrors the shape of the existing LocalAI / OpenRouter examples on the same page