### PR TITLE
fix: remove mix_stderr=False for click 8.2.0 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
 [dependency-groups]
 dev = [
     "build",
-    "click<8.2.0", # https://github.com/simonw/llm/issues/1024
+    "click",
     "pytest",
     "numpy",
     "pytest-httpx>=0.33.0",

--- a/tests/test_cli_openai_models.py
+++ b/tests/test_cli_openai_models.py
@@ -182,7 +182,7 @@ def test_gpt4o_mini_sync_and_async(monkeypatch, tmpdir, httpx_mock, async_, usag
         },
         headers={"Content-Type": "application/json"},
     )
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     args = ["-m", "gpt-4o-mini", "--key", "x", "--no-stream"]
     if usage:
         args.append(usage)

--- a/tests/test_embed_cli.py
+++ b/tests/test_embed_cli.py
@@ -582,7 +582,7 @@ def test_embed_multi_files_errors(multi_files, args, expected_error):
 )
 def test_embed_multi_files_encoding(multi_files, extra_args, expected_error):
     db_path, files = multi_files
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
     result = runner.invoke(
         cli,
         [


### PR DESCRIPTION
Fixes #1293

## Problem

`CliRunner(mix_stderr=False)` raises `TypeError: CliRunner.__init__() got an unexpected keyword argument 'mix_stderr'` with click 8.2.0, which removed this parameter. As a workaround, the project pinned `click<8.2.0` in dev dependencies, but this prevents using the latest click release.

## Solution

- Remove `mix_stderr=False` from the two `CliRunner()` calls in the test suite
- Drop the `click<8.2.0` dev-dependency pin

In click 8.2.0+, stderr is always captured separately from stdout, so `result.stderr` continues to work correctly without the `mix_stderr` parameter.

## Testing

Both affected tests (`test_embed_multi_files_encoding` and `test_gpt4o_mini_sync_and_async`) still check `result.stderr` correctly because click 8.2.0 always separates stderr from stdout by default.