### PR TITLE
Fix UNIQUE constraint crash when same --attachment passed twice

### DIFF
--- a/llm/migrations.py
+++ b/llm/migrations.py
@@ -418,3 +418,14 @@ def m020_tool_results_attachments(db):
 @migration
 def m021_tool_results_exception(db):
     db["tool_results"].add_column("exception", str)
+
+
+@migration
+def m022_prompt_attachments_pk(db):
+    # The same attachment can be attached to a response multiple times
+    # (e.g. llm "..." --attachment file.pdf --attachment file.pdf)
+    # Mirror the fix applied for prompt_fragments in m016.
+    # https://github.com/simonw/llm/issues/1354
+    db["prompt_attachments"].transform(
+        pk=("response_id", "attachment_id", "order")
+    )

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -61,6 +61,48 @@ def test_prompt_attachment(mock_model, logs_db, attachment_type, attachment_cont
     assert prompt_attachment["response_id"] == response["id"]
 
 
+def test_duplicate_attachment_logs_cleanly(mock_model, logs_db, tmp_path):
+    """Passing the same --attachment twice should log successfully, not raise.
+
+    Regression test for https://github.com/simonw/llm/issues/1354
+    """
+    file_path = tmp_path / "image.png"
+    file_path.write_bytes(TINY_PNG)
+
+    runner = CliRunner()
+    mock_model.enqueue(["ok"])
+    result = runner.invoke(
+        cli.cli,
+        [
+            "prompt",
+            "-m",
+            "mock",
+            "describe file",
+            "-a",
+            str(file_path),
+            "-a",
+            str(file_path),
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+
+    # Both attachments should be logged, sharing one attachment row
+    # but two prompt_attachments rows with distinct "order" values.
+    attachments = list(logs_db["attachments"].rows)
+    assert len(attachments) == 1
+    prompt_attachments = list(
+        logs_db["prompt_attachments"].rows_where(
+            order_by='"order"'
+        )
+    )
+    assert len(prompt_attachments) == 2
+    assert [row["order"] for row in prompt_attachments] == [0, 1]
+    assert all(
+        row["attachment_id"] == attachments[0]["id"] for row in prompt_attachments
+    )
+
+
 def _count_open_fds():
     """Count open file descriptors (macOS and Linux only)."""
     if sys.platform == "darwin":


### PR DESCRIPTION
Closes #1354.

## The bug

```console
$ llm "Describe this" --attachment resume.pdf --attachment resume.pdf
...
File ".../llm/models.py", line 924, in log_to_db
    db["prompt_attachments"].insert(...)
sqlite3.IntegrityError: UNIQUE constraint failed:
  prompt_attachments.response_id, prompt_attachments.attachment_id
```

The `prompt_attachments` table was created in `m012` with a composite PK of `(response_id, attachment_id)`, so inserting the same attachment a second time against one response violates the constraint. The full prompt + model call runs fine; only the log step crashes, which means the user sees a traceback instead of output.

## The fix

This is the same bug that previously existed on `prompt_fragments`, fixed in `m016_fragments_table_pks` by extending the PK with the per-row `order` column. This PR mirrors that fix with a new migration:

```python
@migration
def m022_prompt_attachments_pk(db):
    db["prompt_attachments"].transform(
        pk=("response_id", "attachment_id", "order")
    )
```

`log_to_db()` already passes a distinct `order` per attachment (`enumerate(self.prompt.attachments)`), so the logic side needs no change.

## Verification

- Reproduced the `IntegrityError` against `main` at 1bfb96d.
- After the migration, both fresh databases and databases upgraded from pre-m022 schema accept duplicate `(response_id, attachment_id)` rows with distinct `order`.
- Added `test_duplicate_attachment_logs_cleanly` in `tests/test_attachments.py` exercising the CLI path end-to-end.
- Full test suite green (457 passed) excluding the existing openai-models + async-recording tests that require network/cassettes.

--- [kcolbchain](https://kcolbchain.com) / [Abhishek Krishna](https://abhishekkrishna.com)