### PR TITLE
Fix schema DSL crash on empty field names before :

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -2669,7 +2669,10 @@ def schemas_dsl_debug(input, multi):
     \b
         llm schema dsl 'name, age int, bio: their bio'
     """
-    schema = schema_dsl(input, multi)
+    try:
+        schema = schema_dsl(input, multi)
+    except ValueError as ex:
+        raise click.ClickException(str(ex))
     click.echo(json.dumps(schema, indent=2))
 
 

--- a/llm/utils.py
+++ b/llm/utils.py
@@ -293,7 +293,10 @@ def resolve_schema_input(db, schema_input, load_template):
             pass
     if " " in schema_input.strip() or "," in schema_input:
         # Treat it as schema DSL
-        return schema_dsl(schema_input)
+        try:
+            return schema_dsl(schema_input)
+        except ValueError as ex:
+            raise click.BadParameter(str(ex))
     # Is it a file on disk?
     path = pathlib.Path(schema_input)
     if path.exists():
@@ -392,6 +395,8 @@ def schema_dsl(schema_dsl: str, multi: bool = False) -> Dict[str, Any]:
 
         # Process field name and type
         field_parts = field_info.strip().split()
+        if not field_parts:
+            raise ValueError("Schema field is missing a name before ':'")
         field_name = field_parts[0].strip()
 
         # Default type is string

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -833,6 +833,22 @@ def test_schemas_dsl():
     }
 
 
+def test_schemas_dsl_invalid_empty_field_name():
+    result = CliRunner().invoke(cli, ["schemas", "dsl", ":foo"], catch_exceptions=False)
+    assert result.exit_code == 1
+    assert result.output == "Error: Schema field is missing a name before ':'\n"
+
+
+def test_schema_using_dsl_invalid_empty_field_name(mock_model):
+    result = CliRunner().invoke(
+        cli,
+        ["prompt", "-m", "mock", "--schema", "name, :foo"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 2
+    assert "Invalid value: Schema field is missing a name before ':'" in result.output
+
+
 @mock.patch.dict(os.environ, {"OPENAI_API_KEY": "X"})
 @pytest.mark.parametrize("custom_database_path", (False, True))
 def test_llm_prompt_continue_with_database(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -246,6 +246,11 @@ def test_schema_dsl_multi():
     }
 
 
+def test_schema_dsl_rejects_empty_field_name():
+    with pytest.raises(ValueError, match="missing a name before ':'"):
+        schema_dsl(":just a description")
+
+
 @pytest.mark.parametrize(
     "text, max_length, normalize_whitespace, keep_end, expected",
     [


### PR DESCRIPTION
## Summary

Fix `schema_dsl()` so inputs like `:foo` or `name, :foo` raise a validation error instead of crashing with `IndexError`.

## Root cause

When a schema DSL field contains a colon but no field name on the left side, `field_info.strip().split()` returns an empty list. The existing code indexed `field_parts[0]`, which raised `IndexError`.

## Changes

- validate that each schema DSL field has a name before `:`
- return a clean CLI error for `llm schemas dsl`
- return a clean validation error when schema DSL is resolved via `--schema`
- add regression tests for the utility and CLI paths

## Validation

- `uv run pytest tests/test_utils.py -k schema_dsl`
- `uv run pytest tests/test_llm.py -k 'schemas_dsl or schema_using_dsl_invalid_empty_field_name'`
- `uv run black llm/utils.py llm/cli.py tests/test_utils.py tests/test_llm.py`
- `uv run ruff check llm/utils.py llm/cli.py tests/test_utils.py tests/test_llm.py`
- `uv run pytest tests/test_utils.py tests/test_llm.py`
- `uv run llm schemas dsl ':foo'`
- `uv run llm schemas dsl 'name:text'`
