### PR TITLE
Add llm-freellmpool to plugin directory

### DIFF
--- a/docs/plugins/directory.md
+++ b/docs/plugins/directory.md
@@ -32,6 +32,7 @@ These plugins can be used to interact with remotely hosted models via their API:
 - **[llm-anyscale-endpoints](https://github.com/simonw/llm-anyscale-endpoints)** supports models hosted on the [Anyscale Endpoints](https://app.endpoints.anyscale.com/) platform, including Llama 2 70B.
 - **[llm-replicate](https://github.com/simonw/llm-replicate)** adds support for remote models hosted on [Replicate](https://replicate.com/), including Llama 2 from Meta AI.
 - **[llm-fireworks](https://github.com/simonw/llm-fireworks)** supports models hosted by [Fireworks AI](https://fireworks.ai/).
+- **[llm-freellmpool](https://github.com/0xzr/llm-freellmpool)** routes prompts through [freellmpool](https://github.com/0xzr/freellmpool), pooling free-tier LLM providers with failover and keyless startup.
 - **[llm-openrouter](https://github.com/simonw/llm-openrouter)** provides access to models hosted on [OpenRouter](https://openrouter.ai/).
 - **[llm-cohere](https://github.com/Accudio/llm-cohere)** by Alistair Shepherd provides `cohere-generate` and `cohere-summarize` API models, powered by [Cohere](https://cohere.com/).
 - **[llm-bedrock](https://github.com/simonw/llm-bedrock)** adds support for Nova by Amazon via Amazon Bedrock.


### PR DESCRIPTION
Adds llm-freellmpool to the Remote APIs plugin directory. The plugin routes prompts through freellmpool, which pools free-tier LLM providers with failover and keyless startup.