### PR TITLE
Experimental prompt.display_reasoning mechanism

### DIFF
--- a/docs/plugins/advanced-model-plugins.md
+++ b/docs/plugins/advanced-model-plugins.md
@@ -257,6 +257,7 @@ The 0.32 alpha introduced a richer contract for plugins than "yield strings":
 1. **`execute()` yields `StreamEvent` objects** (or plain `str`, still supported) so text, reasoning (thinking tokens), tool calls, and server-side tool results each surface as their own event type. The framework assembles these into typed `Part` objects.
 2. **`build_messages` (or equivalent) reads `prompt.messages`** — a `list[llm.Message]` that is the complete input chain for this turn.
 3. **Opaque provider tokens round-trip via `provider_metadata`** — Anthropic thinking signatures, Gemini thought signatures, OpenAI Responses API encrypted reasoning blobs. Plugins stash whatever the API returns, then echo it back on the next request.
+4. **`prompt.display_reasoning` tells plugins whether visible reasoning is wanted**. It defaults to `True`; the CLI's `-R/--no-reasoning` flag sets it to `False`. Providers that can omit reasoning summaries should use this to avoid requesting display-only reasoning text in the first place.
 
 **Older plugins still work.** A plugin that still yields plain `str` from `execute()` works unchanged — each string is wrapped as a `StreamEvent(type="text", chunk=...)` internally.
 

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -822,6 +822,7 @@ def prompt(
             validated_options[key_] = value
 
     kwargs = {}
+    kwargs["display_reasoning"] = not no_reasoning
 
     resolved_attachments = [*attachments, *attachment_types]
 
@@ -1159,6 +1160,7 @@ def chat(
             raise click.ClickException(render_errors(ex.errors()))
 
     kwargs = {}
+    kwargs["display_reasoning"] = not no_reasoning
     if validated_options:
         kwargs["options"] = validated_options
 

--- a/llm/models.py
+++ b/llm/models.py
@@ -357,6 +357,7 @@ class Prompt:
     tools: List[Tool]
     tool_results: List[ToolResult]
     options: "Options"
+    display_reasoning: bool
 
     def __init__(
         self,
@@ -373,6 +374,7 @@ class Prompt:
         tools=None,
         tool_results=None,
         messages=None,
+        display_reasoning=True,
     ):
         self._prompt = prompt
         self.model = model
@@ -387,6 +389,7 @@ class Prompt:
         self.tools = _wrap_tools(tools or [])
         self.tool_results = tool_results or []
         self.options = options or {}
+        self.display_reasoning = display_reasoning
         # Explicit messages= list, if the caller supplied one. Copied so
         # later mutation by the caller doesn't alter the Prompt.
         self._explicit_messages = list(messages) if messages is not None else None
@@ -583,6 +586,7 @@ class Conversation(_BaseConversation):
         messages: Optional[List[Any]] = None,
         stream: bool = True,
         key: Optional[str] = None,
+        display_reasoning: bool = True,
         **options,
     ) -> "Response":
         # Build the authoritative chain so response.prompt.messages
@@ -606,6 +610,7 @@ class Conversation(_BaseConversation):
                 system_fragments=system_fragments,
                 messages=chain,
                 options=self.model.Options(**options),
+                display_reasoning=display_reasoning,
             ),
             self.model,
             stream,
@@ -631,6 +636,7 @@ class Conversation(_BaseConversation):
         after_call: Optional[AfterCallSync] = None,
         key: Optional[str] = None,
         options: Optional[dict] = None,
+        display_reasoning: bool = True,
     ) -> "ChainResponse":
         self.model._validate_attachments(attachments)
         # Parity with Conversation.prompt: pre-bake the full chain so
@@ -656,6 +662,7 @@ class Conversation(_BaseConversation):
                 messages=chain_messages,
                 model=self.model,
                 options=self.model.Options(**(options or {})),
+                display_reasoning=display_reasoning,
             ),
             model=self.model,
             stream=stream,
@@ -705,6 +712,7 @@ class AsyncConversation(_BaseConversation):
         after_call: Optional[AfterCallAsync] = None,
         key: Optional[str] = None,
         options: Optional[dict] = None,
+        display_reasoning: bool = True,
     ) -> "AsyncChainResponse":
         self.model._validate_attachments(attachments)
         chain_messages = self._build_full_chain(
@@ -726,6 +734,7 @@ class AsyncConversation(_BaseConversation):
                 messages=chain_messages,
                 model=self.model,
                 options=self.model.Options(**(options or {})),
+                display_reasoning=display_reasoning,
             ),
             model=self.model,
             stream=stream,
@@ -750,6 +759,7 @@ class AsyncConversation(_BaseConversation):
         messages: Optional[List[Any]] = None,
         stream: bool = True,
         key: Optional[str] = None,
+        display_reasoning: bool = True,
         **options,
     ) -> "AsyncResponse":
         chain = self._build_full_chain(
@@ -771,6 +781,7 @@ class AsyncConversation(_BaseConversation):
                 system_fragments=system_fragments,
                 messages=chain,
                 options=self.model.Options(**options),
+                display_reasoning=display_reasoning,
             ),
             self.model,
             stream,
@@ -1624,6 +1635,8 @@ class Response(_BaseResponse):
         # (mirrors Conversation.prompt's `tools or self.tools` rule).
         if "tools" not in kwargs and self.prompt.tools:
             kwargs["tools"] = self.prompt.tools
+        if "display_reasoning" not in kwargs:
+            kwargs["display_reasoning"] = self.prompt.display_reasoning
         chain: List[Any] = list(self.prompt.messages) + list(self._messages_now())
         if tool_results:
             chain.append(
@@ -1956,6 +1969,8 @@ class AsyncResponse(_BaseResponse):
             tool_results = await self.execute_tool_calls()
         if "tools" not in kwargs and self.prompt.tools:
             kwargs["tools"] = self.prompt.tools
+        if "display_reasoning" not in kwargs:
+            kwargs["display_reasoning"] = self.prompt.display_reasoning
         chain: List[Any] = list(self.prompt.messages) + list(self._messages_now())
         if tool_results:
             chain.append(
@@ -2533,6 +2548,7 @@ class ChainResponse(_BaseChainResponse):
                         system_fragments=self.prompt.system_fragments,
                         options=self.prompt.options,
                         attachments=attachments,
+                        display_reasoning=current_response.prompt.display_reasoning,
                     ),
                     self.model,
                     stream=self.stream,
@@ -2604,6 +2620,7 @@ class AsyncChainResponse(_BaseChainResponse):
                     system_fragments=self.prompt.system_fragments,
                     options=self.prompt.options,
                     attachments=attachments,
+                    display_reasoning=current_response.prompt.display_reasoning,
                 )
                 current_response = AsyncResponse(
                     prompt,
@@ -2739,6 +2756,7 @@ class _Model(_BaseModel):
         schema: Optional[Union[dict, type[BaseModel]]] = None,
         tools: Optional[List[ToolDef]] = None,
         tool_results: Optional[List[ToolResult]] = None,
+        display_reasoning: bool = True,
         **options,
     ) -> Response:
         key_value = options.pop("key", None)
@@ -2756,6 +2774,7 @@ class _Model(_BaseModel):
                 messages=messages,
                 model=self,
                 options=self.Options(**options),
+                display_reasoning=display_reasoning,
             ),
             self,
             stream,
@@ -2779,6 +2798,7 @@ class _Model(_BaseModel):
         after_call: Optional[AfterCallSync] = None,
         key: Optional[str] = None,
         options: Optional[dict] = None,
+        display_reasoning: bool = True,
     ) -> ChainResponse:
         return self.conversation().chain(
             prompt=prompt,
@@ -2795,6 +2815,7 @@ class _Model(_BaseModel):
             after_call=after_call,
             key=key,
             options=options,
+            display_reasoning=display_reasoning,
         )
 
 
@@ -2852,6 +2873,7 @@ class _AsyncModel(_BaseModel):
         system_fragments: Optional[List[Union[str, Fragment]]] = None,
         messages: Optional[List[Any]] = None,
         stream: bool = True,
+        display_reasoning: bool = True,
         **options,
     ) -> AsyncResponse:
         key_value = options.pop("key", None)
@@ -2869,6 +2891,7 @@ class _AsyncModel(_BaseModel):
                 messages=messages,
                 model=self,
                 options=self.Options(**options),
+                display_reasoning=display_reasoning,
             ),
             self,
             stream,
@@ -2892,6 +2915,7 @@ class _AsyncModel(_BaseModel):
         after_call: Optional[AfterCallAsync] = None,
         key: Optional[str] = None,
         options: Optional[dict] = None,
+        display_reasoning: bool = True,
     ) -> AsyncChainResponse:
         return self.conversation().chain(
             prompt=prompt,
@@ -2908,6 +2932,7 @@ class _AsyncModel(_BaseModel):
             after_call=after_call,
             key=key,
             options=options,
+            display_reasoning=display_reasoning,
         )
 
 

--- a/tests/test_cli_streaming.py
+++ b/tests/test_cli_streaming.py
@@ -42,6 +42,7 @@ def test_reasoning_goes_to_stderr_not_stdout(mock_model):
     assert "thinking hard" in result.stderr
     assert "thinking hard" not in result.stdout
     assert "answer" in result.stdout
+    assert mock_model.history[0][0].display_reasoning is True
 
 
 def test_reasoning_rendered_in_dim_style(mock_model):
@@ -84,6 +85,7 @@ def test_no_reasoning_flag_suppresses_reasoning(mock_model):
     assert "hidden thinking" not in result.stderr
     assert "hidden thinking" not in result.stdout
     assert "answer" in result.stdout
+    assert mock_model.history[0][0].display_reasoning is False
 
 
 def test_no_reasoning_short_flag_R(mock_model):

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -1062,6 +1062,21 @@ class TestConversationFullChainInvariant:
         r1.text()
         assert r1.prompt.messages == [llm.user("q1")]
 
+    def test_display_reasoning_can_be_disabled(self, mock_model):
+        mock_model.enqueue(["a1"])
+        response = mock_model.prompt("q1", display_reasoning=False)
+        response.text()
+        assert mock_model.history[0][0].display_reasoning is False
+
+    def test_reply_preserves_display_reasoning(self, mock_model):
+        mock_model.enqueue(["a1"])
+        mock_model.enqueue(["a2"])
+        response = mock_model.prompt("q1", display_reasoning=False)
+        response.text()
+        follow_up = response.reply("q2")
+        follow_up.text()
+        assert mock_model.history[1][0].display_reasoning is False
+
     def test_conversation_preserves_reasoning_and_tool_call_parts(self, mock_model):
         """The chain carries reasoning and tool calls from prior turns,
         not just the flat text — required for multi-turn extended


### PR DESCRIPTION
So you can turn off display reasoning and compatible plugins can then opt not to request reasoning summaries from their models, even as they do actually run reasoning.

Not yet sure if the design is right.