### PR TITLE
Tool implementations can receive the ToolCall via llm_tool_call param

### DIFF
--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -211,6 +211,26 @@ response = model.chain(
 print(response.text())
 ```
 
+(python-api-tools-llm-tool-call)=
+
+#### Accessing the tool call from inside a tool
+
+Tool implementations sometimes need to know about the `llm.ToolCall` that triggered them - most often the `tool_call_id`, which can be used to key external state against that specific invocation.
+
+If your tool function accepts a parameter named `llm_tool_call` it will be passed the `llm.ToolCall` object for the current call:
+
+```python
+import llm
+
+def lookup(name: str, llm_tool_call: llm.ToolCall) -> str:
+    "Look up a name."
+    return do_lookup(name, request_id=llm_tool_call.tool_call_id)
+```
+
+The `llm_tool_call` parameter name is reserved: it is excluded from the input schema that is exposed to the model and is populated automatically when the tool executes. The type annotation is optional.
+
+This works for both sync and async tool functions, and for methods on `llm.Toolbox` subclasses. The parameter must be declared explicitly - a `**kwargs` catch-all will not receive `llm_tool_call`.
+
 (python-api-tools-attachments)=
 
 #### Tools can return attachments

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -97,4 +97,6 @@ Consult the {ref}`register_tools() plugin hook <plugin-hooks-register-tools>` do
 
 If your plugin needs access to API secrets I recommend storing those using `llm keys set api-name` and then reading them using the {ref}`plugin-utilities-get-key` utility function. This avoids secrets being logged to the database as part of tool calls.
 
+If your tool implementation needs to know which tool call invoked it - for example to key state against the unique `tool_call_id` - add a parameter named `llm_tool_call` to your function. It will be passed the `llm.ToolCall` object for the current invocation, and is hidden from the schema the model sees. See {ref}`python-api-tools-llm-tool-call` for details.
+
 <!-- Uncomment when this is true: The [llm-tools-datasette](https://github.com/simonw/llm-tools-datasette) plugin is a good example of this pattern in action. -->

--- a/llm/models.py
+++ b/llm/models.py
@@ -188,7 +188,9 @@ def _get_arguments_input_schema(function, name):
     type_hints = get_type_hints(function)
     fields = {}
     for param_name, param in signature.parameters.items():
-        if param_name == "self":
+        if param_name in ("self", "llm_tool_call"):
+            # llm_tool_call is reserved: populated with the ToolCall object
+            # at execution time, never exposed to the model.
             continue
         # Determine the type annotation (default to string if missing)
         annotated_type = type_hints.get(param_name, str)
@@ -200,6 +202,26 @@ def _get_arguments_input_schema(function, name):
             fields[param_name] = (annotated_type, param.default)
 
     return create_model(f"{name}InputSchema", **fields)
+
+
+def _accepts_llm_tool_call(implementation) -> bool:
+    try:
+        signature = inspect.signature(implementation)
+    except (TypeError, ValueError):
+        return False
+    return "llm_tool_call" in signature.parameters
+
+
+def _implementation_arguments(tool: "Tool", tool_call: "ToolCall") -> dict:
+    """Arguments to invoke a tool implementation with.
+
+    Implementations with an explicit ``llm_tool_call`` parameter receive
+    the ToolCall object itself - a ``**kwargs`` catch-all does not count.
+    """
+    arguments = dict(tool_call.arguments)
+    if _accepts_llm_tool_call(tool.implementation):
+        arguments["llm_tool_call"] = tool_call
+    return arguments
 
 
 class Toolbox:
@@ -1814,10 +1836,13 @@ class Response(_BaseResponse):
             exception = None
 
             try:
+                implementation_arguments = _implementation_arguments(tool, tool_call)
                 if inspect.iscoroutinefunction(tool.implementation):
-                    result = asyncio.run(tool.implementation(**tool_call.arguments))
+                    result = asyncio.run(
+                        tool.implementation(**implementation_arguments)
+                    )
                 else:
-                    result = tool.implementation(**tool_call.arguments)
+                    result = tool.implementation(**implementation_arguments)
 
                 if isinstance(result, ToolOutput):
                     attachments = result.attachments
@@ -2127,7 +2152,9 @@ class AsyncResponse(_BaseResponse):
                     attachments = []
 
                     try:
-                        result = await tool.implementation(**tc.arguments)
+                        result = await tool.implementation(
+                            **_implementation_arguments(tool, tc)
+                        )
                         if isinstance(result, ToolOutput):
                             attachments.extend(result.attachments)
                             result = result.output
@@ -2188,7 +2215,7 @@ class AsyncResponse(_BaseResponse):
                     exception = KeyError(tc.name)
                 else:
                     try:
-                        res = tool.implementation(**tc.arguments)
+                        res = tool.implementation(**_implementation_arguments(tool, tc))
                         if inspect.isawaitable(res):
                             res = await res
                         if isinstance(res, ToolOutput):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -604,7 +604,9 @@ def test_tool_function_receives_llm_tool_call():
 
     model = llm.get_model("echo")
     chain_response = model.chain(
-        json.dumps({"tool_calls": [{"name": "lookup", "arguments": {"name": "simon"}}]}),
+        json.dumps(
+            {"tool_calls": [{"name": "lookup", "arguments": {"name": "simon"}}]}
+        ),
         tools=[lookup],
     )
     chain_response.text()
@@ -627,7 +629,9 @@ def test_async_tool_function_receives_llm_tool_call_with_sync_model():
 
     model = llm.get_model("echo")
     chain_response = model.chain(
-        json.dumps({"tool_calls": [{"name": "lookup", "arguments": {"name": "simon"}}]}),
+        json.dumps(
+            {"tool_calls": [{"name": "lookup", "arguments": {"name": "simon"}}]}
+        ),
         tools=[lookup],
     )
     chain_response.text()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -592,3 +592,137 @@ async def test_chain_async_cancel_only_first_of_two():
     assert results[1].name == "t2"
     assert results[1].output == "ran2"
     assert results[1].exception is None
+
+
+def test_tool_function_receives_llm_tool_call():
+    captured = {}
+
+    def lookup(name: str, llm_tool_call) -> str:
+        "Look up a name"
+        captured["tool_call"] = llm_tool_call
+        return "result for " + name
+
+    model = llm.get_model("echo")
+    chain_response = model.chain(
+        json.dumps({"tool_calls": [{"name": "lookup", "arguments": {"name": "simon"}}]}),
+        tools=[lookup],
+    )
+    chain_response.text()
+
+    tool_call = captured["tool_call"]
+    assert isinstance(tool_call, llm.ToolCall)
+    assert tool_call.name == "lookup"
+    assert tool_call.arguments == {"name": "simon"}
+    second = chain_response._responses[1]
+    assert second.prompt.tool_results[0].output == "result for simon"
+
+
+def test_async_tool_function_receives_llm_tool_call_with_sync_model():
+    captured = {}
+
+    async def lookup(name: str, llm_tool_call: llm.ToolCall) -> str:
+        "Look up a name"
+        captured["tool_call"] = llm_tool_call
+        return "result for " + name
+
+    model = llm.get_model("echo")
+    chain_response = model.chain(
+        json.dumps({"tool_calls": [{"name": "lookup", "arguments": {"name": "simon"}}]}),
+        tools=[lookup],
+    )
+    chain_response.text()
+
+    tool_call = captured["tool_call"]
+    assert isinstance(tool_call, llm.ToolCall)
+    assert tool_call.name == "lookup"
+    assert tool_call.arguments == {"name": "simon"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("async_tool", (False, True))
+async def test_tool_function_receives_llm_tool_call_async_model(async_tool):
+    captured = {}
+
+    def lookup(name: str, llm_tool_call) -> str:
+        "Look up a name"
+        captured["tool_call"] = llm_tool_call
+        return "result for " + name
+
+    async def async_lookup(name: str, llm_tool_call) -> str:
+        "Look up a name"
+        captured["tool_call"] = llm_tool_call
+        return "result for " + name
+
+    fn = async_lookup if async_tool else lookup
+    model = llm.get_async_model("echo")
+    chain_response = model.chain(
+        json.dumps(
+            {"tool_calls": [{"name": fn.__name__, "arguments": {"name": "simon"}}]}
+        ),
+        tools=[fn],
+    )
+    output = await chain_response.text()
+    assert '"output": "result for simon"' in output
+
+    tool_call = captured["tool_call"]
+    assert isinstance(tool_call, llm.ToolCall)
+    assert tool_call.name == fn.__name__
+    assert tool_call.arguments == {"name": "simon"}
+
+
+def test_llm_tool_call_excluded_from_input_schema():
+    def lookup(name: str, llm_tool_call) -> str:
+        "Look up a name"
+        return name
+
+    tool = llm.Tool.function(lookup)
+    assert "llm_tool_call" not in tool.input_schema.get("properties", {})
+    assert "llm_tool_call" not in tool.input_schema.get("required", [])
+    assert "name" in tool.input_schema["properties"]
+
+
+def test_kwargs_only_function_does_not_receive_llm_tool_call():
+    # A tool that accepts **kwargs but does not name llm_tool_call
+    # explicitly should NOT have it injected.
+    captured = {}
+
+    async def impl(**kwargs):
+        captured.update(kwargs)
+        return "ok"
+
+    tool = llm.Tool(
+        name="t",
+        description="A tool",
+        input_schema={"type": "object", "properties": {"name": {"type": "string"}}},
+        implementation=impl,
+    )
+    model = llm.get_model("echo")
+    chain_response = model.chain(
+        json.dumps({"tool_calls": [{"name": "t", "arguments": {"name": "x"}}]}),
+        tools=[tool],
+    )
+    chain_response.text()
+    assert captured == {"name": "x"}
+
+
+def test_toolbox_method_receives_llm_tool_call():
+    captured = {}
+
+    class Tools(llm.Toolbox):
+        def lookup(self, name: str, llm_tool_call) -> str:
+            captured["tool_call"] = llm_tool_call
+            return "hi " + name
+
+    model = llm.get_model("echo")
+    chain_response = model.chain(
+        json.dumps(
+            {"tool_calls": [{"name": "Tools_lookup", "arguments": {"name": "simon"}}]}
+        ),
+        tools=[Tools()],
+    )
+    output = chain_response.text()
+    assert '"output": "hi simon"' in output
+
+    tool_call = captured["tool_call"]
+    assert isinstance(tool_call, llm.ToolCall)
+    assert tool_call.arguments == {"name": "simon"}


### PR DESCRIPTION
Tool functions (sync or async, including Toolbox methods) that declare a parameter named `llm_tool_call` are now passed the `llm.ToolCall` object for the current invocation. The parameter is reserved: it is excluded from the input schema exposed to the model and is only injected when declared explicitly - a `**kwargs` catch-all does not receive it.

This lets tool implementations key external state against the unique `tool_call_id`, e.g. for human-in-the-loop approval flows that need to resume a specific tool call after the answer arrives.