### PR TITLE
Pin build-system setuptools to >=77 for PEP-639 SPDX license

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ Changelog = "https://github.com/simonw/llm/releases"
 llm = "llm.cli:cli"
 
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Refs #1444.

`pyproject.toml` declares the license as a plain SPDX expression (`license = "Apache-2.0"`), which is the modern PEP-639 form. Setuptools added native PEP-639 support in 77.0.0; pre-77 setuptools validates against pre-PEP-639 PEP-621 and requires the license field to be a table:

```
ValueError: invalid pyproject.toml config: `project.license`
... must be valid exactly by one definition (2 matches found):
    - keys: 'file': ...
    - keys: 'text': ...
```

The reporter hit this on FreeBSD Poudriere because the build environment was using a pre-77 setuptools and `[build-system].requires` was just `["setuptools"]` with no version constraint, so no newer setuptools got pulled in for the build.

Pinning `setuptools>=77` in `[build-system].requires` forces PEP-517-isolated build environments to install a setuptools that understands the SPDX form, which fixes the reported build failure without giving up the modern license format that PEP-639 explicitly recommends.

Alternative I considered and didn't take: switch the project field to the legacy table form (`license = { text = "Apache-2.0" }`). That also works on old setuptools, but PEP-639 deprecates the table form and modern setuptools (77+) emits a warning for it; the build-system pin keeps the file aligned with current packaging standards.

## Validation

- `python -c "import tomllib; tomllib.loads(open('pyproject.toml','rb').read().decode())"` parses clean.
- Built and parsed the file against setuptools 78.x locally; the SPDX `license = "Apache-2.0"` validates without warning when the new build constraint is honored.

## AI Assistance Disclosure

This PR was drafted with AI assistance (Claude Code). I read the issue, traced the PEP-639 vs pre-PEP-639 setuptools history, considered the legacy-table-form alternative the reporter proposed, and chose the build-system pin because it keeps the project on the modern license format. The change is a single character on one line and the tradeoff is captured above for your call.