### PR TITLE
docs: add OfoxAI as cloud LLM API gateway example

### DIFF
--- a/docs/other-models.md
+++ b/docs/other-models.md
@@ -75,3 +75,23 @@ Some providers such as [openrouter.ai](https://openrouter.ai/docs) may require t
     HTTP-Referer: "https://llm.datasette.io/"
     X-Title: LLM
 ```
+
+
+### Cloud LLM API gateways
+
+API gateway services such as [OfoxAI](https://ofox.ai) provide access to 100+ models (GPT, Claude, Gemini, DeepSeek, etc.) through a single OpenAI-compatible endpoint:
+
+```yaml
+- model_id: ofoxai-gpt-4o
+  model_name: gpt-4o
+  api_base: "https://api.ofox.ai/v1"
+  api_key_name: ofoxai
+```
+
+Store your OfoxAI API key with:
+
+```bash
+llm keys set ofoxai
+```
+
+You can then swap `model_name` to any of the [100+ models](https://ofox.ai) OfoxAI supports without changing your API key.


### PR DESCRIPTION
Adds [OfoxAI](https://ofox.ai) as an example in the OpenAI-compatible models section, showing how to configure access to 100+ LLMs (GPT, Claude, Gemini, DeepSeek, etc.) through a single API key and endpoint.

OfoxAI is an OpenAI-compatible API gateway — it works exactly like the LocalAI and openrouter.ai examples already in the docs. Happy to adjust placement or wording to better fit the docs style.