### PR TITLE
Fix: allow prompts starting with -- (ignore unknown options)

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -375,7 +375,10 @@ def cli():
     """
 
 
-@cli.command(name="prompt")
+@cli.command(
+    name="prompt",
+    context_settings={"ignore_unknown_options": True},
+)
 @click.argument("prompt", required=False)
 @click.option("-s", "--system", help="System prompt to use")
 @click.option("model_id", "-m", "--model", help="Model to use", envvar="LLM_MODEL")

--- a/tests/test_cli_options.py
+++ b/tests/test_cli_options.py
@@ -136,3 +136,28 @@ def test_prompt_uses_model_options(user_path):
         "previous": [],
         "options": {"example_bool": True},
     }
+
+
+@pytest.mark.parametrize(
+    "prompt",
+    (
+        "--find me",
+        "--option value",
+        "-x test",
+        "--help-me-please",
+    ),
+)
+def test_prompts_starting_with_dash_are_not_rejected(prompt):
+    """Prompts starting with -- or - should be treated as prompt text,
+    not CLI options. Regression test for issue #245."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--no-log", prompt])
+    # Should NOT get Click's "No such option" error (exit 2)
+    assert result.exit_code != 2, (
+        f"Click rejected '{prompt}' as an option. "
+        f"Exit code: {result.exit_code}. Output: {result.output}"
+    )
+    # Should NOT contain "No such option" anywhere
+    assert "No such option" not in result.output, (
+        f"Click error in output for prompt '{prompt}': {result.output}"
+    )


### PR DESCRIPTION
## Problem
Click interprets prompt text starting with `--` as CLI options, causing `No such option` errors. Users cannot use prompts like `llm "--find me"` because Click tries to parse `--find` as a flag.

Fixes #245

## Root Cause
The `prompt` command at the end of the Click command chain was accepting unknown options. When the prompt starts with `--`, Click attempts to match it against registered options before falling through to the prompt argument.

Root cause analysis credit: Agent A (Node A)

## Fix
Added `context_settings={"ignore_unknown_options": True}` to the `@cli.command` decorator for the `prompt` command. This tells Click to pass any unrecognized options through as arguments rather than raising `No such option` errors.

```python
@cli.command(
    name="prompt",
    context_settings={"ignore_unknown_options": True},
)
```

## Testing
- `llm "--find me"` → reaches API key error (not "No such option") ✓
- `llm "hello world"` → normal prompt still works ✓
- `llm -m gpt-4 "test"` → recognized flags still parsed correctly ✓
- Added parametrized test with 4 variants (`--find me`, `--option value`, `-x test`, `--help-me-please`) ✓
- Full test suite: 613 passed, 0 regressions (56 pre-existing failures in async/OpenAI tests)