### PR TITLE
Raise a clear error for schema DSL fields with no name

### DIFF
--- a/llm/utils.py
+++ b/llm/utils.py
@@ -392,6 +392,8 @@ def schema_dsl(schema_dsl: str, multi: bool = False) -> Dict[str, Any]:
 
         # Process field name and type
         field_parts = field_info.strip().split()
+        if not field_parts:
+            raise ValueError(f"Field is missing a name: {field!r}")
         field_name = field_parts[0].strip()
 
         # Default type is string

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -225,6 +225,12 @@ def test_schema_dsl(schema, expected):
     assert result == expected
 
 
+@pytest.mark.parametrize("schema", [":just a description", "name, :description"])
+def test_schema_dsl_missing_field_name(schema):
+    with pytest.raises(ValueError, match="Field is missing a name"):
+        schema_dsl(schema)
+
+
 def test_schema_dsl_multi():
     result = schema_dsl("name, age int: The age", multi=True)
     assert result == {


### PR DESCRIPTION
`schema_dsl()` crashes with an opaque `IndexError` when a field has no name before the colon (reachable from the CLI via `llm schema dsl ':foo'` and from `resolve_schema_input`):

```python
>>> from llm.utils import schema_dsl
>>> schema_dsl(":just a description")
IndexError: list index out of range
```

After `field.split(":", 1)` the left-hand side is empty, so `field_info.strip().split()` returns `[]` and `field_parts[0]` is out of range.

This raises a `ValueError` naming the offending field instead, so the cause is obvious:

```python
>>> schema_dsl(":just a description")
ValueError: Field is missing a name: ':just a description'
```

Valid schemas are unaffected.

### Tests

Added `test_schema_dsl_missing_field_name` (parametrized over `':just a description'` and `'name, :description'`) asserting the `ValueError`. `pytest tests/test_utils.py` passes (84 tests).

Closes #1466