### PR TITLE
Fix monotonic_ulid() when the system clock jumps backwards

### DIFF
--- a/llm/utils.py
+++ b/llm/utils.py
@@ -711,8 +711,11 @@ def monotonic_ulid() -> ULID:
         # Decode timestamp from the last ULID we handed out
         last_ms = int.from_bytes(_last[:TIMESTAMP_LEN], "big")
 
-        # If the millisecond is the same, increment the randomness
-        if now_ms == last_ms:
+        # If the clock has not advanced past the last ULID - either the same
+        # millisecond or a backwards clock jump (e.g. an NTP correction) -
+        # keep the previous timestamp and increment the randomness so the
+        # result stays strictly larger than the previous one.
+        if now_ms <= last_ms:
             rand_int = int.from_bytes(_last[TIMESTAMP_LEN:], "big") + 1
             if rand_int >= 1 << (RANDOMNESS_LEN * 8):
                 raise OverflowError(
@@ -723,7 +726,7 @@ def monotonic_ulid() -> ULID:
             _last = _last[:TIMESTAMP_LEN] + randomness
             return ULID(_last)
 
-        # New millisecond, start fresh
+        # Clock moved forward, start fresh
         _last = _fresh(now_ms)
         return ULID(_last)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -468,6 +468,23 @@ def test_monotonic_ulids():
     assert ulids == sorted(ulids)
 
 
+def test_monotonic_ulid_handles_clock_going_backwards(monkeypatch):
+    # monotonic_ulid() promises a value strictly larger than every previous
+    # one, even if the system clock jumps backwards (e.g. an NTP correction)
+    import llm.utils as utils
+
+    fake_ns = {"value": 1_700_000_000_000 * utils.NANOSECS_IN_MILLISECS}
+    monkeypatch.setattr(utils.time, "time_ns", lambda: fake_ns["value"])
+    monkeypatch.setattr(utils, "_last", None)
+
+    first = monotonic_ulid()
+    # Clock jumps backwards by five seconds
+    fake_ns["value"] -= 5_000 * utils.NANOSECS_IN_MILLISECS
+    second = monotonic_ulid()
+
+    assert second > first
+
+
 def test_toolbox_config_capture():
     """Test that Toolbox captures __init__ parameters in _config"""
 


### PR DESCRIPTION
## Bug

`monotonic_ulid()` documents that every returned ULID is *strictly larger* than every previous one, and its docstring says it "works the same way the reference JavaScript `monotonicFactory` does". That reference increments the randomness whenever the seed time is the **same or earlier** than the last timestamp.

The implementation only handled the equal case (`now_ms == last_ms`). If the system clock moves backwards — e.g. an NTP correction or a leap-second style adjustment — `now_ms < last_ms` falls through to the "start fresh" branch and produces a ULID built from the smaller current timestamp. That value sorts *before* the previously returned one, breaking the monotonicity guarantee that the IDs (and the tests relying on it) depend on.

## Fix

Treat `now_ms <= last_ms` the same way: keep the last (larger) timestamp and increment the randomness, so the result stays strictly larger than the previous ULID. This matches the reference `monotonicFactory` behaviour.

## Verification

Added `test_monotonic_ulid_handles_clock_going_backwards`, which forces the clock backwards via a patched `time.time_ns` and asserts the second ULID is still greater than the first.

```
$ python -m pytest tests/test_utils.py -q
83 passed
```

Before the fix the new test fails:
```
assert second > first
E  assert ULID(01HF7YAN3RFTDFC4J4HETJ576W) > ULID(01HF7YAT00H2MAH1AP018ZRJQA)
```
