### PR TITLE
fix(migrations): retry temporary sqlite lock errors (#789)

### DIFF
--- a/llm/migrations.py
+++ b/llm/migrations.py
@@ -1,11 +1,20 @@
 import datetime
+import sqlite3
+import time
 from typing import Callable, List
 
 MIGRATIONS: List[Callable] = []
 migration = MIGRATIONS.append
 
 
-def migrate(db):
+def _is_locked_error(ex: sqlite3.OperationalError) -> bool:
+    return any(
+        token in str(ex).lower()
+        for token in ("database is locked", "database table is locked")
+    )
+
+
+def _migrate_once(db):
     ensure_migrations_table(db)
     already_applied = {r["name"] for r in db["_llm_migrations"].rows}
     for fn in MIGRATIONS:
@@ -19,6 +28,16 @@ def migrate(db):
                 }
             )
             already_applied.add(name)
+
+
+def migrate(db, retries: int = 5, delay: float = 0.05):
+    for attempt in range(retries + 1):
+        try:
+            return _migrate_once(db)
+        except sqlite3.OperationalError as ex:
+            if attempt >= retries or not _is_locked_error(ex):
+                raise
+            time.sleep(delay * (2**attempt))
 
 
 def ensure_migrations_table(db):

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -1,4 +1,5 @@
 import llm
+import sqlite3
 from llm.migrations import migrate
 from llm.embeddings_migrations import embeddings_migrations
 import pytest
@@ -96,6 +97,25 @@ def test_migrations_with_legacy_alter_table():
     db = sqlite_utils.Database(memory=True)
     db.execute("pragma legacy_alter_table=on")
     migrate(db)
+
+
+def test_migrate_retries_locked_database(monkeypatch):
+    db = sqlite_utils.Database(memory=True)
+    original = llm.migrations.ensure_migrations_table
+    calls = {"count": 0}
+
+    def flaky(database):
+        if calls["count"] == 0:
+            calls["count"] += 1
+            raise sqlite3.OperationalError("database is locked")
+        return original(database)
+
+    monkeypatch.setattr(llm.migrations, "ensure_migrations_table", flaky)
+
+    migrate(db)
+
+    assert calls["count"] == 1
+    assert "_llm_migrations" in db.table_names()
 
 
 def test_migrations_for_embeddings():


### PR DESCRIPTION
## Summary

- retry migration startup when SQLite reports a temporary lock
- only retry lock-related sqlite3.OperationalError cases
- add a regression test for a transient lock on the migrations table

## Testing

- pytest --noconftest tests/test_migrate.py -q
- python3 -m py_compile llm/migrations.py tests/test_migrate.py

Fixes #789