### PR TITLE
Update existing row when re-embedding the same content with different store/metadata

### DIFF
--- a/llm/embeddings.py
+++ b/llm/embeddings.py
@@ -131,9 +131,28 @@ class Collection:
         from llm import encode
 
         content_hash = self.content_hash(value)
-        if self.db["embeddings"].count_where(
-            "content_hash = ? and collection_id = ?", [content_hash, self.id]
-        ):
+        existing = list(
+            self.db["embeddings"].rows_where(
+                "content_hash = ? and collection_id = ?",
+                [content_hash, self.id],
+            )
+        )
+        if existing:
+            # Avoid recomputing the embedding, but refresh stored content
+            # and metadata so changing --store / metadata between calls is
+            # not silently ignored. See issue #224.
+            new_content = value if (store and isinstance(value, str)) else None
+            new_content_blob = value if (store and isinstance(value, bytes)) else None
+            new_metadata = json.dumps(metadata) if metadata else None
+            self.db["embeddings"].update(
+                (existing[0]["collection_id"], existing[0]["id"]),
+                {
+                    "content": new_content,
+                    "content_blob": new_content_blob,
+                    "metadata": new_metadata,
+                    "updated": int(time.time()),
+                },
+            )
             return
         embedding = self.model().embed(value)
         cast(Table, self.db["embeddings"]).insert(
@@ -196,18 +215,45 @@ class Collection:
             # Calculate hashes first
             items_and_hashes = [(item, self.content_hash(item[1])) for item in batch]
             # Any of those hashes already exist?
-            existing_ids = [
-                row["id"]
+            existing_hashes = {
+                row["content_hash"]
                 for row in self.db.query(
                     """
-                    select id from embeddings
+                    select content_hash from embeddings
                     where collection_id = ? and content_hash in ({})
                     """.format(",".join("?" for _ in items_and_hashes)),
                     [collection_id]
                     + [item_and_hash[1] for item_and_hash in items_and_hashes],
                 )
+            }
+            # Items whose content already has an embedding stored: update the
+            # content/metadata in place so changing --store/metadata between
+            # calls is not silently ignored. See issue #224.
+            existing_items = [
+                (item, h) for item, h in items_and_hashes if h in existing_hashes
             ]
-            filtered_batch = [item for item in batch if item[0] not in existing_ids]
+            filtered_batch = [
+                item for item, h in items_and_hashes if h not in existing_hashes
+            ]
+            if existing_items:
+                now = int(time.time())
+                with self.db.conn:
+                    for (id, value, metadata), content_hash in existing_items:
+                        self.db.execute(
+                            """
+                            update embeddings
+                            set content = ?, content_blob = ?, metadata = ?, updated = ?
+                            where collection_id = ? and content_hash = ?
+                            """,
+                            [
+                                value if (store and isinstance(value, str)) else None,
+                                value if (store and isinstance(value, bytes)) else None,
+                                json.dumps(metadata) if metadata else None,
+                                now,
+                                collection_id,
+                                content_hash,
+                            ],
+                        )
             embeddings = list(
                 self.model().embed_multi(item[1] for item in filtered_batch)
             )

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -146,6 +146,51 @@ def test_embed_multi(with_metadata, batch_size, expected_batches):
     assert collection.model().batch_count == expected_batches
 
 
+def test_embed_updates_store_and_metadata_on_existing_hash():
+    # Issue #224: re-embedding the same content with a new --store/metadata
+    # setting should update the existing row, not silently keep the old NULL.
+    db = sqlite_utils.Database(memory=True)
+    collection = llm.Collection("test", db, model_id="embed-demo")
+    # First call: do not store content, no metadata
+    collection.embed("a", "hello world", store=False)
+    row = next(db["embeddings"].rows_where("id = ?", ["a"]))
+    assert row["content"] is None
+    assert row["metadata"] is None
+    # Re-embed same content with store=True and metadata
+    collection.embed("a", "hello world", metadata={"k": "v"}, store=True)
+    row = next(db["embeddings"].rows_where("id = ?", ["a"]))
+    assert row["content"] == "hello world"
+    assert json.loads(row["metadata"]) == {"k": "v"}
+    # And once more, going back to store=False should clear stored content
+    collection.embed("a", "hello world", store=False)
+    row = next(db["embeddings"].rows_where("id = ?", ["a"]))
+    assert row["content"] is None
+    assert row["metadata"] is None
+
+
+def test_embed_multi_updates_store_and_metadata_on_existing_hash():
+    # Issue #224 (embed_multi variant)
+    db = sqlite_utils.Database(memory=True)
+    collection = llm.Collection("test", db, model_id="embed-demo")
+    entries = [("a", "hello world"), ("b", "goodbye world")]
+    collection.embed_multi(entries, store=False)
+    rows = {r["id"]: r for r in db["embeddings"].rows}
+    assert rows["a"]["content"] is None and rows["b"]["content"] is None
+    # Re-run with store=True for the same content
+    collection.embed_multi(entries, store=True)
+    rows = {r["id"]: r for r in db["embeddings"].rows}
+    assert rows["a"]["content"] == "hello world"
+    assert rows["b"]["content"] == "goodbye world"
+    # Re-run with metadata via embed_multi_with_metadata
+    collection.embed_multi_with_metadata(
+        [("a", "hello world", {"k": "v1"}), ("b", "goodbye world", {"k": "v2"})],
+        store=True,
+    )
+    rows = {r["id"]: r for r in db["embeddings"].rows}
+    assert json.loads(rows["a"]["metadata"]) == {"k": "v1"}
+    assert json.loads(rows["b"]["metadata"]) == {"k": "v2"}
+
+
 def test_collection_delete(collection):
     db = collection.db
     assert db["embeddings"].count == 2


### PR DESCRIPTION
## Summary

Fixes #224. `Collection.embed()` and `embed_multi_with_metadata()` short-circuit when a row with the same `content_hash` already exists, never updating `content` / `content_blob` / `metadata` to reflect new `store=` and `metadata=` arguments. Switching from `store=False` to `store=True`, or adding metadata, was silently ignored.

This matches the intent stated in the issue: *"It should update the database for records that already exist but where the metadata or content --store option has changed."*

## Fix

`llm/embeddings.py`:
- `embed()`: on existing hash, perform an UPDATE of `content` / `content_blob` / `metadata` / `updated` instead of returning early.
- `embed_multi_with_metadata()`: split batch into existing-hash items (UPDATE in place via SQL) and new items (still go through `embed_multi` + insert), avoiding re-running the model on duplicates while honouring the new options.

## Test

`tests/test_embed.py`:
- `test_embed_updates_store_and_metadata_on_existing_hash`
- `test_embed_multi_updates_store_and_metadata_on_existing_hash`

`pytest tests/` → 492 passed (full suite). `ruff check` clean. Production diff: ~80 LOC.

## Risk notes
- Behaviour change: a previously no-op repeat `embed()` now writes (clears or sets `content` / `metadata`, refreshes `updated`). This is the documented intent.
- The cross-collection embedding-reuse discussion in the thread (your model_id check that got punted from 0.10) is intentionally out of scope.

Refs #224