### PR TITLE
Fix extract_fenced_code_block for language tags with non-word characters

### DIFF
--- a/llm/utils.py
+++ b/llm/utils.py
@@ -200,14 +200,15 @@ def extract_fenced_code_block(text: str, last: bool = False) -> Optional[str]:
     # Regex pattern to match fenced code blocks
     # - ^ or \n ensures that the fence is at the start of a line
     # - (`{3,}) captures the opening backticks (at least three)
-    # - (\w+)? optionally captures the language tag
+    # - (?P<lang>[^\n`]*) optionally captures the language/info tag, allowing
+    #   non-word characters as in "c++", "objective-c" or "c#"
     # - \n matches the newline after the opening fence
     # - (.*?) non-greedy match for the code block content
     # - (?P=fence) ensures that the closing fence has the same number of backticks
     # - [ ]* allows for optional spaces between the closing fence and newline
     # - (?=\n|$) ensures that the closing fence is followed by a newline or end of string
     pattern = re.compile(
-        r"""(?m)^(?P<fence>`{3,})(?P<lang>\w+)?\n(?P<code>.*?)^(?P=fence)[ ]*(?=\n|$)""",
+        r"""(?m)^(?P<fence>`{3,})(?P<lang>[^\n`]*)\n(?P<code>.*?)^(?P=fence)[ ]*(?=\n|$)""",
         re.DOTALL,
     )
     matches = list(pattern.finditer(text))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -107,6 +107,22 @@ def test_simplify_usage_dict(input_data, expected_output):
             False,
             "def foo():\n    return `bar`\n",
         ],
+        # Language/info tags containing non-word characters must still match.
+        [
+            "```c++\nint x = 1;\n```",
+            False,
+            "int x = 1;\n",
+        ],
+        [
+            '```objective-c\nNSLog(@"hi");\n```',
+            False,
+            'NSLog(@"hi");\n',
+        ],
+        [
+            "```c#\nvar x = 1;\n```",
+            False,
+            "var x = 1;\n",
+        ],
     ],
 )
 def test_extract_fenced_code_block(input, last, expected):


### PR DESCRIPTION
`extract_fenced_code_block` captured the language/info tag with `(\w+)?`. `\w` only matches `[A-Za-z0-9_]`, so a fenced block whose info string contains a non-word character fails to match entirely and the function returns `None`. Common, real-world language tags trigger this: ` ```c++ `, ` ```objective-c `, ` ```c# `, ` ```f# `. The effect is that `llm -x` / `--extract` / `--extract-last` and the template `extract:` / `extract_last:` options silently extract nothing when a model labels the block with one of these languages.

This widens the capture to `[^\n`]*` so the whole info string up to the newline is consumed, regardless of punctuation. Plain ` ``` ` (no language) and existing word-only tags are unaffected.

Added parametrized cases to `test_extract_fenced_code_block` for `c++`, `objective-c`, and `c#`. They fail on `main` (return `None`) and pass with this change; the rest of `tests/test_utils.py` stays green.
