### PR TITLE
--hide-reasoning and hide_reasoning=True parameters

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -32,7 +32,7 @@ Plugin authors should read the expanded {ref}`Advanced model plugins <advanced-m
 ### CLI
 
 - `llm prompt` and `llm chat` now display visible reasoning text to stderr in a dim style while the response streams.
-- New `-R/--no-reasoning` flag for `llm prompt` and `llm chat` to suppress the reasoning stream.
+- New `-R/--hide-reasoning` flag for `llm prompt` and `llm chat` to hide the reasoning stream.
 - `llm logs` now renders any visible reasoning emitted during a response under a `## Reasoning` heading above the response.
 - New `reasoning` column on the `responses` table populated from the visible-reasoning text.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## unreleased
+
+- New `hide_reasoning=True` keyword argument on `model.prompt()`, `conversation.prompt()`, `model.chain()`, `conversation.chain()`, and their async counterparts, exposed to model plugins as `prompt.hide_reasoning`. Model plugins can use this to decide if they should request visible reasoning summaries from their providers.
+
 (v0_32_a1)=
 ## 0.32a1 (2026-04-29)
 

--- a/docs/help.md
+++ b/docs/help.md
@@ -145,7 +145,7 @@ Options:
   --no-stream                     Do not stream output
   -n, --no-log                    Don't log to database
   --log                           Log prompt and response to the database
-  -R, --no-reasoning              Don't display reasoning output
+  -R, --hide-reasoning            Hide reasoning output
   -c, --continue                  Continue the most recent conversation.
   --cid, --conversation TEXT      Continue the conversation with the given ID.
   --key TEXT                      API key to use
@@ -177,7 +177,7 @@ Options:
   -o, --option <TEXT TEXT>...   key/value options for the model
   -d, --database FILE           Path to log database
   --no-stream                   Do not stream output
-  -R, --no-reasoning            Don't display reasoning output
+  -R, --hide-reasoning          Hide reasoning output
   --key TEXT                    API key to use
   -T, --tool TEXT               Name of a tool to make available to the model
   --functions TEXT              Python code block or file path defining

--- a/docs/plugins/advanced-model-plugins.md
+++ b/docs/plugins/advanced-model-plugins.md
@@ -325,6 +325,25 @@ yield StreamEvent(type="reasoning", chunk=text_chunk)
 
 Reasoning events that appear before/after text events become distinct `ReasoningPart` and `TextPart` entries in `response.messages` automatically. If your provider emits two thinking blocks separated by a tool call, you'll get two `ReasoningPart`s.
 
+Plugins should respect `prompt.hide_reasoning`. This is set when the caller passes `hide_reasoning=True` to `model.prompt()`, `conversation.prompt()`, `model.chain()`, `conversation.chain()`, or their async counterparts. It is also set by the CLI `-R/--hide-reasoning` option.
+
+`prompt.hide_reasoning` means "hide visible reasoning output", not "disable model reasoning". If your provider requires an explicit request for visible reasoning summaries, do not request those summaries when `prompt.hide_reasoning` is true:
+
+```python
+kwargs = {}
+if not prompt.hide_reasoning:
+    kwargs["reasoning"] = {"summary": "auto"}
+```
+
+If your provider emits reasoning blocks regardless of request parameters, keep yielding those reasoning events as usual:
+
+```python
+if chunk.type == "thinking":
+    yield StreamEvent(type="reasoning", chunk=chunk.text)
+```
+
+LLM's display layers use `prompt.hide_reasoning` to avoid showing those events to the user, while still allowing the framework to persist `ReasoningPart` objects and provider metadata for logs, serialization, and future turns.
+
 ### Tool calls
 
 Each tool call emits two event types sharing a `tool_call_id`:

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -591,6 +591,24 @@ Event types are `"text"`, `"reasoning"`, `"tool_call_name"`, `"tool_call_args"`,
 
 Iterating against the response object itself (`for chunk in response`) yields only text strings — reasoning and tool-call events are filtered out.
 
+#### Hiding reasoning output
+
+Some model plugins can return visible reasoning text, exposed as `"reasoning"` events from `response.stream_events()` and assembled as `ReasoningPart` objects in `response.messages()`.
+
+Pass `hide_reasoning=True` to ask LLM and supported model plugins not to expose that visible reasoning output:
+
+```python
+response = model.prompt(
+    "Explain quantum computing briefly.",
+    hide_reasoning=True,
+)
+print(response.text())
+```
+
+This is the Python API equivalent of the CLI `-R/--hide-reasoning` option. It is available on `model.prompt()`, `conversation.prompt()`, `model.chain()`, `conversation.chain()`, and their async counterparts.
+
+`hide_reasoning=True` does not ask the model to stop reasoning. It asks the plugin to hide visible reasoning text and, where the provider API supports it, avoid requesting visible reasoning summaries. Plugins may still preserve opaque provider metadata, such as reasoning signatures or encrypted reasoning blobs, so later turns in a conversation can continue correctly.
+
 #### Inspecting the finished response
 
 `response.messages()` returns the assembled list of `Message` objects produced by the model, excluding the messages from the original prompt. Calling it forces execution if the response hasn't been drained yet, so you don't need a separate `response.text()` first:

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -607,7 +607,7 @@ print(response.text())
 
 This is the Python API equivalent of the CLI `-R/--hide-reasoning` option. It is available on `model.prompt()`, `conversation.prompt()`, `model.chain()`, `conversation.chain()`, and their async counterparts.
 
-`hide_reasoning=True` does not ask the model to stop reasoning. It asks the plugin to hide visible reasoning text and, where the provider API supports it, avoid requesting visible reasoning summaries. Plugins may still preserve opaque provider metadata, such as reasoning signatures or encrypted reasoning blobs, so later turns in a conversation can continue correctly.
+Note that this only requests that the underlying model does not return visible tokens. This request may not be supported by your provider, in which case this hint will not prevent visible reasoning tokens from being returned in the stream.
 
 #### Inspecting the finished response
 

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -490,7 +490,7 @@ def cli():
 @click.option("-n", "--no-log", is_flag=True, help="Don't log to database")
 @click.option("--log", is_flag=True, help="Log prompt and response to the database")
 @click.option(
-    "-R", "--no-reasoning", is_flag=True, help="Don't display reasoning output"
+    "-R", "--hide-reasoning", is_flag=True, help="Hide reasoning output"
 )
 @click.option(
     "_continue",
@@ -542,7 +542,7 @@ def prompt(
     no_stream,
     no_log,
     log,
-    no_reasoning,
+    hide_reasoning,
     _continue,
     conversation_id,
     key,
@@ -911,7 +911,7 @@ def prompt(
                     )
                     await display_async_stream_events(
                         response.astream_events(),
-                        show_reasoning=not no_reasoning,
+                        show_reasoning=not hide_reasoning,
                     )
                     print("")
                 else:
@@ -946,7 +946,7 @@ def prompt(
             if should_stream:
                 display_stream_events(
                     response.stream_events(),
-                    show_reasoning=not no_reasoning,
+                    show_reasoning=not hide_reasoning,
                 )
                 print("")
             else:
@@ -1045,7 +1045,7 @@ def prompt(
 )
 @click.option("--no-stream", is_flag=True, help="Do not stream output")
 @click.option(
-    "-R", "--no-reasoning", is_flag=True, help="Don't display reasoning output"
+    "-R", "--hide-reasoning", is_flag=True, help="Hide reasoning output"
 )
 @click.option("--key", help="API key to use")
 @click.option(
@@ -1095,7 +1095,7 @@ def chat(
     param,
     options,
     no_stream,
-    no_reasoning,
+    hide_reasoning,
     key,
     database,
     tools,
@@ -1302,7 +1302,7 @@ def chat(
         argument_system_fragments = []
         display_stream_events(
             response.stream_events(),
-            show_reasoning=not no_reasoning,
+            show_reasoning=not hide_reasoning,
         )
         response.log_to_db(db)
         print("")

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -489,9 +489,7 @@ def cli():
 @click.option("--no-stream", is_flag=True, help="Do not stream output")
 @click.option("-n", "--no-log", is_flag=True, help="Don't log to database")
 @click.option("--log", is_flag=True, help="Log prompt and response to the database")
-@click.option(
-    "-R", "--hide-reasoning", is_flag=True, help="Hide reasoning output"
-)
+@click.option("-R", "--hide-reasoning", is_flag=True, help="Hide reasoning output")
 @click.option(
     "_continue",
     "-c",
@@ -1047,9 +1045,7 @@ def prompt(
     help="Path to log database",
 )
 @click.option("--no-stream", is_flag=True, help="Do not stream output")
-@click.option(
-    "-R", "--hide-reasoning", is_flag=True, help="Hide reasoning output"
-)
+@click.option("-R", "--hide-reasoning", is_flag=True, help="Hide reasoning output")
 @click.option("--key", help="API key to use")
 @click.option(
     "tools",

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -895,6 +895,9 @@ def prompt(
         # Merge in options for the .prompt() methods
         kwargs.update(validated_options)
 
+    if hide_reasoning:
+        kwargs["hide_reasoning"] = True
+
     try:
         if async_:
 
@@ -1197,6 +1200,8 @@ def chat(
 
     if key and isinstance(model, KeyModel):
         kwargs["key"] = key
+    if hide_reasoning:
+        kwargs["hide_reasoning"] = True
 
     try:
         fragments_and_attachments = resolve_fragments(

--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -1349,10 +1349,13 @@ class _SharedResponses(_Shared):
         if seed is not None:
             kwargs["seed"] = seed
         if self._reasoning:
-            reasoning = {"summary": "auto"}
+            reasoning = {}
+            if not getattr(prompt, "hide_reasoning", False):
+                reasoning["summary"] = "auto"
             if reasoning_effort:
                 reasoning["effort"] = reasoning_effort
-            kwargs["reasoning"] = reasoning
+            if reasoning:
+                kwargs["reasoning"] = reasoning
 
         text: Dict[str, Any] = {}
         if verbosity:

--- a/llm/models.py
+++ b/llm/models.py
@@ -357,6 +357,7 @@ class Prompt:
     tools: List[Tool]
     tool_results: List[ToolResult]
     options: "Options"
+    hide_reasoning: bool
 
     def __init__(
         self,
@@ -373,6 +374,7 @@ class Prompt:
         tools=None,
         tool_results=None,
         messages=None,
+        hide_reasoning=False,
     ):
         self._prompt = prompt
         self.model = model
@@ -387,6 +389,7 @@ class Prompt:
         self.tools = _wrap_tools(tools or [])
         self.tool_results = tool_results or []
         self.options = options or {}
+        self.hide_reasoning = hide_reasoning
         # Explicit messages= list, if the caller supplied one. Copied so
         # later mutation by the caller doesn't alter the Prompt.
         self._explicit_messages = list(messages) if messages is not None else None
@@ -596,6 +599,7 @@ class Conversation(_BaseConversation):
         stream: bool = True,
         key: Optional[str] = None,
         options: Optional[dict] = None,
+        hide_reasoning: bool = False,
         **kwargs,
     ) -> "Response":
         merged = _merge_options(options, kwargs)
@@ -620,6 +624,7 @@ class Conversation(_BaseConversation):
                 system_fragments=system_fragments,
                 messages=chain,
                 options=self.model.Options(**merged),
+                hide_reasoning=hide_reasoning,
             ),
             self.model,
             stream,
@@ -645,6 +650,7 @@ class Conversation(_BaseConversation):
         after_call: Optional[AfterCallSync] = None,
         key: Optional[str] = None,
         options: Optional[dict] = None,
+        hide_reasoning: bool = False,
     ) -> "ChainResponse":
         self.model._validate_attachments(attachments)
         # Parity with Conversation.prompt: pre-bake the full chain so
@@ -670,6 +676,7 @@ class Conversation(_BaseConversation):
                 messages=chain_messages,
                 model=self.model,
                 options=self.model.Options(**(options or {})),
+                hide_reasoning=hide_reasoning,
             ),
             model=self.model,
             stream=stream,
@@ -719,6 +726,7 @@ class AsyncConversation(_BaseConversation):
         after_call: Optional[AfterCallAsync] = None,
         key: Optional[str] = None,
         options: Optional[dict] = None,
+        hide_reasoning: bool = False,
     ) -> "AsyncChainResponse":
         self.model._validate_attachments(attachments)
         chain_messages = self._build_full_chain(
@@ -740,6 +748,7 @@ class AsyncConversation(_BaseConversation):
                 messages=chain_messages,
                 model=self.model,
                 options=self.model.Options(**(options or {})),
+                hide_reasoning=hide_reasoning,
             ),
             model=self.model,
             stream=stream,
@@ -765,6 +774,7 @@ class AsyncConversation(_BaseConversation):
         stream: bool = True,
         key: Optional[str] = None,
         options: Optional[dict] = None,
+        hide_reasoning: bool = False,
         **kwargs,
     ) -> "AsyncResponse":
         merged = _merge_options(options, kwargs)
@@ -787,6 +797,7 @@ class AsyncConversation(_BaseConversation):
                 system_fragments=system_fragments,
                 messages=chain,
                 options=self.model.Options(**merged),
+                hide_reasoning=hide_reasoning,
             ),
             self.model,
             stream,
@@ -2570,6 +2581,7 @@ class ChainResponse(_BaseChainResponse):
                         system_fragments=self.prompt.system_fragments,
                         options=self.prompt.options,
                         attachments=attachments,
+                        hide_reasoning=current_response.prompt.hide_reasoning,
                     ),
                     self.model,
                     stream=self.stream,
@@ -2641,6 +2653,7 @@ class AsyncChainResponse(_BaseChainResponse):
                     system_fragments=self.prompt.system_fragments,
                     options=self.prompt.options,
                     attachments=attachments,
+                    hide_reasoning=current_response.prompt.hide_reasoning,
                 )
                 current_response = AsyncResponse(
                     prompt,
@@ -2777,6 +2790,7 @@ class _Model(_BaseModel):
         tools: Optional[List[ToolDef]] = None,
         tool_results: Optional[List[ToolResult]] = None,
         options: Optional[dict] = None,
+        hide_reasoning: bool = False,
         **kwargs,
     ) -> Response:
         key_value = kwargs.pop("key", None)
@@ -2795,6 +2809,7 @@ class _Model(_BaseModel):
                 messages=messages,
                 model=self,
                 options=self.Options(**merged),
+                hide_reasoning=hide_reasoning,
             ),
             self,
             stream,
@@ -2818,6 +2833,7 @@ class _Model(_BaseModel):
         after_call: Optional[AfterCallSync] = None,
         key: Optional[str] = None,
         options: Optional[dict] = None,
+        hide_reasoning: bool = False,
     ) -> ChainResponse:
         return self.conversation().chain(
             prompt=prompt,
@@ -2834,6 +2850,7 @@ class _Model(_BaseModel):
             after_call=after_call,
             key=key,
             options=options,
+            hide_reasoning=hide_reasoning,
         )
 
 
@@ -2892,6 +2909,7 @@ class _AsyncModel(_BaseModel):
         messages: Optional[List[Any]] = None,
         stream: bool = True,
         options: Optional[dict] = None,
+        hide_reasoning: bool = False,
         **kwargs,
     ) -> AsyncResponse:
         key_value = kwargs.pop("key", None)
@@ -2910,6 +2928,7 @@ class _AsyncModel(_BaseModel):
                 messages=messages,
                 model=self,
                 options=self.Options(**merged),
+                hide_reasoning=hide_reasoning,
             ),
             self,
             stream,
@@ -2933,6 +2952,7 @@ class _AsyncModel(_BaseModel):
         after_call: Optional[AfterCallAsync] = None,
         key: Optional[str] = None,
         options: Optional[dict] = None,
+        hide_reasoning: bool = False,
     ) -> AsyncChainResponse:
         return self.conversation().chain(
             prompt=prompt,
@@ -2949,6 +2969,7 @@ class _AsyncModel(_BaseModel):
             after_call=after_call,
             key=key,
             options=options,
+            hide_reasoning=hide_reasoning,
         )
 
 

--- a/tests/test_cli_streaming.py
+++ b/tests/test_cli_streaming.py
@@ -1,5 +1,5 @@
 """Tests for CLI streaming display: reasoning → stderr (dim),
-text → stdout, -R / --no-reasoning flag.
+text → stdout, -R / --hide-reasoning flag.
 """
 
 import click
@@ -65,7 +65,7 @@ def test_reasoning_rendered_in_dim_style(mock_model):
     assert dim_start in result.stderr
 
 
-def test_no_reasoning_flag_suppresses_reasoning(mock_model):
+def test_hide_reasoning_flag_suppresses_reasoning(mock_model):
     mock_model.enqueue(
         [
             llm.parts.StreamEvent(
@@ -77,7 +77,7 @@ def test_no_reasoning_flag_suppresses_reasoning(mock_model):
     runner = CliRunner(mix_stderr=False)
     result = runner.invoke(
         cli,
-        ["-m", "mock", "hi", "--no-log", "--no-reasoning"],
+        ["-m", "mock", "hi", "--no-log", "--hide-reasoning"],
         catch_exceptions=False,
     )
     assert result.exit_code == 0
@@ -86,7 +86,7 @@ def test_no_reasoning_flag_suppresses_reasoning(mock_model):
     assert "answer" in result.stdout
 
 
-def test_no_reasoning_short_flag_R(mock_model):
+def test_hide_reasoning_short_flag_R(mock_model):
     mock_model.enqueue(
         [
             llm.parts.StreamEvent(type="reasoning", chunk="hidden", part_index=0),

--- a/tests/test_cli_streaming.py
+++ b/tests/test_cli_streaming.py
@@ -84,6 +84,7 @@ def test_hide_reasoning_flag_suppresses_reasoning(mock_model):
     assert "hidden thinking" not in result.stderr
     assert "hidden thinking" not in result.stdout
     assert "answer" in result.stdout
+    assert mock_model.history[0][0].hide_reasoning is True
 
 
 def test_hide_reasoning_short_flag_R(mock_model):

--- a/tests/test_openai_responses.py
+++ b/tests/test_openai_responses.py
@@ -140,6 +140,47 @@ def test_default_routes_to_responses_endpoint(httpx_mock):
     assert request_body["reasoning"] == {"summary": "auto"}
 
 
+def test_hide_reasoning_omits_reasoning_summary_from_responses_request(httpx_mock):
+    httpx_mock.add_response(
+        method="POST",
+        url="https://api.openai.com/v1/responses",
+        json={
+            "id": "resp_test_1",
+            "object": "response",
+            "created_at": 1,
+            "model": "gpt-5.5",
+            "output": [
+                {
+                    "type": "message",
+                    "id": "msg_1",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "hidden",
+                            "annotations": [],
+                        }
+                    ],
+                }
+            ],
+            "usage": {
+                "input_tokens": 5,
+                "output_tokens": 3,
+                "total_tokens": 8,
+            },
+            "status": "completed",
+        },
+        headers={"Content-Type": "application/json"},
+    )
+    model = llm.get_model("gpt-5.5")
+    response = model.prompt("hello", stream=False, key="test", hide_reasoning=True)
+    assert response.text() == "hidden"
+    request_body = json.loads(httpx_mock.get_requests()[-1].content)
+    assert request_body["include"] == ["reasoning.encrypted_content"]
+    assert "reasoning" not in request_body
+
+
 def test_non_reasoning_responses_model_omits_encrypted_reasoning_include(httpx_mock):
     from llm.default_plugins.openai_models import Responses
 
@@ -347,6 +388,38 @@ def test_responses_kwargs_sets_reasoning_summary_without_effort():
     p.schema = None
     kwargs = model._build_responses_kwargs(p, stream=False)
     assert kwargs["reasoning"] == {"summary": "auto"}
+
+
+def test_responses_kwargs_omits_reasoning_summary_when_hide_reasoning():
+    model = llm.get_model("gpt-5.5")
+    options = model.Options(reasoning_effort="low")
+
+    class FakePrompt:
+        pass
+
+    p = FakePrompt()
+    p.options = options
+    p.tools = []
+    p.schema = None
+    p.hide_reasoning = True
+    kwargs = model._build_responses_kwargs(p, stream=False)
+    assert kwargs["reasoning"] == {"effort": "low"}
+
+
+def test_responses_kwargs_omits_empty_reasoning_when_hide_reasoning():
+    model = llm.get_model("gpt-5.5")
+    options = model.Options()
+
+    class FakePrompt:
+        pass
+
+    p = FakePrompt()
+    p.options = options
+    p.tools = []
+    p.schema = None
+    p.hide_reasoning = True
+    kwargs = model._build_responses_kwargs(p, stream=False)
+    assert "reasoning" not in kwargs
 
 
 def test_responses_streams_reasoning_summary_text(httpx_mock):


### PR DESCRIPTION
Previously we had a `-R/--no-reasoning` option to `llm prompt` which was misleadingly named - it only suppressed output of reasoning text, it did not turn reasoning off - and was not passed through to the models.

As of #1435 the default OpenAI model plugin requests `"summary": "auto"` reasoning summaries. You can hide these with `-R` but they are still requested.

This change passes `hide_reasoning=True` through on the `Prompt` object, such that plugins can opt not to request visible reasoning tokens.