### PR TITLE
Fix tool_instances attribution for multi-toolbox runs (#1398)

### DIFF
--- a/llm/models.py
+++ b/llm/models.py
@@ -1529,9 +1529,11 @@ class _BaseResponse:
 
         # Persist any tools, tool calls and tool results
         tool_ids_by_name = {}
+        tools_by_name = {}
         for tool in self.prompt.tools:
             tool_id = ensure_tool(db, tool)
             tool_ids_by_name[tool.name] = tool_id
+            tools_by_name[tool.name] = tool
             db["tool_responses"].insert(
                 {
                     "tool_id": tool_id,
@@ -1551,14 +1553,15 @@ class _BaseResponse:
         for tool_result in self.prompt.tool_results:
             instance_id = None
             if tool_result.instance:
+                matching_tool = tools_by_name.get(tool_result.name)
                 try:
-                    if not tool_result.instance.instance_id:
+                    if not tool_result.instance.instance_id and matching_tool is not None:
                         tool_result.instance.instance_id = (
                             db["tool_instances"]
                             .insert(
                                 {
-                                    "plugin": tool.plugin,
-                                    "name": tool.name.split("_")[0],
+                                    "plugin": matching_tool.plugin,
+                                    "name": matching_tool.name.split("_")[0],
                                     "arguments": json.dumps(
                                         tool_result.instance._config
                                     ),

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -947,7 +947,7 @@ def test_toolbox_logging_async(logs_db, tmpdir):
                     "name": "Memory_set",
                     "output": "null",
                     "instance": {
-                        "name": "Filesystem",
+                        "name": "Memory",
                         "plugin": "ToolboxPlugin",
                         "arguments": "{}",
                     },
@@ -956,7 +956,7 @@ def test_toolbox_logging_async(logs_db, tmpdir):
                     "name": "Memory_get",
                     "output": "two",
                     "instance": {
-                        "name": "Filesystem",
+                        "name": "Memory",
                         "plugin": "ToolboxPlugin",
                         "arguments": "{}",
                     },


### PR DESCRIPTION
Fixes #1398.

In `_BaseResponse.log_to_db()`, the `tool_instances` insert inside the `for tool_result in self.prompt.tool_results` loop was reading `tool.plugin` and `tool.name` from the previous `for tool in self.prompt.tools` loop variable, which retains the last tool after the loop ends. Every toolbox-backed tool result was attributed to whichever tool happened to be last in `self.prompt.tools`.

The fix builds `tools_by_name` next to the existing `tool_ids_by_name` and looks up the correct tool by `tool_result.name` when inserting the `tool_instances` row. If no matching tool is found we skip the insert (instead of writing a wrong row from the leaked variable).

`tests/test_plugins.py::test_toolbox_logging_async` was asserting the buggy attribution (Memory_set/Memory_get → `Filesystem`); updated to expect Memory_set/Memory_get → `Memory`. Full test suite still passes (782 passed).
