### PR TITLE
Async tool calls to missing tools now produce error results

### DIFF
--- a/llm/models.py
+++ b/llm/models.py
@@ -2192,13 +2192,48 @@ class AsyncResponse(_BaseResponse):
             tool: Optional[Tool] = tools_by_name.get(tc.name)
             exception: Optional[Exception] = None
 
-            if tool is None:
-                output = f'Error: tool "{tc.name}" does not exist'
-                exception = KeyError(tc.name)
-            elif not tool.implementation:
-                output = f'Error: tool "{tc.name}" has no implementation'
-                exception = KeyError(tc.name)
-            elif inspect.iscoroutinefunction(tool.implementation):
+            if tool is None or not tool.implementation:
+                # Mirror the sync executor: append an error ToolResult so
+                # the provider still receives a result for every tool
+                # call. before_call fires even though the tool is
+                # unavailable.
+                if before_call:
+                    try:
+                        cb = before_call(tool, tc)
+                        if inspect.isawaitable(cb):
+                            await cb
+                    except CancelToolCall as ex:
+                        indexed_results.append(
+                            (
+                                idx,
+                                ToolResult(
+                                    name=tc.name,
+                                    output="Cancelled: " + str(ex),
+                                    tool_call_id=tc.tool_call_id,
+                                    exception=ex,
+                                ),
+                            )
+                        )
+                        continue
+                    except Exception as ex:
+                        failures.append((idx, ex))
+                        break
+                reason = "does not exist" if tool is None else "has no implementation"
+                msg = 'tool "{}" {}'.format(tc.name, reason)
+                indexed_results.append(
+                    (
+                        idx,
+                        ToolResult(
+                            name=tc.name,
+                            output="Error: " + msg,
+                            tool_call_id=tc.tool_call_id,
+                            exception=KeyError(msg),
+                        ),
+                    )
+                )
+                continue
+
+            if inspect.iscoroutinefunction(tool.implementation):
 
                 async def run_async(tc=tc, tool=tool, idx=idx):
                     # before_call inside the task
@@ -2286,52 +2321,46 @@ class AsyncResponse(_BaseResponse):
                 exception = None
                 attachments = []
 
-                if tool is None:
-                    output = f'Error: tool "{tc.name}" does not exist'
-                    exception = KeyError(tc.name)
-                else:
-                    try:
-                        res = tool.implementation(**_implementation_arguments(tool, tc))
-                        if inspect.isawaitable(res):
-                            res = await res
-                        if isinstance(res, ToolOutput):
-                            attachments.extend(res.attachments)
-                            res = res.output
-                        output = (
-                            res
-                            if isinstance(res, str)
-                            else json.dumps(res, default=repr)
-                        )
-                    except PauseChain as ex:
-                        # Inline execution stops here; later calls never
-                        # start. Tasks already started are still awaited
-                        # below before the pause propagates.
-                        ex.tool_call = tc
-                        paused.append((idx, ex))
-                        break
-                    except Exception as ex:
-                        output = f"Error: {ex}"
-                        exception = ex
-
-                    tr = ToolResult(
-                        name=tc.name,
-                        output=output,
-                        attachments=attachments,
-                        tool_call_id=tc.tool_call_id,
-                        instance=_get_instance(tool.implementation),
-                        exception=exception,
+                try:
+                    res = tool.implementation(**_implementation_arguments(tool, tc))
+                    if inspect.isawaitable(res):
+                        res = await res
+                    if isinstance(res, ToolOutput):
+                        attachments.extend(res.attachments)
+                        res = res.output
+                    output = (
+                        res if isinstance(res, str) else json.dumps(res, default=repr)
                     )
+                except PauseChain as ex:
+                    # Inline execution stops here; later calls never
+                    # start. Tasks already started are still awaited
+                    # below before the pause propagates.
+                    ex.tool_call = tc
+                    paused.append((idx, ex))
+                    break
+                except Exception as ex:
+                    output = f"Error: {ex}"
+                    exception = ex
 
-                    try:
-                        if tool is not None and after_call:
-                            cb2 = after_call(tool, tc, tr)
-                            if inspect.isawaitable(cb2):
-                                await cb2
-                    except Exception as ex:
-                        failures.append((idx, ex))
-                        break
+                tr = ToolResult(
+                    name=tc.name,
+                    output=output,
+                    attachments=attachments,
+                    tool_call_id=tc.tool_call_id,
+                    instance=_get_instance(tool.implementation),
+                    exception=exception,
+                )
 
-                    indexed_results.append((idx, tr))
+                try:
+                    if after_call:
+                        cb2 = after_call(tool, tc, tr)
+                        if inspect.isawaitable(cb2):
+                            await cb2
+                except Exception as ex:
+                    failures.append((idx, ex))
+                    break
+
+                indexed_results.append((idx, tr))
 
         # Await every task that was started; return_exceptions so a pause
         # or hook failure in one task cannot orphan its siblings mid-flight.

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -820,3 +820,79 @@ async def test_tool_call_ids_guaranteed_async_model():
     await chain_response.text()
     assert len(seen) == 1
     assert seen[0] is not None and seen[0].startswith("tc_")
+
+
+@pytest.mark.asyncio
+async def test_async_missing_tool_produces_error_result():
+    # Async executor parity with sync: a call to a tool that is not in
+    # tools= must produce an error ToolResult, not silently vanish -
+    # otherwise the next provider call has a tool_call with no result.
+    before_calls = []
+
+    async def real_tool() -> str:
+        return "ok"
+
+    async def before(tool, tool_call):
+        # before_call fires even when tool is None, like the sync path
+        before_calls.append((tool.name if tool else None, tool_call.name))
+
+    model = llm.get_async_model("echo")
+    chain_response = model.chain(
+        json.dumps({"tool_calls": [{"name": "missing_tool"}, {"name": "real_tool"}]}),
+        tools=[real_tool],
+        before_call=before,
+    )
+    await chain_response.text()
+
+    second = chain_response._responses[1]
+    results = [(r.name, r.output) for r in second.prompt.tool_results]
+    assert results == [
+        ("missing_tool", 'Error: tool "missing_tool" does not exist'),
+        ("real_tool", "ok"),
+    ]
+    assert isinstance(second.prompt.tool_results[0].exception, KeyError)
+    assert (None, "missing_tool") in before_calls
+
+
+@pytest.mark.asyncio
+async def test_async_missing_tool_can_be_cancelled_by_before_call():
+    async def real_tool() -> str:
+        return "ok"
+
+    async def before(tool, tool_call):
+        if tool is None:
+            raise CancelToolCall("no such tool")
+
+    model = llm.get_async_model("echo")
+    chain_response = model.chain(
+        json.dumps({"tool_calls": [{"name": "missing_tool"}, {"name": "real_tool"}]}),
+        tools=[real_tool],
+        before_call=before,
+    )
+    await chain_response.text()
+    second = chain_response._responses[1]
+    results = [(r.name, r.output) for r in second.prompt.tool_results]
+    assert results == [
+        ("missing_tool", "Cancelled: no such tool"),
+        ("real_tool", "ok"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_async_tool_without_implementation_produces_error_result():
+    tool = llm.Tool(
+        name="no_impl",
+        description="A tool with no implementation",
+        input_schema={"type": "object", "properties": {}},
+        implementation=None,
+    )
+    model = llm.get_async_model("echo")
+    chain_response = model.chain(
+        json.dumps({"tool_calls": [{"name": "no_impl"}]}),
+        tools=[tool],
+    )
+    await chain_response.text()
+    second = chain_response._responses[1]
+    assert [(r.name, r.output) for r in second.prompt.tool_results] == [
+        ("no_impl", 'Error: tool "no_impl" has no implementation'),
+    ]


### PR DESCRIPTION
I said to Claude Fable 5 in Claude Code:

> OK look at ~/dev/llm again - looks good right? Anything else we should change before shipping a new alpha of that?

And it went ahead and found and then cerated a branch for and fixed this issue.:

> The async `execute_tool_calls()` silently dropped calls to tools that were not in tools= (or had no implementation): output and exception were assigned but no ToolResult was ever appended, so the next provider call carried an assistant tool_call with no matching result - which OpenAI and Anthropic reject. The sync executor already returned an 'Error: tool ... does not exist' result.
> 
> The async path now mirrors the sync one: before_call fires (and can CancelToolCall) even though the tool is unavailable, and an error ToolResult is appended in call order. Also removes the now-unreachable tool-is-None branch from the inline sync-implementation path.
> 
> This matters more since chain resume landed: a pending call whose tool is no longer registered would otherwise never resolve.