### PR TITLE
Add options= dict parameter to .prompt() and .reply()

### DIFF
--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -411,11 +411,11 @@ Some model plugins may include features that take advantage of fragments, for ex
 
 ### Model options
 
-For models that support options (view those with `llm models --options`) you can pass options as keyword arguments to the `.prompt()` method:
+For models that support options (view those with `llm models --options`) pass them as a dictionary to the `options=` argument of the `.prompt()` method:
 
 ```python
 model = llm.get_model()
-print(model.prompt("Names for otters", temperature=0.2))
+print(model.prompt("Names for otters", options={"temperature": 0.2}))
 ```
 
 (python-api-models-api-keys)=

--- a/llm/models.py
+++ b/llm/models.py
@@ -484,6 +484,18 @@ def _wrap_tools(tools: List[ToolDef]) -> List[Tool]:
     return wrapped_tools
 
 
+def _merge_options(options: Optional[dict], kwargs: dict) -> dict:
+    if not options:
+        return kwargs
+    overlap = set(options) & set(kwargs)
+    if overlap:
+        raise TypeError(
+            "Got values for these options both in options= and as keyword "
+            "arguments: {}".format(sorted(overlap))
+        )
+    return {**options, **kwargs}
+
+
 @dataclass
 class _BaseConversation:
     model: "_BaseModel"
@@ -583,8 +595,10 @@ class Conversation(_BaseConversation):
         messages: Optional[List[Any]] = None,
         stream: bool = True,
         key: Optional[str] = None,
-        **options,
+        options: Optional[dict] = None,
+        **kwargs,
     ) -> "Response":
+        merged = _merge_options(options, kwargs)
         # Build the authoritative chain so response.prompt.messages
         # equals exactly what the model sees for this turn.
         chain = self._build_full_chain(
@@ -605,7 +619,7 @@ class Conversation(_BaseConversation):
                 tool_results=tool_results,
                 system_fragments=system_fragments,
                 messages=chain,
-                options=self.model.Options(**options),
+                options=self.model.Options(**merged),
             ),
             self.model,
             stream,
@@ -750,8 +764,10 @@ class AsyncConversation(_BaseConversation):
         messages: Optional[List[Any]] = None,
         stream: bool = True,
         key: Optional[str] = None,
-        **options,
+        options: Optional[dict] = None,
+        **kwargs,
     ) -> "AsyncResponse":
+        merged = _merge_options(options, kwargs)
         chain = self._build_full_chain(
             prompt=prompt,
             attachments=attachments,
@@ -770,7 +786,7 @@ class AsyncConversation(_BaseConversation):
                 tool_results=tool_results,
                 system_fragments=system_fragments,
                 messages=chain,
-                options=self.model.Options(**options),
+                options=self.model.Options(**merged),
             ),
             self.model,
             stream,
@@ -1600,6 +1616,7 @@ class Response(_BaseResponse):
         *,
         messages: Optional[List[Any]] = None,
         tool_results: Optional[List[ToolResult]] = None,
+        options: Optional[dict] = None,
         **kwargs,
     ) -> "Response":
         """Continue the conversation from this response.
@@ -1643,7 +1660,7 @@ class Response(_BaseResponse):
             chain.append(Message(role="user", parts=[TextPart(text=prompt)]))
         if messages:
             chain.extend(messages)
-        return self.model.prompt(messages=chain, **kwargs)
+        return self.model.prompt(messages=chain, options=options, **kwargs)
 
     def to_dict(self) -> ResponseDict:
         """Serialize this response for JSON persistence.
@@ -1937,6 +1954,7 @@ class AsyncResponse(_BaseResponse):
         *,
         messages: Optional[List[Any]] = None,
         tool_results: Optional[List[ToolResult]] = None,
+        options: Optional[dict] = None,
         **kwargs,
     ) -> "AsyncResponse":
         """Async counterpart of Response.reply(). Requires this response
@@ -1975,7 +1993,7 @@ class AsyncResponse(_BaseResponse):
             chain.append(Message(role="user", parts=[TextPart(text=prompt)]))
         if messages:
             chain.extend(messages)
-        return self.model.prompt(messages=chain, **kwargs)
+        return self.model.prompt(messages=chain, options=options, **kwargs)
 
     def to_dict(self) -> ResponseDict:
         """Async counterpart of Response.to_dict(). Requires awaiting."""
@@ -2739,9 +2757,11 @@ class _Model(_BaseModel):
         schema: Optional[Union[dict, type[BaseModel]]] = None,
         tools: Optional[List[ToolDef]] = None,
         tool_results: Optional[List[ToolResult]] = None,
-        **options,
+        options: Optional[dict] = None,
+        **kwargs,
     ) -> Response:
-        key_value = options.pop("key", None)
+        key_value = kwargs.pop("key", None)
+        merged = _merge_options(options, kwargs)
         self._validate_attachments(attachments)
         return Response(
             Prompt(
@@ -2755,7 +2775,7 @@ class _Model(_BaseModel):
                 system_fragments=system_fragments,
                 messages=messages,
                 model=self,
-                options=self.Options(**options),
+                options=self.Options(**merged),
             ),
             self,
             stream,
@@ -2852,9 +2872,11 @@ class _AsyncModel(_BaseModel):
         system_fragments: Optional[List[Union[str, Fragment]]] = None,
         messages: Optional[List[Any]] = None,
         stream: bool = True,
-        **options,
+        options: Optional[dict] = None,
+        **kwargs,
     ) -> AsyncResponse:
-        key_value = options.pop("key", None)
+        key_value = kwargs.pop("key", None)
+        merged = _merge_options(options, kwargs)
         self._validate_attachments(attachments)
         return AsyncResponse(
             Prompt(
@@ -2868,7 +2890,7 @@ class _AsyncModel(_BaseModel):
                 system_fragments=system_fragments,
                 messages=messages,
                 model=self,
-                options=self.Options(**options),
+                options=self.Options(**merged),
             ),
             self,
             stream,

--- a/tests/test_options_parameter.py
+++ b/tests/test_options_parameter.py
@@ -1,0 +1,99 @@
+"""Tests for the `options=` parameter on `.prompt()` and `.reply()`.
+
+The `options={...}` dict form is the documented API; the `**kwargs` form
+continues to work undocumented for backwards compatibility.
+"""
+
+import pytest
+
+
+def test_prompt_with_options_dict(mock_model):
+    mock_model.enqueue(["ok"])
+    r = mock_model.prompt("q", options={"max_tokens": 42})
+    r.text()
+    assert r.prompt.options.max_tokens == 42
+    assert r.to_dict()["prompt"].get("options") == {"max_tokens": 42}
+
+
+def test_prompt_kwargs_still_work(mock_model):
+    mock_model.enqueue(["ok"])
+    r = mock_model.prompt("q", max_tokens=42)
+    r.text()
+    assert r.prompt.options.max_tokens == 42
+
+
+def test_prompt_options_and_kwargs_merge(mock_model):
+    # Non-overlapping keys merge cleanly — options= and kwargs both contribute
+    mock_model.Options.model_rebuild()
+    mock_model.enqueue(["ok"])
+    # Only max_tokens exists on MockModel.Options — use it via options=.
+    # Pass an empty options dict alongside a kwarg to confirm both paths coexist.
+    r = mock_model.prompt("q", options={}, max_tokens=7)
+    r.text()
+    assert r.prompt.options.max_tokens == 7
+
+
+def test_prompt_options_and_kwargs_conflict_raises(mock_model):
+    mock_model.enqueue(["ok"])
+    with pytest.raises(TypeError, match="both in options="):
+        mock_model.prompt("q", options={"max_tokens": 1}, max_tokens=2)
+
+
+def test_conversation_prompt_with_options_dict(mock_model):
+    mock_model.enqueue(["ok"])
+    convo = mock_model.conversation()
+    r = convo.prompt("q", options={"max_tokens": 99})
+    r.text()
+    assert r.prompt.options.max_tokens == 99
+
+
+def test_response_reply_with_options_dict(mock_model):
+    mock_model.enqueue(["first"])
+    mock_model.enqueue(["second"])
+    r1 = mock_model.prompt("q1", options={"max_tokens": 5})
+    r1.text()
+    r2 = r1.reply("q2", options={"max_tokens": 17})
+    r2.text()
+    assert r2.prompt.options.max_tokens == 17
+
+
+def test_response_reply_kwargs_still_work(mock_model):
+    mock_model.enqueue(["first"])
+    mock_model.enqueue(["second"])
+    r1 = mock_model.prompt("q1", max_tokens=5)
+    r1.text()
+    r2 = r1.reply("q2", max_tokens=17)
+    r2.text()
+    assert r2.prompt.options.max_tokens == 17
+
+
+@pytest.mark.asyncio
+async def test_async_prompt_with_options_dict(async_mock_model):
+    # AsyncMockModel inherits the empty base Options (extra="forbid"),
+    # so pass an empty options dict — this verifies the parameter is
+    # accepted and the empty-dict path works.
+    async_mock_model.enqueue(["ok"])
+    r = await async_mock_model.prompt("q", options={}).text()
+    assert r == "ok"
+
+
+@pytest.mark.asyncio
+async def test_async_prompt_options_and_kwargs_conflict_raises(async_mock_model):
+    import llm
+
+    # Build an async model with a real Option field so we can collide them.
+    class AsyncModelWithOption(llm.AsyncModel):
+        model_id = "async-with-option"
+
+        class Options(llm.Options):
+            from typing import Optional as _Opt
+            from pydantic import Field as _Field
+
+            max_tokens: _Opt[int] = _Field(default=None)
+
+        async def execute(self, prompt, stream, response, conversation):
+            yield "ok"
+
+    m = AsyncModelWithOption()
+    with pytest.raises(TypeError, match="both in options="):
+        await m.prompt("q", options={"max_tokens": 1}, max_tokens=2).text()


### PR DESCRIPTION
> Currently the .prompt() method uses **kwargs for options - I want to eventually migrate that to options={…} but for the moment I want options= to work as an alternative and be documented and the large to not be documented

Accepts model options as an explicit dict alongside the existing
**kwargs form. The kwargs form continues to work unchanged for
backwards compatibility but is no longer documented. Mixing the two
forms with overlapping keys raises TypeError.

Applies to Model.prompt, Conversation.prompt, Response.reply and
their async equivalents. .chain() already used this pattern.