### PR TITLE
fix: reject non-ASCII keys in llm keys set

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1335,6 +1335,11 @@ def keys_set(name, value):
         $ llm keys set openai
         Enter key: ...
     """
+    if not value.isascii():
+        raise click.ClickException(
+            "API keys must contain only ASCII characters - "
+            "please re-enter the key and try again"
+        )
     default = {"// Note": "This file stores secret API credentials. Do not share!"}
     path = user_dir() / "keys.json"
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -52,6 +52,18 @@ def test_keys_get(monkeypatch, tmpdir):
     assert result2.output.strip() == "fx"
 
 
+@pytest.mark.xfail(sys.platform == "win32", reason="Expected to fail on Windows")
+def test_keys_set_rejects_non_ascii(monkeypatch, tmpdir):
+    user_path = tmpdir / "user/keys"
+    monkeypatch.setenv("LLM_USER_PATH", str(user_path))
+    keys_path = user_path / "keys.json"
+    runner = CliRunner()
+    result = runner.invoke(cli, ["keys", "set", "openai"], input="bad√key")
+    assert result.exit_code == 1
+    assert "ASCII" in result.output
+    assert not keys_path.exists()
+
+
 @pytest.mark.parametrize("args", (["keys", "list"], ["keys"]))
 def test_keys_list(monkeypatch, tmpdir, args):
     user_path = str(tmpdir / "user/keys")


### PR DESCRIPTION
Refs #1128

## Summary

`llm keys set` currently accepts non-ASCII input and stores it in `keys.json`.
That later fails with an opaque `ascii` codec error when the key is used as an HTTP header value.

This change rejects non-ASCII key values up front so the failure happens at the point where the bad key is entered.

## Reproduction

Before this change:

```bash
llm keys set openai
# paste: bad√key
llm hello --no-stream
# Error: 'ascii' codec can't encode character '\u221a' ...
```

After this change:

```bash
llm keys set openai
# paste: bad√key
# Error: API keys must contain only ASCII characters - please re-enter the key and try again
```

## Validation

- `uv run pytest tests/test_keys.py -q`
- `uv run ruff check llm/cli.py tests/test_keys.py`
- `uv run black --check llm/cli.py tests/test_keys.py`
