### PR TITLE
Keep monotonic_ulid monotonic when the system clock moves backward

### DIFF
--- a/llm/utils.py
+++ b/llm/utils.py
@@ -692,7 +692,8 @@ def monotonic_ulid() -> ULID:
 
     It works the same way the reference JavaScript `monotonicFactory` does:
     * If the current call happens in the same millisecond as the previous
-        one, the 80-bit randomness part is incremented by exactly one.
+        one, or the system clock has moved backward, the 80-bit randomness
+        part is incremented by exactly one.
     * As soon as the system clock moves forward, a brand-new ULID with
         cryptographically secure randomness is generated.
     * If more than 2**80 ULIDs are requested within a single millisecond
@@ -711,8 +712,10 @@ def monotonic_ulid() -> ULID:
         # Decode timestamp from the last ULID we handed out
         last_ms = int.from_bytes(_last[:TIMESTAMP_LEN], "big")
 
-        # If the millisecond is the same, increment the randomness
-        if now_ms == last_ms:
+        # If the clock has not moved forward (same millisecond, or it was
+        # set backward), keep the previous timestamp and increment the
+        # randomness, so the result still sorts strictly after the last ULID.
+        if now_ms <= last_ms:
             rand_int = int.from_bytes(_last[TIMESTAMP_LEN:], "big") + 1
             if rand_int >= 1 << (RANDOMNESS_LEN * 8):
                 raise OverflowError(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -468,6 +468,29 @@ def test_monotonic_ulids():
     assert ulids == sorted(ulids)
 
 
+def test_monotonic_ulid_survives_backward_clock(monkeypatch):
+    # A backward clock jump (NTP correction, VM migration, manual change)
+    # must not produce a ULID that sorts before the previous one.
+    import llm.utils as utils
+
+    ms = utils.NANOSECS_IN_MILLISECS
+    times_ns = iter(
+        [
+            2_000_000 * ms,  # first call
+            1_000_000 * ms,  # clock jumps a million ms backward
+            1_000_001 * ms,  # still behind the first call
+        ]
+    )
+    monkeypatch.setattr(utils.time, "time_ns", lambda: next(times_ns))
+    monkeypatch.setattr(utils, "_last", None)
+
+    first = monotonic_ulid()
+    after_backward = monotonic_ulid()
+    third = monotonic_ulid()
+
+    assert first < after_backward < third
+
+
 def test_toolbox_config_capture():
     """Test that Toolbox captures __init__ parameters in _config"""
 


### PR DESCRIPTION
`monotonic_ulid()` documents that its result is "strictly larger than every other ULID returned by this function inside the same process", and that it "works the same way the reference JavaScript `monotonicFactory` does".

It doesn't, quite. It only handles `now_ms == last_ms` as the increment-the-randomness case:

```python
if now_ms == last_ms:
    # increment randomness, keep last timestamp
    ...
# New millisecond, start fresh
_last = _fresh(now_ms)
```

When the system clock moves **backward** — an NTP correction, a VM migration, a manual change — `now_ms < last_ms`, which skips that branch and falls through to `_fresh(now_ms)`. That builds a ULID whose timestamp prefix is *smaller* than the previous one, so it sorts before it and the monotonicity guarantee is broken.

The JS `monotonicFactory` this is modelled on uses `seed <= lastTime` precisely to cover this case. This change does the same: when the clock hasn't moved forward, keep the previous timestamp and increment the randomness.

Added `test_monotonic_ulid_survives_backward_clock`, which patches `time.time_ns` to jump backward between calls. It fails on `main` (the post-jump ULID sorts first) and passes with the fix. Existing `test_monotonic_ulids` and the rest of `test_utils.py` still pass.