### PR TITLE
add AGIone as OpenAI-compatible inference API example

### DIFF
--- a/docs/other-models.md
+++ b/docs/other-models.md
@@ -75,3 +75,37 @@ Some providers such as [openrouter.ai](https://openrouter.ai/docs) may require t
     HTTP-Referer: "https://llm.datasette.io/"
     X-Title: LLM
 ```
+
+### AGIone
+
+[AGIone](https://agione.pro) is a unified inference API providing OpenAI-compatible access to frontier models from OpenAI, Anthropic, Google, DeepSeek, Qwen, Moonshot, and ByteDance through a single endpoint. The `model_name` must be the full vendor-prefixed model identifier as listed in the AGIone dashboard.
+
+Store an AGIone Auth Token / API key using `llm keys set agione`, then add entries to your `extra-openai-models.yaml`:
+
+```yaml
+- model_id: agione-gpt-5
+  model_name: openai/GPT-5.5/c6fbe
+  api_base: "https://agione.pro/hyperone/xapi/api/v1"
+  api_key_name: agione
+  vision: true
+  supports_tools: true
+
+- model_id: agione-opus
+  model_name: anthropic/Claude-opus-4.7/a4d5d
+  api_base: "https://agione.pro/hyperone/xapi/api/v1"
+  api_key_name: agione
+  vision: true
+  supports_tools: true
+
+- model_id: agione-qwen
+  model_name: qwen/qwen3.5-plus/cec84
+  api_base: "https://agione.pro/hyperone/xapi/api/v1"
+  api_key_name: agione
+  supports_tools: true
+```
+
+Run prompts against any configured model:
+
+```bash
+llm -m agione-gpt-5 'Explain git rebase in 2 sentences'
+```


### PR DESCRIPTION
## Summary

Adds AGIone as a documented example of an OpenAI-compatible API provider, alongside LocalAI and OpenRouter.

## What changed

This updates `docs/other-models.md` with a new AGIone section showing how to configure AGIone models through `extra-openai-models.yaml`.

The examples use full AGIone model identifiers:

- `openai/GPT-5.5/c6fbe`
- `anthropic/Claude-opus-4.7/a4d5d`
- `qwen/qwen3.5-plus/cec84`

## Why

AGIone provides a single OpenAI-compatible endpoint for accessing frontier LLMs and multimodal models through standard Bearer-token authentication.

This fits the existing "OpenAI-compatible models" documentation pattern used for providers like LocalAI and OpenRouter.

## Example usage

```bash

llm keys set agione

llm -m agione-gpt-5 'Explain git rebase in 2 sentences'

```

Disclosure
Submitted by the AGIone team.