### PR TITLE
Add llm-empiriolabs to plugin directory

### DIFF
--- a/docs/plugins/directory.md
+++ b/docs/plugins/directory.md
@@ -41,6 +41,7 @@ These plugins can be used to interact with remotely hosted models via their API:
 - **[llm-deepseek](https://github.com/abrasumente233/llm-deepseek)** adds support for the [DeepSeek](https://deepseek.com)'s DeepSeek-Chat and DeepSeek-Coder models.
 - **[llm-lambda-labs](https://github.com/simonw/llm-lambda-labs)** provides access to models hosted by [Lambda Labs](https://docs.lambdalabs.com/public-cloud/lambda-chat-api/), including the Nous Hermes 3 series.
 - **[llm-venice](https://github.com/ar-jan/llm-venice)** provides access to uncensored models hosted by privacy-focused [Venice AI](https://docs.venice.ai/), including Llama 3.1 405B.
+- **[llm-empiriolabs](https://github.com/EmpirioLabs-ai/llm-empiriolabs)** adds support for [EmpirioLabs](https://empiriolabs.ai) models (Qwen, DeepSeek, GLM, Kimi, MiniMax, and more) via their OpenAI-compatible API.
 
 If an API model host provides an OpenAI-compatible API you can also [configure LLM to talk to it](https://llm.datasette.io/en/stable/other-models.html#openai-compatible-models) without needing an extra plugin.
 


### PR DESCRIPTION
Adds a Remote APIs entry to `docs/plugins/directory.md` for the [llm-empiriolabs](https://github.com/EmpirioLabs-ai/llm-empiriolabs) plugin, published on PyPI as [llm-empiriolabs](https://pypi.org/project/llm-empiriolabs/).

Install with:

```
llm install llm-empiriolabs
```

The plugin adds support for EmpirioLabs models (Qwen, DeepSeek, GLM, Kimi, MiniMax, and more) through their OpenAI-compatible API, with the model list fetched from the live catalog. Single-line addition following the same format as the surrounding entries.
