### PR TITLE
Fix llm logs --data-ids using response id for conversation id

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1913,7 +1913,9 @@ def logs_list(
                 if data_ids:
                     for item in new_items:
                         item[find_unused_key(item, "response_id")] = row["id"]
-                        item[find_unused_key(item, "conversation_id")] = row["id"]
+                        item[find_unused_key(item, "conversation_id")] = row[
+                            "conversation_id"
+                        ]
                 to_output.extend(new_items)
             except ValueError:
                 pass

--- a/tests/test_llm_logs.py
+++ b/tests/test_llm_logs.py
@@ -470,6 +470,35 @@ def test_logs_schema_data_ids(schema_log_path):
         assert set(row.keys()) == {"conversation_id", "response_id", "name"}
 
 
+def test_logs_schema_data_ids_values(schema_log_path):
+    # Regression test: --data-ids should populate the conversation_id key
+    # with the row's conversation_id, not the response id. See issue #800
+    # for the original feature intent.
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "logs",
+            "-n",
+            "0",
+            "-p",
+            str(schema_log_path),
+            "--data-ids",
+            "--schema",
+            SINGLE_ID,
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    rows = [json.loads(line) for line in result.output.strip().splitlines()]
+    assert rows, "expected at least one row from --data-ids output"
+    for row in rows:
+        # response_id should look like a ULID (26 chars, base32) lowercased
+        assert row["response_id"] != row["conversation_id"]
+        # The fixture sets every SINGLE_ID response's conversation_id to "abc123"
+        assert row["conversation_id"] == "abc123"
+
+
 _expected_yaml_re = r"""- id: [a-f0-9]{32}
   summary: \|
     


### PR DESCRIPTION
## Summary

`llm logs --data-ids` populates both `response_id` and `conversation_id` in the emitted JSON items with the response ULID. The conversation reference the flag exists to provide — and that #800 explicitly documented as the use case ("a `--data-ids` option which includes the response and conversation IDs") — is silently lost, so the join back to the responses table doesn't work.

## Root cause

`llm/cli.py` around line 1916 (block introduced by commit `eafe141`):

```python
item[find_unused_key(item, "response_id")] = row["id"]
item[find_unused_key(item, "conversation_id")] = row["id"]   # should be row["conversation_id"]
```

The selecting SQL (`responses.conversation_id`, around line 1509) already exposes the right column on `row`. The second assignment just reads the wrong field. The existing `test_logs_schema_data_ids` only checked key presence (not values), so this was invisible to CI.

## Fix

3-LOC change in `llm/cli.py`: `row["id"]` → `row["conversation_id"]` in the conversation key assignment. No schema or query change needed.

## Tests

New `test_logs_schema_data_ids_values` in `tests/test_llm_logs.py` (29 LOC). Asserts:

- `response_id != conversation_id`
- `conversation_id == "abc123"` (the fixture value)

**RED proof on main**:
```
AssertionError: assert '01ksyc5rw9q269e07pqk8synfg' != '01ksyc5rw9q269e07pqk8synfg'
```

**GREEN after patch**: 755 passed in `tests/` (network-required tests skipped). `ruff check` + `black --check` clean.

## Risk notes

- `row["conversation_id"]` can be NULL if a response was logged without a conversation. JSON will then emit `null` — same behaviour as any other null cell in logs output; not a new regression.
- 3-LOC merge surface, no schema change.

Refs #800