### PR TITLE
Fix chat template quit handling

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1271,6 +1271,8 @@ def chat(
                 accumulated_fragments += fragments
                 accumulated_attachments += attachments
                 continue
+        if prompt.strip() in ("exit", "quit"):
+            break
         if template_obj:
             try:
                 # Mirror prompt() logic: only pass input if template uses it
@@ -1286,8 +1288,6 @@ def chat(
                     prompt = f"{template_prompt}\n{prompt}"
                 else:
                     prompt = template_prompt
-        if prompt.strip() in ("exit", "quit"):
-            break
 
         response = conversation.chain(
             prompt,

--- a/tests/test_chat_templates.py
+++ b/tests/test_chat_templates.py
@@ -31,6 +31,30 @@ def test_chat_template_system_only_no_duplicate_prompt(
 
 
 @pytest.mark.xfail(sys.platform == "win32", reason="Expected to fail on Windows")
+def test_chat_template_prompt_does_not_capture_quit(
+    mock_model, logs_db, templates_path
+):
+    (templates_path / "french-greeting.yaml").write_text(
+        "system: Speak in French\nprompt: Say hello\n", "utf-8"
+    )
+
+    runner = CliRunner()
+    mock_model.enqueue(["Bonjour !"])
+    result = runner.invoke(
+        llm.cli.cli,
+        ["chat", "-m", "mock", "-t", "french-greeting"],
+        input="hi\nquit\n",
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+    rows = list(logs_db["responses"].rows)
+    assert len(rows) == 1
+    assert rows[0]["prompt"] == "Say hello\nhi"
+    assert rows[0]["system"] == "Speak in French"
+
+
+@pytest.mark.xfail(sys.platform == "win32", reason="Expected to fail on Windows")
 def test_chat_system_fragments_only_first_turn(tmpdir, mock_model, logs_db):
     # Create a system fragment file
     sys_frag_path = str(tmpdir / "sys.txt")


### PR DESCRIPTION
## Summary
- Check `exit` / `quit` chat commands before applying a prompt template
- Prevent templates with a `prompt:` value from turning `quit` into a model prompt
- Add a regression covering `llm chat -t` with a template prompt

Fixes #1336.

## Validation
- `uv run pytest tests/test_chat_templates.py -q`
- `uv run pytest tests/test_chat.py tests/test_chat_templates.py -q`
- `uv run ruff check llm/cli.py tests/test_chat_templates.py`
- `uv run black --check --target-version py313 llm/cli.py tests/test_chat_templates.py`
- `git diff --check`