### PR TITLE
fix: update license field to PEP-621 format in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = { file = "README.md", content-type = "text/markdown" }
 authors = [
     { name = "Simon Willison" },
 ]
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
The `license` field in `pyproject.toml` uses the deprecated string format. PEP 621 requires the table format:

```toml
# Before
license = "Apache-2.0"

# After  
license = {text = "Apache-2.0"}
```

This fixes build warnings on FreeBSD and other tooling that validates PEP-621 compliance.

Fixes #1444