### PR TITLE
fix: add follow_redirects and timeout to URL attachment fetching

### DIFF
--- a/llm/models.py
+++ b/llm/models.py
@@ -84,7 +84,7 @@ class Attachment:
         if self.path:
             return mimetype_from_path(self.path)
         if self.url:
-            response = httpx.head(self.url)
+            response = httpx.head(self.url, follow_redirects=True, timeout=30.0)
             response.raise_for_status()
             return response.headers.get("content-type")
         if self.content:
@@ -98,7 +98,7 @@ class Attachment:
             if self.path:
                 content = Path(self.path).read_bytes()
             elif self.url:
-                response = httpx.get(self.url)
+                response = httpx.get(self.url, follow_redirects=True, timeout=30.0)
                 response.raise_for_status()
                 content = response.content
         return content


### PR DESCRIPTION
Adds follow_redirects=True and timeout=30.0 to httpx.get and httpx.head in Attachment.content_bytes() and resolve_type(), preventing hangs and redirect failures when loading remote images via URL.