### PR TITLE
fix: skip OpenAI model registration when no API key is configured

### DIFF
--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -43,6 +43,8 @@ import yaml
 
 @hookimpl
 def register_models(register):
+    if not llm.get_key(alias="openai", env="OPENAI_API_KEY"):
+        return
     # GPT-4o
     register(
         Chat("gpt-4o", vision=True, supports_schema=True, supports_tools=True),
@@ -380,6 +382,8 @@ def register_models(register):
 
 @hookimpl
 def register_embedding_models(register):
+    if not llm.get_key(alias="openai", env="OPENAI_API_KEY"):
+        return
     register(
         OpenAIEmbeddingModel("text-embedding-ada-002", "text-embedding-ada-002"),
         aliases=(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,7 @@ def templates_path(user_path):
 @pytest.fixture(autouse=True)
 def env_setup(monkeypatch, user_path):
     monkeypatch.setenv("LLM_USER_PATH", str(user_path))
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
 
 
 class MockModel(llm.Model):

--- a/tests/test_cli_openai_models.py
+++ b/tests/test_cli_openai_models.py
@@ -6,6 +6,12 @@ import pytest
 import sqlite_utils
 
 
+@pytest.fixture(autouse=True)
+def openai_api_key(monkeypatch):
+    """Set a fake OpenAI API key so models are registered in all tests in this file."""
+    monkeypatch.setenv("OPENAI_API_KEY", "fake-key-for-testing")
+
+
 @pytest.fixture
 def mocked_models(httpx_mock):
     httpx_mock.add_response(
@@ -504,3 +510,23 @@ def test_gpt4o_mini_sync_and_async(monkeypatch, tmpdir, httpx_mock, async_, usag
     assert db["responses"].count == 1
     row = next(db["responses"].rows)
     assert row["response"] == "Ho ho ho"
+
+
+def test_openai_models_not_registered_without_key(monkeypatch):
+    """OpenAI models should not appear in the model list when no API key is configured."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["models"], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "OpenAI Chat" not in result.output
+    assert "OpenAI Completion" not in result.output
+
+
+def test_openai_models_registered_with_key(monkeypatch):
+    """OpenAI models should appear in the model list when an API key is configured."""
+    monkeypatch.setenv("OPENAI_API_KEY", "fake-key-for-testing")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["models"], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "OpenAI Chat: gpt-4o" in result.output
+    assert "OpenAI Chat: gpt-4o-mini" in result.output


### PR DESCRIPTION
## Problem

When no OpenAI API key is set, `llm` still registers ~50 OpenAI models (and several embedding models) at startup. This causes several issues:

- `llm models` output is cluttered with models the user cannot use
- Model IDs like `gpt-4o-mini` collide with identically-named models from other plugins (e.g. a LiteLLM proxy)
- The default model resolves to an OpenAI model, so bare `llm` invocations fail with `No key found` for users who don't use OpenAI at all

## Fix

Add a guard at the top of `register_models` and `register_embedding_models` in the built-in OpenAI plugin. If no key is available (neither in `keys.json` nor `OPENAI_API_KEY` env var), registration is skipped entirely.

```python
if not llm.get_key(alias="openai", env="OPENAI_API_KEY"):
    return
```

Users who later configure a key will see the models appear automatically on the next invocation.

## Tests

- Added `test_openai_models_not_registered_without_key` — verifies OpenAI Chat models are absent from `llm models` when no key is set
- Added `test_openai_models_registered_with_key` — verifies OpenAI Chat models appear when a key is present
- Updated `conftest.py` to set a fake `OPENAI_API_KEY` in the global `env_setup` fixture so existing tests that exercise OpenAI model features continue to pass
- Added a file-level autouse fixture in `test_cli_openai_models.py` for explicitness

Fixes #1445