### PR TITLE
fix: log toolbox tool results with the correct metadata

### DIFF
--- a/llm/models.py
+++ b/llm/models.py
@@ -950,7 +950,9 @@ class _BaseResponse:
                     "tool_call_id": tool_call.tool_call_id,
                 }
             )
+        tools_by_name = {tool.name: tool for tool in self.prompt.tools}
         for tool_result in self.prompt.tool_results:
+            matching_tool = tools_by_name.get(tool_result.name)
             instance_id = None
             if tool_result.instance:
                 try:
@@ -959,8 +961,15 @@ class _BaseResponse:
                             db["tool_instances"]
                             .insert(
                                 {
-                                    "plugin": tool.plugin,
-                                    "name": tool.name.split("_")[0],
+                                    "plugin": getattr(
+                                        matching_tool, "plugin", None
+                                    )
+                                    or getattr(tool_result.instance, "plugin", None),
+                                    "name": (
+                                        matching_tool.name.split("_")[0]
+                                        if matching_tool
+                                        else tool_result.instance.__class__.__name__
+                                    ),
                                     "arguments": json.dumps(
                                         tool_result.instance._config
                                     ),

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -940,7 +940,7 @@ def test_toolbox_logging_async(logs_db, tmpdir):
                     "name": "Memory_set",
                     "output": "null",
                     "instance": {
-                        "name": "Filesystem",
+                        "name": "Memory",
                         "plugin": "ToolboxPlugin",
                         "arguments": "{}",
                     },
@@ -949,7 +949,7 @@ def test_toolbox_logging_async(logs_db, tmpdir):
                     "name": "Memory_get",
                     "output": "two",
                     "instance": {
-                        "name": "Filesystem",
+                        "name": "Memory",
                         "plugin": "ToolboxPlugin",
                         "arguments": "{}",
                     },


### PR DESCRIPTION
Summary
fix toolbox-backed tool-result logging so each result uses its own tool metadata
update the mixed-toolbox logging regression to assert Memory results stay attributed to Memory

Root cause
_BaseResponse.log_to_db() reused the 	ool loop variable from the earlier or tool in self.prompt.tools loop when inserting 	ool_instances rows for self.prompt.tool_results. In Python that leaked the last tool from the previous loop, so mixed toolbox runs logged every result against the last toolbox.

Testing
C:\Users\Atharva\Documents\CODEX\llm\.venv\Scripts\python.exe -m pytest tests/test_plugins.py
C:\Users\Atharva\Documents\CODEX\llm\.venv\Scripts\python.exe -m ruff check .
C:\Users\Atharva\Documents\CODEX\llm\.venv\Scripts\python.exe -m mypy llm

Closes #1398