### PR TITLE
fix: prevent UNIQUE constraint error when same tool is passed twice

### DIFF
--- a/llm/models.py
+++ b/llm/models.py
@@ -938,7 +938,8 @@ class _BaseResponse:
                 {
                     "tool_id": tool_id,
                     "response_id": response_id,
-                }
+                },
+                ignore=True,
             )
         for tool_call in self.tool_calls():  # TODO Should  be _or_raise()
             db["tool_calls"].insert(

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -369,6 +369,24 @@ def test_default_tool_llm_time():
     }
 
 
+def test_duplicate_tool_name_does_not_crash(logs_db):
+    """Passing the same tool twice (same name) should not cause a sqlite UNIQUE constraint error."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.cli,
+        [
+            "-m",
+            "echo",
+            "-T",
+            "llm_time",
+            "-T",
+            "llm_time",
+            json.dumps({"tool_calls": [{"name": "llm_time"}]}),
+        ],
+    )
+    assert result.exit_code == 0
+
+
 def test_incorrect_tool_usage():
     model = llm.get_model("echo")
 


### PR DESCRIPTION
Fixes #1252

## Problem

When the same tool file is passed multiple times via `-T` (e.g. `llm prompt -T llm_time -T llm_time ...`), the database logging fails with:

```
sqlite3.IntegrityError: UNIQUE constraint failed: tool_responses.tool_id, tool_responses.response_id
```

This happens because `ensure_tool()` returns the same `tool_id` for duplicate tools (tools are deduplicated by hash), but the loop in `log_to_db()` calls `db["tool_responses"].insert()` for each occurrence, producing two rows with the same `(tool_id, response_id)` primary key.

## Solution

Add `ignore=True` to the `tool_responses.insert()` call so that duplicate `(tool_id, response_id)` pairs are silently skipped instead of raising an integrity error.

## Testing

Added a test that passes the same tool twice and confirms `exit_code == 0` (previously this would raise an unhandled exception).