### PR TITLE
embed-multi --skip-errors and on_error= callback for embeddings

### DIFF
--- a/docs/embeddings/cli.md
+++ b/docs/embeddings/cli.md
@@ -157,8 +157,11 @@ All three mechanisms support these options:
 - `--prefix` to prepend a prefix to the stored ID of each item
 - `--prepend` to prepend a string to the content before embedding 
 - `--batch-size SIZE` to process embeddings in batches of the specified size
+- `--skip-errors` to skip any items that fail to embed (for example because they are too long) and continue, rather than aborting the entire operation
 
 The `--prepend` option is useful for embedding models that require you to prepend a special token to the content before embedding it. [nomic-embed-text-v2-moe](https://huggingface.co/nomic-ai/nomic-embed-text-v2-moe) for example requires documents to be prepended `'search_document: '` and search queries to be prepended `'search_query: '`.
+
+By default, if any item fails to embed the entire `llm embed-multi` operation stops with an error and nothing is stored. Pass `--skip-errors` to skip the items that fail, store everything that succeeds, and print a warning listing the IDs that were skipped.
 
 (embeddings-cli-embed-multi-csv-etc)=
 ### Embedding data from a CSV, TSV or JSON file

--- a/docs/embeddings/python-api.md
+++ b/docs/embeddings/python-api.md
@@ -112,6 +112,19 @@ collection.embed_multi(
 )
 ```
 
+By default, if an item fails to embed (for example because it is too long for the model) the whole `embed_multi()` call raises an exception and no embeddings are stored. Pass an `on_error` callback to skip items that fail instead. It is called with `(entry, exception)` for each skipped item, where `entry` is the `(id, value, metadata)` tuple, and the remaining items are still embedded:
+
+```python
+skipped = []
+collection.embed_multi(
+    (
+        (i, line)
+        for i, line in enumerate(lines_in_file)
+    ),
+    on_error=lambda entry, exception: skipped.append(entry[0]),
+)
+```
+
 (embeddings-python-collection-class)=
 ### Collection class reference
 
@@ -123,8 +136,8 @@ A collection instance has the following properties and methods:
 - `model()` - returns the `EmbeddingModel` instance, based on that `model_id`
 - `count()` - returns the integer number of items in the collection
 - `embed(id: str, text: str, metadata: dict=None, store: bool=False)` - embeds the given string and stores it in the collection under the given ID. Can optionally include metadata (stored as JSON) and store the text content itself in the database table.
-- `embed_multi(entries: Iterable, store: bool=False, batch_size: int=100)` - see above
-- `embed_multi_with_metadata(entries: Iterable, store: bool=False, batch_size: int=100)` - see above
+- `embed_multi(entries: Iterable, store: bool=False, batch_size: int=100, on_error: Callable=None)` - see above
+- `embed_multi_with_metadata(entries: Iterable, store: bool=False, batch_size: int=100, on_error: Callable=None)` - see above
 - `similar(query: str, number: int=10)` - returns a list of entries that are most similar to the embedding of the given query string
 - `similar_by_id(id: str, number: int=10)` - returns a list of entries that are most similar to the embedding of the item with the given ID
 - `similar_by_vector(vector: List[float], number: int=10, skip_id: str=None)` - returns a list of entries that are most similar to the given embedding vector, optionally skipping the entry with the given ID

--- a/docs/help.md
+++ b/docs/help.md
@@ -929,6 +929,8 @@ Options:
   --attach <TEXT FILE>...      Additional databases to attach - specify alias
                                and file path
   --batch-size INTEGER         Batch size to use when running embeddings
+  --skip-errors                Skip items that fail to embed (e.g. too long) and
+                               warn, instead of aborting
   --prefix TEXT                Prefix to add to the IDs
   -m, --model TEXT             Embedding model to use
   --prepend TEXT               Prepend this string to all content before

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -3292,6 +3292,11 @@ def embed(
 @click.option(
     "--batch-size", type=int, help="Batch size to use when running embeddings"
 )
+@click.option(
+    "--skip-errors",
+    is_flag=True,
+    help="Skip items that fail to embed (e.g. too long) and warn, instead of aborting",
+)
 @click.option("--prefix", help="Prefix to add to the IDs", default="")
 @click.option(
     "-m", "--model", help="Embedding model to use", envvar="LLM_EMBEDDING_MODEL"
@@ -3317,6 +3322,7 @@ def embed_multi(
     sql,
     attach,
     batch_size,
+    skip_errors,
     prefix,
     model,
     prepend,
@@ -3457,6 +3463,8 @@ def embed_multi(
         except json.JSONDecodeError as ex:
             raise click.ClickException(str(ex))
 
+    skipped: List[Tuple[str, Exception]] = []
+
     with click.progressbar(
         rows, label="Embedding", show_percent=True, length=expected_length
     ) as rows:
@@ -3477,7 +3485,23 @@ def embed_multi(
         embed_kwargs = {"store": store}
         if batch_size:
             embed_kwargs["batch_size"] = batch_size
+        if skip_errors:
+
+            def on_error(entry, exception):
+                skipped.append((entry[0], exception))
+
+            embed_kwargs["on_error"] = on_error
         collection_obj.embed_multi(tuples(), **embed_kwargs)
+
+    if skipped:
+        click.echo(
+            "Skipped {} item{} that could not be embedded:".format(
+                len(skipped), "" if len(skipped) == 1 else "s"
+            ),
+            err=True,
+        )
+        for skipped_id, exception in skipped:
+            click.echo("  {}: {}".format(skipped_id, exception), err=True)
 
 
 @cli.command()

--- a/llm/embeddings.py
+++ b/llm/embeddings.py
@@ -7,7 +7,12 @@ import json
 from sqlite_utils import Database
 from sqlite_utils.db import Table
 import time
-from typing import cast, Any, Dict, Iterable, List, Optional, Tuple, Union
+from typing import cast, Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
+
+EmbedEntry = Tuple[str, Union[str, bytes], Optional[Dict[str, Any]]]
+# Called with (entry, exception) when an item is skipped due to an embedding
+# error; entry is the (id, value, metadata) tuple that failed.
+OnErrorCallback = Callable[[EmbedEntry, Exception], None]
 
 
 @dataclass
@@ -155,6 +160,7 @@ class Collection:
         entries: Iterable[Tuple[str, Union[str, bytes]]],
         store: bool = False,
         batch_size: int = 100,
+        on_error: Optional[OnErrorCallback] = None,
     ) -> None:
         """
         Embed multiple texts and store them in the collection with given IDs.
@@ -163,11 +169,16 @@ class Collection:
             entries (iterable): Iterable of (id: str, text: str) tuples
             store (bool, optional): Whether to store the text in the content column
             batch_size (int, optional): custom maximum batch size to use
+            on_error (callable, optional): If provided, called with
+                ``(entry, exception)`` for any item that fails to embed (for
+                example because it is too long) instead of raising. The failed
+                item is skipped and the remaining items are still embedded.
         """
         self.embed_multi_with_metadata(
             ((id, value, None) for id, value in entries),
             store=store,
             batch_size=batch_size,
+            on_error=on_error,
         )
 
     def embed_multi_with_metadata(
@@ -175,6 +186,7 @@ class Collection:
         entries: Iterable[Tuple[str, Union[str, bytes], Optional[Dict[str, Any]]]],
         store: bool = False,
         batch_size: int = 100,
+        on_error: Optional[OnErrorCallback] = None,
     ) -> None:
         """
         Embed multiple values along with metadata and store them in the collection with given IDs.
@@ -183,10 +195,15 @@ class Collection:
             entries (iterable): Iterable of (id: str, value: str or bytes, metadata: None or dict)
             store (bool, optional): Whether to store the value in the content or content_blob column
             batch_size (int, optional): custom maximum batch size to use
+            on_error (callable, optional): If provided, called with
+                ``(entry, exception)`` for any item that fails to embed (for
+                example because it is too long) instead of raising. The failed
+                item is skipped and the remaining items are still embedded.
         """
         import llm
 
-        batch_size = min(batch_size, (self.model().batch_size or batch_size))
+        model = self.model()
+        batch_size = min(batch_size, (model.batch_size or batch_size))
         iterator = iter(entries)
         collection_id = self.id
         while True:
@@ -208,9 +225,12 @@ class Collection:
                 )
             ]
             filtered_batch = [item for item in batch if item[0] not in existing_ids]
-            embeddings = list(
-                self.model().embed_multi(item[1] for item in filtered_batch)
-            )
+            if on_error is None:
+                # Default behaviour: any failure aborts the whole operation
+                embeddings = list(model.embed_multi(item[1] for item in filtered_batch))
+                pairs = list(zip(embeddings, filtered_batch))
+            else:
+                pairs = self._embed_filtered_batch(model, filtered_batch, on_error)
             with self.db.conn:
                 cast(Table, self.db["embeddings"]).insert_all(
                     (
@@ -228,12 +248,34 @@ class Collection:
                             "metadata": json.dumps(metadata) if metadata else None,
                             "updated": int(time.time()),
                         }
-                        for (embedding, (id, value, metadata)) in zip(
-                            embeddings, filtered_batch
-                        )
+                        for (embedding, (id, value, metadata)) in pairs
                     ),
                     replace=True,
                 )
+
+    def _embed_filtered_batch(
+        self,
+        model: EmbeddingModel,
+        filtered_batch: List[EmbedEntry],
+        on_error: OnErrorCallback,
+    ) -> List[Tuple[List[float], EmbedEntry]]:
+        """
+        Embed a filtered batch, but if the batch as a whole fails fall back to
+        embedding each item on its own. Items that still fail are passed to
+        ``on_error`` and skipped, so a single bad item (for example one that is
+        too long) no longer discards the entire batch.
+        """
+        try:
+            embeddings = list(model.embed_multi(item[1] for item in filtered_batch))
+            return list(zip(embeddings, filtered_batch))
+        except Exception:
+            pairs: List[Tuple[List[float], EmbedEntry]] = []
+            for item in filtered_batch:
+                try:
+                    pairs.append((model.embed(item[1]), item))
+                except Exception as item_exception:
+                    on_error(item, item_exception)
+            return pairs
 
     def similar_by_vector(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -170,6 +170,23 @@ class EmbedTextOnly(EmbedDemo):
     supports_binary = False
 
 
+class EmbedDemoErrors(EmbedDemo):
+    """
+    Like EmbedDemo but raises if any text in a batch contains "FAIL".
+
+    This mimics a provider (such as OpenAI) rejecting an entire batch request
+    because one of the items is too long.
+    """
+
+    model_id = "embed-demo-errors"
+
+    def embed_batch(self, texts):
+        texts = list(texts)
+        if any(isinstance(text, str) and "FAIL" in text for text in texts):
+            raise ValueError("Simulated embedding failure")
+        yield from super().embed_batch(texts)
+
+
 @pytest.fixture
 def embed_demo():
     return EmbedDemo()
@@ -205,6 +222,7 @@ def register_embed_demo_model(embed_demo, mock_model, async_mock_model):
             register(embed_demo)
             register(EmbedBinaryOnly())
             register(EmbedTextOnly())
+            register(EmbedDemoErrors())
 
         @llm.hookimpl
         def register_models(self, register):

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -146,6 +146,59 @@ def test_embed_multi(with_metadata, batch_size, expected_batches):
     assert collection.model().batch_count == expected_batches
 
 
+def test_embed_multi_skip_errors():
+    # on_error lets a single bad item be skipped instead of aborting everything
+    db = sqlite_utils.Database(memory=True)
+    collection = llm.Collection("test", db, model_id="embed-demo-errors")
+    entries = [
+        ("1", "hello one"),
+        ("2", "this one will FAIL"),
+        ("3", "hello three"),
+    ]
+    skipped = []
+    collection.embed_multi(
+        entries,
+        on_error=lambda entry, exception: skipped.append((entry[0], exception)),
+    )
+    # The two good items in the same batch as the bad one are still stored
+    ids = sorted(row["id"] for row in db["embeddings"].rows)
+    assert ids == ["1", "3"]
+    assert [entry_id for entry_id, _ in skipped] == ["2"]
+    assert isinstance(skipped[0][1], ValueError)
+
+
+def test_embed_multi_without_on_error_raises():
+    # Without on_error the old behaviour is preserved: the whole batch fails
+    db = sqlite_utils.Database(memory=True)
+    collection = llm.Collection("test", db, model_id="embed-demo-errors")
+    entries = [("1", "hello one"), ("2", "this one will FAIL")]
+    with pytest.raises(ValueError):
+        collection.embed_multi(entries)
+    assert db["embeddings"].count == 0
+
+
+def test_embed_multi_skip_errors_across_batches():
+    # Failures in different batches are all skipped, the rest are stored
+    db = sqlite_utils.Database(memory=True)
+    collection = llm.Collection("test", db, model_id="embed-demo-errors")
+    entries = [
+        ("1", "ok one"),
+        ("2", "FAIL two"),
+        ("3", "ok three"),
+        ("4", "ok four"),
+        ("5", "FAIL five"),
+    ]
+    skipped = []
+    collection.embed_multi(
+        entries,
+        batch_size=2,
+        on_error=lambda entry, exception: skipped.append(entry[0]),
+    )
+    ids = sorted(row["id"] for row in db["embeddings"].rows)
+    assert ids == ["1", "3", "4"]
+    assert sorted(skipped) == ["2", "5"]
+
+
 def test_collection_delete(collection):
     db = collection.db
     assert db["embeddings"].count == 2

--- a/tests/test_embed_cli.py
+++ b/tests/test_embed_cli.py
@@ -713,3 +713,53 @@ def test_duplicate_content_embedded_only_once(embed_demo):
     # Should have only embedded one more thing
     assert db["embeddings"].count == 4
     assert len(embed_demo.embedded_content) == 4
+
+
+def test_embed_multi_skip_errors_cli(tmpdir):
+    db_path = tmpdir / "embeddings.db"
+    csv_path = tmpdir / "input.csv"
+    csv_path.write_text(
+        "id,content\n1,hello one\n2,this will FAIL\n3,hello three\n", "utf-8"
+    )
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        cli,
+        [
+            "embed-multi",
+            "docs",
+            str(csv_path),
+            "-d",
+            str(db_path),
+            "-m",
+            "embed-demo-errors",
+            "--skip-errors",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    db = sqlite_utils.Database(str(db_path))
+    ids = sorted(row["id"] for row in db["embeddings"].rows)
+    assert ids == ["1", "3"]
+    assert "Skipped 1 item" in result.stderr
+    assert "2:" in result.stderr
+
+
+def test_embed_multi_without_skip_errors_cli_fails(tmpdir):
+    db_path = tmpdir / "embeddings.db"
+    csv_path = tmpdir / "input.csv"
+    csv_path.write_text("id,content\n1,hello one\n2,this will FAIL\n", "utf-8")
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        cli,
+        [
+            "embed-multi",
+            "docs",
+            str(csv_path),
+            "-d",
+            str(db_path),
+            "-m",
+            "embed-demo-errors",
+        ],
+    )
+    # Without --skip-errors the command aborts
+    assert result.exit_code != 0


### PR DESCRIPTION
Refs #1085

## Problem
`llm embed-multi` aborts the entire run if a single item is too long for the embedding model — and because the provider rejects the whole batch request, **nothing** gets stored:

```
openai.BadRequestError: Error code: 400 - ... maximum context length is 8192 tokens, however you requested 17143 ...
```

## What this does
Implements the "skip the too-long strings, embed everything else, show a warning" behaviour from this issue, as an opt-in so existing behaviour is unchanged.

- **Library:** `Collection.embed_multi()` / `embed_multi_with_metadata()` take an optional `on_error(entry, exception)` callback. When provided, a batch that fails is retried one item at a time; items that still fail are passed to `on_error` and skipped, and the rest are embedded and stored. (Roughly the optional hook @daturkel suggested.)
- **CLI:** `llm embed-multi … --skip-errors` wires that up to skip failures and warn:

```
Skipped 1 item that could not be embedded:
  doc-42: This model's maximum context length is 8192 tokens ...
```

## Design notes
- **No new dependencies.** Deliberately does *not* attempt truncation, since that needs model-specific tokenization (e.g. `tiktoken`) and, per your note, belongs in the relevant plugin rather than core `llm`.
- **Non-breaking.** Without `on_error` / `--skip-errors`, behaviour is exactly as before (the operation raises).
- Happy to change the default, rename the flag, or grow `--skip-errors` into a mode (`skip` / `error`, plus `truncate` once a plugin hook exists) if you'd prefer that shape.

## Tests & docs
- Library tests: skip-and-report, default-still-raises, failures across multiple batches.
- CLI tests: `--skip-errors` skips + warns; without it the command still fails.
- Updated `docs/embeddings/cli.md`, `docs/embeddings/python-api.md`, regenerated `docs/help.md`.

`just test` and `just lint` (black, ruff, mypy, cog) pass locally.
