### PR TITLE
Treat empty extra-openai-models.yaml as no extra models (fixes #505)

### DIFF
--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -320,6 +320,11 @@ def register_models(register):
         return
     with open(extra_path) as f:
         extra_models = yaml.safe_load(f)
+    # yaml.safe_load returns None for an empty / whitespace-only / comments-only
+    # file. Treat that the same as "no extra models" instead of crashing with
+    # TypeError when we try to iterate. See https://github.com/simonw/llm/issues/505
+    if not extra_models:
+        return
     for extra_model in extra_models:
         model_id = extra_model["model_id"]
         aliases = extra_model.get("aliases", [])

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -448,6 +448,28 @@ def test_extra_openai_models_async(user_path):
 
 
 @pytest.mark.parametrize(
+    "yaml_contents",
+    (
+        "",  # truly empty file
+        "   \n  \n",  # only whitespace
+        "# this is a placeholder\n# I'll fill it in later\n",  # only comments
+    ),
+)
+def test_extra_openai_models_empty_yaml(user_path, yaml_contents):
+    # Regression test for https://github.com/simonw/llm/issues/505 — an empty
+    # extra-openai-models.yaml file (or one that contains only whitespace /
+    # comments) used to crash model registration with
+    # "TypeError: 'NoneType' object is not iterable" because
+    # yaml.safe_load returns None for these inputs.
+    config_path = user_path / "extra-openai-models.yaml"
+    config_path.write_text(yaml_contents, "utf-8")
+    # Just calling get_models() forces register_models() to run for the
+    # default plugin; before the fix this raised TypeError.
+    models = llm.get_models()
+    assert any(m.model_id == "gpt-4o-mini" for m in models)
+
+
+@pytest.mark.parametrize(
     "args,exit_code",
     (
         (["-q", "mo", "-q", "ck"], 0),


### PR DESCRIPTION
## Summary

Fixes #505 — an empty `extra-openai-models.yaml` file (or one that contains only whitespace or comments) crashes every `llm` invocation with `TypeError: 'NoneType' object is not iterable`.

`yaml.safe_load` returns `None` for those inputs. The previous code then ran `for extra_model in extra_models:` against `None`. The fix adds an early `return` when `extra_models` is falsy.

The original report describes the exact scenario this guards against: a user creates the file intending to come back to it later, leaves it empty, and is then locked out of every `llm` command until they remember the file exists and delete it.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# Disposable user dir so we don't touch anything real
export LLM_USER_PATH="$(mktemp -d)"
# Reproduce the trip-wires from the issue: empty file, whitespace, comments
: > "$LLM_USER_PATH/extra-openai-models.yaml"  # empty

git checkout main      # BEFORE
# Expected: TypeError: 'NoneType' object is not iterable (from openai_models.py)
python -c "import llm; llm.get_models()"

git checkout fix/505-empty-extra-openai-models-yaml   # AFTER
# Expected: no output (success — empty file is treated as "no extra models")
python -c "import llm; llm.get_models()"
```

## What I ran locally

```
$ pytest tests/test_llm.py::test_extra_openai_models_empty_yaml -v
tests/test_llm.py::test_extra_openai_models_empty_yaml[]                                                                                     PASSED
tests/test_llm.py::test_extra_openai_models_empty_yaml[   \n  \n]                                                                            PASSED
tests/test_llm.py::test_extra_openai_models_empty_yaml[# this is a placeholder\n# I'll fill it in later\n]                                   PASSED

$ pytest -q
757 passed in 55.56s
```

The new test fails on `main` with the exact `TypeError` from the issue and passes on this branch. The other 754 tests are unchanged.

`ruff check` and `black --check` are clean on both touched files.

## Edge cases

| Scenario | BEFORE main | AFTER this PR |
|---|---|---|
| File absent | OK (existing early-return on `extra_path.exists()` is false) | OK (unchanged) |
| File present, empty (`: > file`) | `TypeError: 'NoneType' object is not iterable` | Treated as "no extra models", returns silently |
| File present, whitespace only (`"   \n  \n"`) | Same `TypeError` | Same as above |
| File present, comments only (`"# placeholder\n"`) | Same `TypeError` | Same as above |
| File present, valid list of models | Models registered correctly | Unchanged — existing `test_openai_localai_configuration` + `test_extra_openai_models_async` still pass |
| File present, malformed YAML | Raises `yaml.YAMLError` (informative) | Unchanged |

---

*PR drafted with assistance from Claude Code (Anthropic). The change was reviewed manually against `llm/default_plugins/openai_models.py` and `tests/test_llm.py`. The BEFORE/AFTER reproducer block above is the one I used during development; reviewers can paste it verbatim.*
