### PR TITLE
Security: fix critical exec(), path traversal, and tool output injection

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -164,7 +164,12 @@ def resolve_fragments(
                 # Now try path
                 path = pathlib.Path(fragment)
                 if path.exists():
-                    resolved.append(Fragment(path.read_text(), str(path.resolve())))
+                    resolved_path = path.resolve()
+                    try:
+                        resolved_path.relative_to(pathlib.Path.cwd().resolve())
+                    except ValueError:
+                        raise FragmentNotFound(f"Fragment '{fragment}' not found")
+                    resolved.append(Fragment(path.read_text(), str(resolved_path)))
                 else:
                     raise FragmentNotFound(f"Fragment '{fragment}' not found")
     return resolved
@@ -242,6 +247,10 @@ def resolve_attachment(value):
     if not path.exists():
         raise AttachmentError(f"File {value} does not exist")
     path = path.resolve()
+    try:
+        path.relative_to(pathlib.Path.cwd().resolve())
+    except ValueError:
+        raise AttachmentError(f"File path must be within current directory: {value}")
 
     # Try to guess type
     mimetype = mimetype_from_path(str(path))
@@ -3934,6 +3943,59 @@ def load_template(name: str) -> Template:
     return template_obj
 
 
+_SAFE_BUILTINS = {
+    "abs": abs,
+    "all": all,
+    "any": any,
+    "bin": bin,
+    "bool": bool,
+    "bytearray": bytearray,
+    "bytes": bytes,
+    "chr": chr,
+    "dict": dict,
+    "dir": dir,
+    "divmod": divmod,
+    "enumerate": enumerate,
+    "filter": filter,
+    "float": float,
+    "format": format,
+    "frozenset": frozenset,
+    "hasattr": hasattr,
+    "hex": hex,
+    "int": int,
+    "isinstance": isinstance,
+    "issubclass": issubclass,
+    "iter": iter,
+    "len": len,
+    "list": list,
+    "map": map,
+    "max": max,
+    "min": min,
+    "next": next,
+    "oct": oct,
+    "ord": ord,
+    "pow": pow,
+    "range": range,
+    "repr": repr,
+    "reversed": reversed,
+    "round": round,
+    "set": set,
+    "slice": slice,
+    "sorted": sorted,
+    "str": str,
+    "sum": sum,
+    "tuple": tuple,
+    "type": type,
+    "vars": vars,
+    "zip": zip,
+    "locals": locals,
+    "Exception": Exception,
+    "True": True,
+    "False": False,
+    "None": None,
+}
+
+
 def _tools_from_code(code_or_path: str) -> List[Tool]:
     """
     Treat all Python functions in the code as tools
@@ -3943,7 +4005,7 @@ def _tools_from_code(code_or_path: str) -> List[Tool]:
             code_or_path = pathlib.Path(code_or_path).read_text()
         except FileNotFoundError:
             raise click.ClickException("File not found: {}".format(code_or_path))
-    namespace: Dict[str, Any] = {}
+    namespace: Dict[str, Any] = {"__builtins__": _SAFE_BUILTINS}
     tools = []
     try:
         exec(code_or_path, namespace)

--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -30,6 +30,10 @@ import json
 import yaml
 
 
+def _sanitize_tool_output(output: str) -> str:
+    return f"<tool_result>\n{output}\n</tool_result>"
+
+
 @hookimpl
 def register_models(register):
     # GPT-4o
@@ -773,7 +777,7 @@ class _Shared:
                         {
                             "role": "tool",
                             "tool_call_id": tool_result.tool_call_id,
-                            "content": tool_result.output,
+                            "content": _sanitize_tool_output(tool_result.output),
                         }
                     )
                 prev_text = prev_response.text_or_raise()
@@ -804,7 +808,7 @@ class _Shared:
                 {
                     "role": "tool",
                     "tool_call_id": tool_result.tool_call_id,
-                    "content": tool_result.output,
+                    "content": _sanitize_tool_output(tool_result.output),
                 }
             )
         if not prompt.attachments:

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -372,17 +372,18 @@ def test_chat_tools(logs_db):
 
 @pytest.mark.xfail(sys.platform == "win32", reason="Expected to fail on Windows")
 def test_chat_fragments(tmpdir):
-    path1 = str(tmpdir / "frag1.txt")
-    path2 = str(tmpdir / "frag2.txt")
-    with open(path1, "w") as fp:
-        fp.write("one")
-    with open(path2, "w") as fp:
-        fp.write("two")
     runner = CliRunner()
-    output = runner.invoke(
-        llm.cli.cli,
-        ["chat", "-m", "echo", "-f", path1],
-        input=("hi\n!fragment {}\nquit\n".format(path2)),
-    ).output
-    assert '"prompt": "one' in output
-    assert '"prompt": "two"' in output
+    with runner.isolated_filesystem():
+        path1 = "frag1.txt"
+        path2 = "frag2.txt"
+        with open(path1, "w") as fp:
+            fp.write("one")
+        with open(path2, "w") as fp:
+            fp.write("two")
+        output = runner.invoke(
+            llm.cli.cli,
+            ["chat", "-m", "echo", "-f", path1],
+            input=("hi\n!fragment {}\nquit\n".format(path2)),
+        ).output
+        assert '"prompt": "one' in output
+        assert '"prompt": "two"' in output


### PR DESCRIPTION
This PR addresses three security findings identified in an audit of the simonw/llm repository:\n\n1. **Critical – Arbitrary code execution via `--functions`**\n   - `llm/cli.py`: `_tools_from_code()` used `exec(code_or_path, namespace)` with no sandboxing.\n   - Fix: Restrict available builtins to a safe subset (removes `exec`, `eval`, `compile`, `__import__`, `open`, etc.).\n\n2. **High – Path traversal in fragment and attachment resolution**\n   - `llm/cli.py`: `resolve_fragments()` and `resolve_attachment()` accepted arbitrary filesystem paths.\n   - Fix: Contain resolved paths to the current working directory using `pathlib.Path.relative_to()`.\n\n3. **High – Indirect prompt injection via unsanitized tool outputs**\n   - `llm/default_plugins/openai_models.py`: Tool results were injected directly into OpenAI messages.\n   - Fix: Wrap tool output in structural `<tool_result>` delimiters to provide a boundary against prompt injection.\n\nAll existing tests in the affected modules pass.