### PR TITLE
Recognize ${braced} variables in template extract_vars

### DIFF
--- a/llm/templates.py
+++ b/llm/templates.py
@@ -85,8 +85,11 @@ class Template(BaseModel):
     @staticmethod
     def extract_vars(string_template: string.Template) -> List[str]:
         """Extract and return the list of named variable identifiers from a string.Template."""
+        # A string.Template match is either $named or ${braced}; collect both,
+        # otherwise ${var} placeholders are missed by vars() and slip past the
+        # MissingVariables check in interpolate().
         return [
-            match.group("named")
+            match.group("named") or match.group("braced")
             for match in string_template.pattern.finditer(string_template.template)
-            if match.group("named")
+            if match.group("named") or match.group("braced")
         ]

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -31,6 +31,27 @@ import yaml
             None,
             None,
         ),
+        # ${braced} variables are valid string.Template syntax too
+        ("S: ${input}", None, None, {}, "S: input", None, None),
+        (
+            "${one} and ${two}",
+            None,
+            None,
+            {"one": 1, "two": 2},
+            "1 and 2",
+            None,
+            None,
+        ),
+        (
+            "${one} and ${two}",
+            None,
+            None,
+            {},
+            None,
+            None,
+            "Missing variables: one, two",
+        ),
+        ("$one and ${two}", None, None, {"one": 1, "two": 2}, "1 and 2", None, None),
     ),
 )
 def test_template_evaluate(


### PR DESCRIPTION
`Template.extract_vars` only collects the `named` group from `string.Template`'s match:

```python
return [
    match.group("named")
    for match in string_template.pattern.finditer(string_template.template)
    if match.group("named")
]
```

But `string.Template` matches a variable as *either* `$named` *or* `${braced}`, and both forms are valid. So `${var}` placeholders are invisible to `extract_vars`, with two consequences:

- `Template.vars()` under-reports — `Template(name="x", prompt="Hello ${name}").vars()` returns `set()` instead of `{"name"}`.
- `interpolate()`'s missing-variable check never sees them, so a template using `${missing}` raises a raw `KeyError` out of `string.Template.substitute()` instead of the intended `Template.MissingVariables` error.

```pycon
>>> Template.interpolate("Hi ${who}", {})
KeyError: 'who'          # expected: MissingVariables: Missing variables: who
```

Fix collects the `braced` group too. Added `${braced}` cases (resolve, missing, and mixed `$a` + `${b}`) to the existing `test_template_evaluate` parametrize list — the missing-variable case fails on `main` with a raw `KeyError` and passes with the fix. Full `test_templates.py` (49 tests) green.