### PR TITLE
schema_dsl: raise ValueError for empty field name before ':'

### DIFF
--- a/llm/utils.py
+++ b/llm/utils.py
@@ -392,6 +392,8 @@ def schema_dsl(schema_dsl: str, multi: bool = False) -> Dict[str, Any]:
 
         # Process field name and type
         field_parts = field_info.strip().split()
+        if not field_parts:
+            raise ValueError(f"Field name is required before ':' (got {field!r})")
         field_name = field_parts[0].strip()
 
         # Default type is string

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -225,6 +225,21 @@ def test_schema_dsl(schema, expected):
     assert result == expected
 
 
+@pytest.mark.parametrize(
+    "schema",
+    [
+        # https://github.com/simonw/llm/issues/1466
+        ":just a description",
+        "name, :description",
+        ":",
+        " :desc",
+    ],
+)
+def test_schema_dsl_missing_field_name(schema):
+    with pytest.raises(ValueError, match="Field name is required"):
+        schema_dsl(schema)
+
+
 def test_schema_dsl_multi():
     result = schema_dsl("name, age int: The age", multi=True)
     assert result == {


### PR DESCRIPTION
Fixes #1466.

`schema_dsl()` crashed with `IndexError: list index out of range` when a field in the DSL had no name before the colon. The traceback in the issue:

```
File "llm/utils.py", line 395, in schema_dsl
    field_name = field_parts[0].strip()
                 ~~~~~~~~~~~^^^
IndexError: list index out of range
```

This is reachable from `llm schema dsl ':foo'` and from `resolve_schema_input` whenever the schema string contains such a field.

After `field.split(':', 1)`, `field_info` is `''`; `field_info.strip().split()` returns `[]`, so `field_parts[0]` raises.

Raise a `ValueError` with the offending field instead — consistent with the other validation errors in this module (`Invalid spec string`, `Unknown class`, etc.).

```
>>> schema_dsl(':just a description')
ValueError: Field name is required before ':' (got ':just a description')
```

Added parametrized regression:

- `':just a description'` (issue example)
- `'name, :description'` (mid-list)
- `':'` (lone colon)
- `' :desc'` (whitespace-only name)

`name: ` (valid name, empty description) is unchanged and still parses.

Prepared with AI assistance.