### PR TITLE
docs: fix wrong hook name and typo in register_fragment_loaders section

### DIFF
--- a/docs/plugins/plugin-hooks.md
+++ b/docs/plugins/plugin-hooks.md
@@ -235,7 +235,7 @@ Note that `functions:` provided by templates using this plugin hook will not be 
 (plugin-hooks-register-fragment-loaders)=
 ## register_fragment_loaders(register)
 
-Plugins can register new fragment loaders using the `register_template_loaders` hook. These can then be used with the `llm -f prefix:argument` syntax.
+Plugins can register new fragment loaders using the `register_fragment_loaders` hook. These can then be used with the `llm -f prefix:argument` syntax.
 
 Fragment loader plugins differ from template loader plugins in that you can stack more than one fragment loader call together in the same prompt.
 
@@ -289,4 +289,4 @@ llm -f my-fragments:argument
 ```
 If multiple fragments are returned they will be used as if the user passed multiple `-f X` arguments to the command.
 
-Multiple fragments are particularly useful for things like plugins that return every file in a directory. If these were concatenated together by the plugin, a change to a single file would invalidate the de-duplicatino cache for that whole fragment. Giving each file its own fragment means we can avoid storing multiple copies of that full collection if only a single file has changed.
+Multiple fragments are particularly useful for things like plugins that return every file in a directory. If these were concatenated together by the plugin, a change to a single file would invalidate the de-duplication cache for that whole fragment. Giving each file its own fragment means we can avoid storing multiple copies of that full collection if only a single file has changed.


### PR DESCRIPTION
## Summary
The `register_fragment_loaders` section of `docs/plugins/plugin-hooks.md` told plugin authors to register using the **`register_template_loaders`** hook — a copy-paste error pointing to the wrong hook. The two hooks are distinct (`llm/hookspecs.py` lines 24 and 29) and dispatched separately (`llm/__init__.py` lines 150 and 158), so following the docs as written wires up the wrong loader.

Also fixes a typo: "de-duplicatino" → "de-duplication".

## Changes
- `docs/plugins/plugin-hooks.md`: correct hook name + typo (2 lines).

*AI-assisted contribution.*
