### PR TITLE
Fix stale loop variable in log_to_db() tool_instances insert

### DIFF
--- a/llm/models.py
+++ b/llm/models.py
@@ -1403,9 +1403,11 @@ class _BaseResponse:
 
         # Persist any tools, tool calls and tool results
         tool_ids_by_name = {}
+        tools_by_name = {}
         for tool in self.prompt.tools:
             tool_id = ensure_tool(db, tool)
             tool_ids_by_name[tool.name] = tool_id
+            tools_by_name[tool.name] = tool
             db["tool_responses"].insert(
                 {
                     "tool_id": tool_id,
@@ -1427,12 +1429,13 @@ class _BaseResponse:
             if tool_result.instance:
                 try:
                     if not tool_result.instance.instance_id:
+                        matched_tool = tools_by_name.get(tool_result.name)
                         tool_result.instance.instance_id = (
                             db["tool_instances"]
                             .insert(
                                 {
-                                    "plugin": tool.plugin,
-                                    "name": tool.name.split("_")[0],
+                                    "plugin": matched_tool.plugin if matched_tool else None,
+                                    "name": matched_tool.name.split("_")[0] if matched_tool else tool_result.name,
                                     "arguments": json.dumps(
                                         tool_result.instance._config
                                     ),


### PR DESCRIPTION
Fixes #1398.

In `_BaseResponse.log_to_db()`, the `tool_instances` INSERT inside the `for tool_result in self.prompt.tool_results` loop was using `tool.plugin` and `tool.name` from the preceding `for tool in self.prompt.tools` loop. In Python, a loop variable retains its last value after the loop ends, so in multi-tool runs all tool results were attributed to whichever tool was last in `self.prompt.tools`.

**Fix:** build a `tools_by_name` dict alongside the existing `tool_ids_by_name` during the tools loop, then look up the correct `Tool` object by `tool_result.name` for each result. Falls back gracefully to `None`/`tool_result.name` if no match is found.

The change is 5 lines and touches only the logging path — no behaviour change for single-tool runs.