### PR TITLE
Support ${VAR} environment variable interpolation in JSON config files

### DIFF
--- a/llm/__init__.py
+++ b/llm/__init__.py
@@ -33,7 +33,7 @@ from .parts import (
     tool_message,
     user,
 )
-from .utils import schema_dsl, Fragment
+from .utils import schema_dsl, Fragment, interpolate_env_vars
 from .embeddings import Collection
 from .templates import Template
 from .plugins import pm, load_plugins
@@ -111,7 +111,7 @@ def get_models_with_aliases() -> List["ModelWithAliases"]:
     aliases_path = user_dir() / "aliases.json"
     extra_model_aliases: Dict[str, list] = {}
     if aliases_path.exists():
-        configured_aliases = json.loads(aliases_path.read_text())
+        configured_aliases = interpolate_env_vars(json.loads(aliases_path.read_text()))
         for alias, model_id in configured_aliases.items():
             extra_model_aliases.setdefault(model_id, []).append(alias)
 
@@ -236,7 +236,7 @@ def get_embedding_models_with_aliases() -> List["EmbeddingModelWithAliases"]:
     aliases_path = user_dir() / "aliases.json"
     extra_model_aliases: Dict[str, list] = {}
     if aliases_path.exists():
-        configured_aliases = json.loads(aliases_path.read_text())
+        configured_aliases = interpolate_env_vars(json.loads(aliases_path.read_text()))
         for alias, model_id in configured_aliases.items():
             extra_model_aliases.setdefault(model_id, []).append(alias)
 
@@ -401,7 +401,7 @@ def get_key(
 def load_keys():
     path = user_dir() / "keys.json"
     if path.exists():
-        return json.loads(path.read_text())
+        return interpolate_env_vars(json.loads(path.read_text()))
     else:
         return {}
 

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -51,6 +51,7 @@ from .utils import (
     find_unused_key,
     has_plugin_prefix,
     instantiate_from_spec,
+    interpolate_env_vars,
     make_schema_id,
     maybe_fenced_code,
     mimetype_from_path,
@@ -3849,7 +3850,7 @@ def get_all_model_options() -> dict:
         return {}
 
     try:
-        options = json.loads(path.read_text())
+        options = interpolate_env_vars(json.loads(path.read_text()))
     except json.JSONDecodeError:
         return {}
 
@@ -3866,16 +3867,7 @@ def get_model_options(model_id: str) -> dict:
     Returns:
         A dictionary of model options
     """
-    path = user_dir() / "model_options.json"
-    if not path.exists():
-        return {}
-
-    try:
-        options = json.loads(path.read_text())
-    except json.JSONDecodeError:
-        return {}
-
-    return options.get(model_id, {})
+    return get_all_model_options().get(model_id, {})
 
 
 def set_model_option(model_id: str, key: str, value: Any) -> None:

--- a/llm/utils.py
+++ b/llm/utils.py
@@ -34,6 +34,38 @@ class Fragment(str):
         return hashlib.sha256(self.encode("utf-8")).hexdigest()
 
 
+_env_interpolation_re = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+
+
+def interpolate_env_vars(obj):
+    """
+    Recursively resolve ${VAR} placeholders in strings from os.environ.
+    Leaves unresolved placeholders unchanged and prints a warning.
+    """
+    if isinstance(obj, dict):
+        return {k: interpolate_env_vars(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [interpolate_env_vars(item) for item in obj]
+    if isinstance(obj, str):
+        return _interpolate_env_vars_in_string(obj)
+    return obj
+
+
+def _interpolate_env_vars_in_string(value: str) -> str:
+    def replace(match):
+        var = match.group(1)
+        env_val = os.environ.get(var)
+        if env_val is None:
+            click.echo(
+                "Warning: environment variable '{}' is not set".format(var),
+                err=True,
+            )
+            return match.group(0)
+        return env_val
+
+    return _env_interpolation_re.sub(replace, value)
+
+
 def mimetype_from_string(content) -> Optional[str]:
     try:
         type_ = puremagic.from_string(content, mime=True)

--- a/tests/test_config_interpolation.py
+++ b/tests/test_config_interpolation.py
@@ -1,0 +1,93 @@
+import pytest
+
+from llm.utils import interpolate_env_vars, _interpolate_env_vars_in_string
+
+
+class TestInterpolateEnvVarsInString:
+    def test_resolves_set_env_var(self, monkeypatch):
+        monkeypatch.setenv("MY_VAR", "hello")
+        assert _interpolate_env_vars_in_string("${MY_VAR}") == "hello"
+
+    def test_leaves_undefined_env_var_unchanged(self, monkeypatch, capsys):
+        monkeypatch.delenv("UNDEFINED_VAR", raising=False)
+        result = _interpolate_env_vars_in_string("${UNDEFINED_VAR}")
+        assert result == "${UNDEFINED_VAR}"
+        captured = capsys.readouterr()
+        assert "Warning: environment variable 'UNDEFINED_VAR' is not set" in captured.err
+
+    def test_multiple_vars_in_string(self, monkeypatch):
+        monkeypatch.setenv("A", "alpha")
+        monkeypatch.setenv("B", "beta")
+        result = _interpolate_env_vars_in_string("${A}-${B}")
+        assert result == "alpha-beta"
+
+    def test_leaves_plain_text_unchanged(self):
+        assert _interpolate_env_vars_in_string("$HOME") == "$HOME"
+
+    def test_leaves_double_dollar_unchanged(self):
+        assert _interpolate_env_vars_in_string("$$HOME") == "$$HOME"
+
+    def test_mixed_text_and_var(self, monkeypatch):
+        monkeypatch.setenv("NAME", "world")
+        result = _interpolate_env_vars_in_string("Hello, ${NAME}!")
+        assert result == "Hello, world!"
+
+
+class TestInterpolateEnvVars:
+    def test_dict_resolution(self, monkeypatch):
+        monkeypatch.setenv("KEY1", "value1")
+        monkeypatch.setenv("KEY2", "value2")
+        data = {"a": "${KEY1}", "b": "${KEY2}", "c": 42}
+        result = interpolate_env_vars(data)
+        assert result == {"a": "value1", "b": "value2", "c": 42}
+
+    def test_list_resolution(self, monkeypatch):
+        monkeypatch.setenv("ITEM", "x")
+        data = ["${ITEM}", "plain", 99]
+        result = interpolate_env_vars(data)
+        assert result == ["x", "plain", 99]
+
+    def test_nested_dict_recursive(self, monkeypatch):
+        monkeypatch.setenv("NESTED", "deep")
+        data = {"outer": {"inner": "${NESTED}"}}
+        result = interpolate_env_vars(data)
+        assert result == {"outer": {"inner": "deep"}}
+
+    def test_non_string_values_passthrough(self):
+        data = {"num": 123, "flag": True, "none": None}
+        result = interpolate_env_vars(data)
+        assert result == {"num": 123, "flag": True, "none": None}
+
+    def test_undefined_var_in_nested_dict_warns(self, monkeypatch, capsys):
+        monkeypatch.delenv("MISSING", raising=False)
+        data = {"a": {"b": "${MISSING}"}}
+        result = interpolate_env_vars(data)
+        assert result == {"a": {"b": "${MISSING}"}}
+        captured = capsys.readouterr()
+        assert "Warning: environment variable 'MISSING' is not set" in captured.err
+
+    def test_no_false_positive_on_dollar_prefix(self):
+        data = {"price": "$10"}
+        result = interpolate_env_vars(data)
+        assert result == {"price": "$10"}
+
+    def test_complex_nesting(self, monkeypatch):
+        monkeypatch.setenv("URL", "https://api.example.com")
+        monkeypatch.setenv("TOKEN", "secret")
+        data = {
+            "endpoint": "${URL}",
+            "headers": {
+                "Authorization": "Bearer ${TOKEN}",
+                "Content-Type": "application/json",
+            },
+            "options": ["${URL}", 8080, True],
+        }
+        result = interpolate_env_vars(data)
+        assert result == {
+            "endpoint": "https://api.example.com",
+            "headers": {
+                "Authorization": "Bearer secret",
+                "Content-Type": "application/json",
+            },
+            "options": ["https://api.example.com", 8080, True],
+        }


### PR DESCRIPTION
Closes #1429

## Summary

Adds `${VAR}` environment variable config interpolations.

- Resolves `${VAR}` from `os.environ` at load time.
- Warns to stderr and leaves the placeholder unchanged if the variable is undefined.
- Non-string values, nested structures, and lists are all handled correctly.
- Applies to `keys.json`, `aliases.json`, and `model_options.json`.
- Existing configs without `${}` are unaffected.

## Test Coverage

13 tests covering:
  - Basic `${VAR}` resolution
  - Undefined variables (warning + passthrough)
  - Multiple variables in one string
  - Plain `$VAR` (no braces) left unchanged
  - Nested dict/list recursion
  - Mixed types

