### PR TITLE
Exit `llm chat` cleanly on Ctrl+D

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1231,7 +1231,11 @@ def chat(
     accumulated_attachments = []
     end_token = "!end"
     while True:
-        prompt = click.prompt("", prompt_suffix="> " if not in_multi else "")
+        try:
+            prompt = click.prompt("", prompt_suffix="> " if not in_multi else "")
+        except click.exceptions.Abort:
+            # Ctrl+D (EOF) should exit the chat cleanly
+            break
         fragments = []
         attachments = []
         if argument_fragments:

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,3 +1,4 @@
+import click
 from click.testing import CliRunner
 from unittest.mock import ANY
 import json
@@ -131,6 +132,31 @@ def test_chat_basic(mock_model, logs_db):
             "reasoning": None,
         }
     ]
+
+
+@pytest.mark.xfail(sys.platform == "win32", reason="Expected to fail on Windows")
+def test_chat_eof_exits_cleanly(mock_model, logs_db, monkeypatch):
+    # Ctrl+D (EOF) at the prompt raises click.Abort, which should exit the
+    # chat cleanly instead of bubbling up and printing "Aborted!"
+    runner = CliRunner()
+    mock_model.enqueue(["one world"])
+    prompts = iter(["Hi"])
+
+    def fake_prompt(*args, **kwargs):
+        try:
+            return next(prompts)
+        except StopIteration:
+            raise click.Abort()
+
+    monkeypatch.setattr("llm.cli.click.prompt", fake_prompt)
+    result = runner.invoke(
+        llm.cli.cli,
+        ["chat", "-m", "mock"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert "Aborted!" not in result.output
+    assert "one world" in result.output
 
 
 @pytest.mark.xfail(sys.platform == "win32", reason="Expected to fail on Windows")


### PR DESCRIPTION
Fixes #1214

Pressing <kbd>Ctrl</kbd>+<kbd>D</kbd> (EOF) at the `llm chat` prompt currently prints `Aborted!` and exits with a non-zero status, instead of exiting cleanly the way most interactive REPLs (Python, etc.) do:

```
> ^DAborted!
```

## Root cause

The chat loop reads input with `click.prompt(...)`. On EOF, `click.prompt` catches the underlying `EOFError` and re-raises it as `click.exceptions.Abort`. Nothing in the loop handles that, so it bubbles up to Click's top level, which prints `Aborted!` and exits with status 1.

## Fix

Wrap the `click.prompt` call in the loop and treat an `Abort` as a clean exit:

```python
while True:
    try:
        prompt = click.prompt("", prompt_suffix="> " if not in_multi else "")
    except click.exceptions.Abort:
        # Ctrl+D (EOF) should exit the chat cleanly
        break
```

## Testing

Added `test_chat_eof_exits_cleanly`, which patches `click.prompt` to raise `click.Abort` (the same thing a real terminal EOF produces) and asserts the command exits with status 0 and never prints `Aborted!`. The test fails on `main` and passes with this change. The rest of `tests/test_chat.py` still passes.