### PR TITLE
fix: deduplicate embed_multi_with_metadata by content hash

### DIFF
--- a/llm/embeddings.py
+++ b/llm/embeddings.py
@@ -196,18 +196,22 @@ class Collection:
             # Calculate hashes first
             items_and_hashes = [(item, self.content_hash(item[1])) for item in batch]
             # Any of those hashes already exist?
-            existing_ids = [
-                row["id"]
+            existing_hashes = {
+                row["content_hash"]
                 for row in self.db.query(
                     """
-                    select id from embeddings
+                    select content_hash from embeddings
                     where collection_id = ? and content_hash in ({})
                     """.format(",".join("?" for _ in items_and_hashes)),
                     [collection_id]
                     + [item_and_hash[1] for item_and_hash in items_and_hashes],
                 )
+            }
+            filtered_batch = [
+                item
+                for item, content_hash in items_and_hashes
+                if content_hash not in existing_hashes
             ]
-            filtered_batch = [item for item in batch if item[0] not in existing_ids]
             embeddings = list(
                 self.model().embed_multi(item[1] for item in filtered_batch)
             )

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -146,6 +146,41 @@ def test_embed_multi(with_metadata, batch_size, expected_batches):
     assert collection.model().batch_count == expected_batches
 
 
+@pytest.mark.parametrize("with_metadata", (False, True))
+def test_embed_multi_deduplicates_by_content_hash(with_metadata):
+    db = sqlite_utils.Database(memory=True)
+    collection = llm.Collection("test", db, model_id="embed-demo")
+    collection.embed("1", "hello world")
+    model = collection.model()
+    model.batch_count = 0
+
+    if with_metadata:
+        entries = (
+            ("2", "hello world", {"meta": "2"}),
+            ("3", "brand new text", {"meta": "3"}),
+        )
+        collection.embed_multi_with_metadata(entries)
+    else:
+        entries = (
+            ("2", "hello world"),
+            ("3", "brand new text"),
+        )
+        collection.embed_multi(entries, store=True)
+
+    rows = list(db["embeddings"].rows)
+    assert len(rows) == 2
+    assert {row["id"] for row in rows} == {"1", "3"}
+    assert model.batch_count == 1
+
+    inserted = next(db["embeddings"].rows_where("id = ?", ["3"]))
+    if with_metadata:
+        assert json.loads(inserted["metadata"]) == {"meta": "3"}
+        assert inserted["content"] is None
+    else:
+        assert inserted["content"] == "brand new text"
+        assert inserted["metadata"] is None
+
+
 def test_collection_delete(collection):
     db = collection.db
     assert db["embeddings"].count == 2


### PR DESCRIPTION
## Summary
- deduplicate embed_multi_with_metadata() using existing content_hash values instead of existing item IDs
- align multi-item embedding behavior with the existing single-item embed() path
- add regression coverage for duplicate content submitted under a new ID

## Testing
- .venv\\Scripts\\python -m pytest tests/test_embed.py -k embed_multi
- .venv\\Scripts\\python -m pytest tests/test_embed.py
- .venv\\Scripts\\python -m ruff check .
- .venv\\Scripts\\python -m mypy llm

Closes #1397