### PR TITLE
fix(utils): skip nameless fields in schema_dsl instead of raising IndexError

### DIFF
--- a/llm/utils.py
+++ b/llm/utils.py
@@ -392,6 +392,8 @@ def schema_dsl(schema_dsl: str, multi: bool = False) -> Dict[str, Any]:
 
         # Process field name and type
         field_parts = field_info.strip().split()
+        if not field_parts:
+            continue
         field_name = field_parts[0].strip()
 
         # Default type is string

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -225,6 +225,19 @@ def test_schema_dsl(schema, expected):
     assert result == expected
 
 
+def test_schema_dsl_empty_field_name():
+    # Fields with no name before the colon (e.g. ':description') should be
+    # silently skipped rather than raising IndexError.
+    result = schema_dsl(":just a description")
+    assert result == {"type": "object", "properties": {}, "required": []}
+    result2 = schema_dsl("name, :no name before colon")
+    assert result2 == {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+        "required": ["name"],
+    }
+
+
 def test_schema_dsl_multi():
     result = schema_dsl("name, age int: The age", multi=True)
     assert result == {


### PR DESCRIPTION
## What's broken

`schema_dsl()` crashes with `IndexError` when a field in the DSL string has no name before the colon — for example `':description'` or `'name, :description'`. This is reachable from the CLI via `llm schema dsl ':foo'` and from `resolve_schema_input` when the schema string contains such a field.

## Why it happens

After splitting on `':'`, the left side (`field_info`) is empty. `field_info.strip().split()` returns `[]`, so `field_parts[0]` raises `IndexError`.

## Fix

Added a two-line guard in `llm/utils.py` after building `field_parts`: if the list is empty, `continue` to the next field. Nameless fields are silently skipped, which is the least surprising behavior — the same way a blank field is already skipped by the `if field.strip()` filter above.

## Test

Added `test_schema_dsl_empty_field_name` in `tests/test_utils.py` covering both `':just a description'` (all-nameless input) and `'name, :no name before colon'` (mixed input). All 83 existing tests still pass.

Fixes #1466