### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -27,7 +27,7 @@ The default OpenAI plugin has a debugging mechanism for showing the exact reques
 
 Set the `LLM_OPENAI_SHOW_RESPONSES` environment variable like this:
 ```bash
-LLM_OPENAI_SHOW_RESPONSES=1 uv run llm -m chatgpt 'three word slogan for an an otter-run bakery'
+LLM_OPENAI_SHOW_RESPONSES=1 uv run llm -m chatgpt 'three word slogan for an otter-run bakery'
 ```
 This will output details of the API requests and responses to the console.
 
@@ -35,7 +35,7 @@ Use `--no-stream` to see a more readable version of the body that avoids streami
 
 ```bash
 LLM_OPENAI_SHOW_RESPONSES=1 uv run llm -m chatgpt --no-stream \
-  'three word slogan for an an otter-run bakery'
+  'three word slogan for an otter-run bakery'
 ```
 
 ## Documentation

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -64,11 +64,11 @@ Further tools can be installed using plugins, or you can use the `llm --function
 
 ## LLM's implementation of tools
 
-In LLM every tool is a defined as a Python function. The function can take any number of arguments and can return a string or an object that can be converted to a string.
+In LLM every tool is defined as a Python function. The function can take any number of arguments and can return a string or an object that can be converted to a string.
 
 Tool functions should include a docstring that describes what the function does. This docstring will become the description that is passed to the model.
 
-Tools can also be defined as {ref}`toolbox classes <python-api-toolbox>`, a subclass of `llm.Toolbox` that allows multiple related tools to be bundled together. Toolbox classes can be be configured when they are instantiated, and can also maintain state in between multiple tool calls.
+Tools can also be defined as {ref}`toolbox classes <python-api-toolbox>`, a subclass of `llm.Toolbox` that allows multiple related tools to be bundled together. Toolbox classes can be configured when they are instantiated, and can also maintain state in between multiple tool calls.
 
 The Python API can accept functions directly. The command-line interface has two ways for tools to be defined: via plugins that implement the {ref}`register_tools() plugin hook <plugin-hooks-register-tools>`, or directly on the command-line using the `--functions` argument to specify a block of Python code defining one or more functions - or a path to a Python file containing the same.
 


### PR DESCRIPTION
A few small documentation typo fixes:

- **docs/tools.md**: "In LLM every tool is a defined as a Python function" → "is defined as" (stray article), and "Toolbox classes can be be configured" → "can be configured" (doubled word).
- **docs/contributing.md**: the `LLM_OPENAI_SHOW_RESPONSES` debugging example asks for a slogan for "an an otter-run bakery" — dropped the doubled "an" in both the streaming and `--no-stream` snippets.

Docs-only; no code changes.
