### PR TITLE
Include system prompt in pre-baked chain messages (fixes #1478)

### DIFF
--- a/llm/models.py
+++ b/llm/models.py
@@ -564,9 +564,7 @@ class _BaseConversation:
             # is already carried forward in last.prompt.messages.
             system_text = _combine_system(system, system_fragments)
             if system_text:
-                chain.append(
-                    Message(role="system", parts=[TextPart(text=system_text)])
-                )
+                chain.append(Message(role="system", parts=[TextPart(text=system_text)]))
 
         # Append the new turn's input
         if tool_results:

--- a/llm/models.py
+++ b/llm/models.py
@@ -402,12 +402,7 @@ class Prompt:
     @property
     def system(self):
         "The system prompt, with any system fragments concatenated."
-        bits = [
-            bit.strip()
-            for bit in (self.system_fragments + [self._system or ""])
-            if bit.strip()
-        ]
-        return "\n\n".join(bits)
+        return _combine_system(self._system, self.system_fragments)
 
     @property
     def messages(self):
@@ -487,6 +482,16 @@ def _wrap_tools(tools: List[ToolDef]) -> List[Tool]:
     return wrapped_tools
 
 
+def _combine_system(system, system_fragments):
+    "Concatenate the system prompt and any system fragments into one string."
+    bits = [
+        bit.strip()
+        for bit in ((system_fragments or []) + [system or ""])
+        if bit.strip()
+    ]
+    return "\n\n".join(bits)
+
+
 def _merge_options(options: Optional[dict], kwargs: dict) -> dict:
     if not options:
         return kwargs
@@ -519,6 +524,8 @@ class _BaseConversation:
         attachments,
         tool_results,
         explicit_messages,
+        system=None,
+        system_fragments=None,
     ) -> List[Any]:
         """Build the full message chain for the next turn.
 
@@ -551,6 +558,15 @@ class _BaseConversation:
             # append that response's structured output.
             chain.extend(last.prompt.messages)
             chain.extend(last._messages_now())
+        else:
+            # Start with the system prompt as the first message so adapters
+            # that build from prompt.messages see it. On later turns it
+            # is already carried forward in last.prompt.messages.
+            system_text = _combine_system(system, system_fragments)
+            if system_text:
+                chain.append(
+                    Message(role="system", parts=[TextPart(text=system_text)])
+                )
 
         # Append the new turn's input
         if tool_results:
@@ -610,6 +626,8 @@ class Conversation(_BaseConversation):
             attachments=attachments,
             tool_results=tool_results,
             explicit_messages=messages,
+            system=system,
+            system_fragments=system_fragments,
         )
         return Response(
             Prompt(
@@ -662,6 +680,8 @@ class Conversation(_BaseConversation):
             attachments=attachments,
             tool_results=tool_results,
             explicit_messages=messages,
+            system=system,
+            system_fragments=system_fragments,
         )
         return ChainResponse(
             Prompt(
@@ -734,6 +754,8 @@ class AsyncConversation(_BaseConversation):
             attachments=attachments,
             tool_results=tool_results,
             explicit_messages=messages,
+            system=system,
+            system_fragments=system_fragments,
         )
         return AsyncChainResponse(
             Prompt(
@@ -783,6 +805,8 @@ class AsyncConversation(_BaseConversation):
             attachments=attachments,
             tool_results=tool_results,
             explicit_messages=messages,
+            system=system,
+            system_fragments=system_fragments,
         )
         return AsyncResponse(
             Prompt(

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -1694,7 +1694,6 @@ class TestChainPropagatesSystem:
             assert e in prompt.system
             assert e in prompt.messages[0].parts[0].text
 
-
     def test_sync_chain_tool_result_turn_preserves_system(self, mock_model):
         # First turn: fake a tool call so the chain iterates.
         tool_call = llm.ToolCall(tool_call_id="c1", name="tick", arguments={})
@@ -1752,7 +1751,9 @@ class TestChainPropagatesSystem:
             tools=[tick],
         )
         list(chain.responses())
-        self.assert_system(chain._responses[1].prompt, "inline sys", "fragment A", "fragment B")
+        self.assert_system(
+            chain._responses[1].prompt, "inline sys", "fragment A", "fragment B"
+        )
 
     @pytest.mark.asyncio
     async def test_async_chain_tool_result_turn_preserves_system(

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -1688,6 +1688,13 @@ class TestChainPropagatesSystem:
     adapters that read prompt.system (OpenAI and other
     stateless-per-turn providers) see it on every call."""
 
+    def assert_system(self, prompt, *expected):
+        assert prompt.messages[0].role == "system"
+        for e in expected:
+            assert e in prompt.system
+            assert e in prompt.messages[0].parts[0].text
+
+
     def test_sync_chain_tool_result_turn_preserves_system(self, mock_model):
         # First turn: fake a tool call so the chain iterates.
         tool_call = llm.ToolCall(tool_call_id="c1", name="tick", arguments={})
@@ -1714,8 +1721,7 @@ class TestChainPropagatesSystem:
         chain = m.chain("q", system="be brief", tools=[tick])
         list(chain.responses())
         # Second response was the tool-result turn.
-        second = chain._responses[1]
-        assert second.prompt.system == "be brief"
+        self.assert_system(chain._responses[1].prompt, "be brief")
 
     def test_sync_chain_tool_result_turn_preserves_system_fragments(self, mock_model):
         tool_call = llm.ToolCall(tool_call_id="c1", name="tick", arguments={})
@@ -1746,12 +1752,7 @@ class TestChainPropagatesSystem:
             tools=[tick],
         )
         list(chain.responses())
-        second = chain._responses[1]
-        # prompt.system concatenates _system + system_fragments; all
-        # three strings should be preserved on the tool-result turn.
-        assert "inline sys" in second.prompt.system
-        assert "fragment A" in second.prompt.system
-        assert "fragment B" in second.prompt.system
+        self.assert_system(chain._responses[1].prompt, "inline sys", "fragment A", "fragment B")
 
     @pytest.mark.asyncio
     async def test_async_chain_tool_result_turn_preserves_system(
@@ -1784,8 +1785,11 @@ class TestChainPropagatesSystem:
         responses = []
         async for r in chain.responses():
             responses.append(r)
-        second = chain._responses[1]
-        assert second.prompt.system == "be brief"
+        self.assert_system(responses[1].prompt, "be brief")
+
+    def test_chain_includes_system_in_messages(self, mock_model):
+        chain = mock_model.chain("q", system="be brief")
+        self.assert_system(chain.prompt, "be brief")
 
 
 # chain() accepts messages= (parity with prompt())


### PR DESCRIPTION

Fixes issue #1478 by modifying `_BaseConversation#_build_full_chain` to initialize the message list with the system prompt.

An alternative approach could be to modify plugins to use `prompt#system` to determine the system prompt instead of examining `prompt#messages`. However the approach I used here seemed more likely to preserve compatibility.