### PR TITLE
Guaranteed tool call IDs

### DIFF
--- a/docs/plugins/advanced-model-plugins.md
+++ b/docs/plugins/advanced-model-plugins.md
@@ -138,7 +138,7 @@ Adding {ref}`tools support <tools>` involves several steps:
 
 1. Add `supports_tools = True` to your model class.
 2. If `prompt.tools` is populated, turn that list of `llm.Tool` objects into the correct format for your model.
-3. Look out for requests to call tools in the responses from your model. Call `response.add_tool_call(llm.ToolCall(...))` for each of those. This should work for streaming and non-streaming and async and non-async cases.
+3. Look out for requests to call tools in the responses from your model. Call `response.add_tool_call(llm.ToolCall(...))` for each of those. This should work for streaming and non-streaming and async and non-async cases. Pass the provider's tool call ID as `tool_call_id=` if there is one; if you omit it LLM synthesizes a unique `tc_`-prefixed id, since consumers rely on every tool call having one.
 4. If your prompt has a `prompt.tool_results` list, pass the information from those `llm.ToolResult` objects to your model.
 5. Include `prompt.tools` and `prompt.tool_results` and tool calls from `response.tool_calls_or_raise()` in the conversation history constructed by your plugin.
 6. Make sure your code is OK with prompts that do not have `prompt.prompt` set to a value, since they may be carrying exclusively the results of a tool call.

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -116,6 +116,7 @@ response = model.prompt("Convert panda to upper", tools=[upper])
 tool_calls = response.tool_calls()
 # [ToolCall(name='upper', arguments={'text': 'panda'}, tool_call_id='...')]
 ```
+Every tool call is guaranteed to have a unique `tool_call_id`. Most providers supply their own; for providers that do not, LLM synthesizes one of the form `tc_01...`, so you can always use the id to correlate a tool call with its result or to key external state against a specific invocation.
 You can call `response.execute_tool_calls()` to execute those calls and get back the results:
 ```python
 tool_results = response.execute_tool_calls()
@@ -215,7 +216,7 @@ print(response.text())
 
 #### Accessing the tool call from inside a tool
 
-Tool implementations sometimes need to know about the `llm.ToolCall` that triggered them - most often the `tool_call_id`, which can be used to key external state against that specific invocation.
+Tool implementations sometimes need to know about the `llm.ToolCall` that triggered them - most often the `tool_call_id` (always populated, see above), which can be used to key external state against that specific invocation.
 
 If your tool function accepts a parameter named `llm_tool_call` it will be passed the `llm.ToolCall` object for the current call:
 

--- a/llm/models.py
+++ b/llm/models.py
@@ -1,6 +1,7 @@
 import asyncio
 import base64
 from condense_json import condense_json
+import dataclasses
 from dataclasses import dataclass, field
 import datetime
 from .errors import NeedsKeyException
@@ -1223,6 +1224,15 @@ class _BaseResponse:
         return parts
 
     def add_tool_call(self, tool_call: ToolCall):
+        if tool_call.tool_call_id is None:
+            # Guarantee every locally-executable tool call has a unique id.
+            # Some providers never supply one, which otherwise forces every
+            # consumer correlating calls with results (or keying external
+            # state on a call) to invent fallback matching schemes.
+            tool_call = dataclasses.replace(
+                tool_call,
+                tool_call_id="tc_{}".format(str(monotonic_ulid()).lower()),
+            )
         self._tool_calls.append(tool_call)
 
     def set_usage(

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,4 +1,5 @@
 from click.testing import CliRunner
+import re
 from unittest.mock import ANY
 import json
 import llm.cli
@@ -338,7 +339,8 @@ def test_chat_tools(logs_db):
         catch_exceptions=False,
     )
     assert result.exit_code == 0
-    assert result.output == (
+    normalized_output = re.sub(r"tc_[0-9a-z]{26}", "tc_TCID", result.output)
+    assert normalized_output == (
         "Chatting with echo\n"
         "Type 'exit' or 'quit' to exit\n"
         "Type '!multi' to enter multiple lines, then '!end' to finish\n"
@@ -368,7 +370,7 @@ def test_chat_tools(logs_db):
         "    {\n"
         '      "name": "upper",\n'
         '      "output": "HELLO",\n'
-        '      "tool_call_id": null\n'
+        '      "tool_call_id": "tc_TCID"\n'
         "    }\n"
         "  ]\n"
         "}\n"

--- a/tests/test_llm_logs.py
+++ b/tests/test_llm_logs.py
@@ -950,15 +950,16 @@ def test_logs_tools(logs_db):
     )
     assert result1.exit_code == 0
     result2 = runner.invoke(cli, ["logs", "-c"])
+    normalized_output = re.sub(r"tc_[0-9a-z]{26}", "tc_TCID", result2.output)
     assert (
         "### Tool results\n"
         "\n"
-        "- **demo**: `None`<br>\n"
+        "- **demo**: `tc_TCID`<br>\n"
         "    one\n"
         "    two\n"
         "    three\n"
         "\n"
-    ) in result2.output
+    ) in normalized_output
     # Log one that did NOT use tools, check that `llm logs --tools` ignores it
     assert runner.invoke(cli, ["-m", "echo", "badger"]).exit_code == 0
     assert "badger" in runner.invoke(cli, ["logs"]).output

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -6,6 +6,8 @@ import llm
 from llm.tools import llm_version, llm_time
 from llm import cli, hookimpl, plugins, get_template_loaders, get_fragment_loaders
 import pathlib
+import re
+from unittest.mock import ANY
 import pytest
 import textwrap
 
@@ -450,19 +452,24 @@ def test_register_tools(tmpdir, logs_db):
             runner.invoke(cli.cli, ["logs", "-c", "-n", "0", "--json"]).output
         )
         results = tuple(
-            (log_row["prompt"], json.dumps(log_row["tool_results"]))
+            (
+                log_row["prompt"],
+                re.sub(
+                    r"tc_[0-9a-z]{26}", "tc_TCID", json.dumps(log_row["tool_results"])
+                ),
+            )
             for log_row in log_rows
         )
         assert results == (
             ('{"tool_calls": [{"name": "upper", "arguments": {"text": "one"}}]}', "[]"),
             (
                 "",
-                '[{"id": 2, "tool_id": 1, "name": "upper", "output": "ONE", "tool_call_id": null, "exception": null, "attachments": []}]',
+                '[{"id": 2, "tool_id": 1, "name": "upper", "output": "ONE", "tool_call_id": "tc_TCID", "exception": null, "attachments": []}]',
             ),
             ('{"tool_calls": [{"name": "upper", "arguments": {"text": "two"}}]}', "[]"),
             (
                 "",
-                '[{"id": 3, "tool_id": 1, "name": "upper", "output": "TWO", "tool_call_id": null, "exception": null, "attachments": []}]',
+                '[{"id": 3, "tool_id": 1, "name": "upper", "output": "TWO", "tool_call_id": "tc_TCID", "exception": null, "attachments": []}]',
             ),
             (
                 '{"tool_calls": [{"name": "upper", "arguments": {"text": "three"}}]}',
@@ -470,7 +477,7 @@ def test_register_tools(tmpdir, logs_db):
             ),
             (
                 "",
-                '[{"id": 4, "tool_id": 1, "name": "upper", "output": "THREE", "tool_call_id": null, "exception": null, "attachments": []}]',
+                '[{"id": 4, "tool_id": 1, "name": "upper", "output": "THREE", "tool_call_id": "tc_TCID", "exception": null, "attachments": []}]',
             ),
         )
         # Test the --td option
@@ -739,8 +746,8 @@ def test_register_toolbox(tmpdir, logs_db):
             "[" + result3.output.split('"tool_results": [')[1].split("]")[0] + "]"
         )
         assert tool_results == [
-            {"name": "Memory_set", "output": "null", "tool_call_id": None},
-            {"name": "Memory_get", "output": "two", "tool_call_id": None},
+            {"name": "Memory_set", "output": "null", "tool_call_id": ANY},
+            {"name": "Memory_get", "output": "two", "tool_call_id": ANY},
         ]
 
         # Test the CLI running a configured toolbox prompt
@@ -767,7 +774,7 @@ def test_register_toolbox(tmpdir, logs_db):
             {
                 "name": "Filesystem_list_files",
                 "output": json.dumps([str(other_path)]),
-                "tool_call_id": None,
+                "tool_call_id": ANY,
             }
         ]
 
@@ -909,9 +916,9 @@ def test_toolbox_logging_async(logs_db, tmpdir):
             "[" + result.output.split('"tool_results": [')[1].rsplit("]", 1)[0] + "]"
         )
         assert tool_results == [
-            {"name": "Memory_set", "output": "null", "tool_call_id": None},
-            {"name": "Memory_get", "output": "two", "tool_call_id": None},
-            {"name": "Filesystem_list_files", "output": "[]", "tool_call_id": None},
+            {"name": "Memory_set", "output": "null", "tool_call_id": ANY},
+            {"name": "Memory_get", "output": "two", "tool_call_id": ANY},
+            {"name": "Filesystem_list_files", "output": "[]", "tool_call_id": ANY},
         ]
     finally:
         plugins.pm.unregister(name="ToolboxPlugin")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,4 +1,5 @@
 import asyncio
+import re
 from click.testing import CliRunner
 from importlib.metadata import version
 import json
@@ -114,6 +115,9 @@ def test_tool_use_async_tool_function():
     bits = output.split("\n}{\n")
     assert len(bits) == 2
     objects = [json.loads(bits[0] + "}"), json.loads("{" + bits[1])]
+    tool_call_id = objects[1]["tool_results"][0]["tool_call_id"]
+    assert tool_call_id.startswith("tc_")
+    objects[1]["tool_results"][0]["tool_call_id"] = None
     assert objects == [
         {"prompt": "", "system": "", "attachments": [], "stream": True, "previous": []},
         {
@@ -155,6 +159,11 @@ async def test_async_tools_run_tools_in_parallel():
     bits = output.split("\n}{\n")
     assert len(bits) == 2
     objects = [json.loads(bits[0] + "}"), json.loads("{" + bits[1])]
+    ids = [r["tool_call_id"] for r in objects[1]["tool_results"]]
+    assert all(i.startswith("tc_") for i in ids)
+    assert len(set(ids)) == 2
+    for r in objects[1]["tool_results"]:
+        r["tool_call_id"] = None
     assert objects == [
         {"prompt": "", "system": "", "attachments": [], "stream": True, "previous": []},
         {
@@ -512,11 +521,14 @@ def test_tool_errors(async_):
     # llm logs -c output
     log_text_result = runner.invoke(cli.cli, ["logs", "-c"])
     assert log_text_result.exit_code == 0
+    normalized_log_text = re.sub(
+        r"tc_[0-9a-z]{26}", "tc_TCID", log_text_result.output
+    )
     assert (
-        "- **trigger_error**: `None`<br>\n"
+        "- **trigger_error**: `tc_TCID`<br>\n"
         "    Error: Error!<br>\n"
         "    **Error**: Exception: Error!\n"
-    ) in log_text_result.output
+    ) in normalized_log_text
 
 
 def test_chain_sync_cancel_only_first_of_two():
@@ -730,3 +742,83 @@ def test_toolbox_method_receives_llm_tool_call():
     tool_call = captured["tool_call"]
     assert isinstance(tool_call, llm.ToolCall)
     assert tool_call.arguments == {"name": "simon"}
+
+
+def test_add_tool_call_synthesizes_missing_tool_call_id():
+    model = llm.get_model("echo")
+    response = model.prompt("hello")
+    response.add_tool_call(llm.ToolCall(name="a", arguments={}))
+    response.add_tool_call(llm.ToolCall(name="b", arguments={}, tool_call_id="given"))
+    response.add_tool_call(llm.ToolCall(name="c", arguments={}))
+    ids = [tc.tool_call_id for tc in response._tool_calls]
+    assert ids[0] is not None and ids[0].startswith("tc_")
+    assert ids[1] == "given"
+    assert ids[2] is not None and ids[2].startswith("tc_")
+    assert ids[0] != ids[2]
+
+
+def test_tool_call_ids_guaranteed_through_chain():
+    seen_before_call = []
+    captured = {}
+
+    def first(llm_tool_call) -> str:
+        captured["first_id"] = llm_tool_call.tool_call_id
+        return "one"
+
+    def second() -> str:
+        return "two"
+
+    def before(tool, tool_call):
+        seen_before_call.append(tool_call.tool_call_id)
+
+    model = llm.get_model("echo")
+    chain_response = model.chain(
+        json.dumps({"tool_calls": [{"name": "first"}, {"name": "second"}]}),
+        tools=[first, second],
+        before_call=before,
+    )
+    chain_response.text()
+
+    assert len(seen_before_call) == 2
+    assert all(i is not None and i.startswith("tc_") for i in seen_before_call)
+    assert seen_before_call[0] != seen_before_call[1]
+    # The implementation saw the same id via llm_tool_call
+    assert captured["first_id"] == seen_before_call[0]
+
+    # ToolResults and the next prompt's tool message carry the same ids
+    second_response = chain_response._responses[1]
+    result_ids = [r.tool_call_id for r in second_response.prompt.tool_results]
+    assert result_ids == seen_before_call
+
+    # The assistant message parts carry the synthesized ids too, so a
+    # persisted-and-replayed history stays correlated
+    from llm.parts import ToolCallPart
+
+    first_response = chain_response._responses[0]
+    part_ids = [
+        p.tool_call_id
+        for p in first_response._messages_now()[0].parts
+        if isinstance(p, ToolCallPart)
+    ]
+    assert part_ids == seen_before_call
+
+
+@pytest.mark.asyncio
+async def test_tool_call_ids_guaranteed_async_model():
+    seen = []
+
+    async def hello() -> str:
+        return "world"
+
+    async def before(tool, tool_call):
+        seen.append(tool_call.tool_call_id)
+
+    model = llm.get_async_model("echo")
+    chain_response = model.chain(
+        json.dumps({"tool_calls": [{"name": "hello"}]}),
+        tools=[hello],
+        before_call=before,
+    )
+    await chain_response.text()
+    assert len(seen) == 1
+    assert seen[0] is not None and seen[0].startswith("tc_")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -521,9 +521,7 @@ def test_tool_errors(async_):
     # llm logs -c output
     log_text_result = runner.invoke(cli.cli, ["logs", "-c"])
     assert log_text_result.exit_code == 0
-    normalized_log_text = re.sub(
-        r"tc_[0-9a-z]{26}", "tc_TCID", log_text_result.output
-    )
+    normalized_log_text = re.sub(r"tc_[0-9a-z]{26}", "tc_TCID", log_text_result.output)
     assert (
         "- **trigger_error**: `tc_TCID`<br>\n"
         "    Error: Error!<br>\n"


### PR DESCRIPTION
Follows:
- #1480

> add_tool_call() now synthesizes a unique tc_-prefixed id (monotonic
ULID) whenever the provider did not supply one. Previously consumers
correlating tool calls with results - or keying external state on a
specific invocation - had to invent fallback matching schemes for
id-less providers, and test models like llm-echo exercised different
code paths than production providers.