### PR TITLE
[codex] Implement prompt message history CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ See also [the llm tag](https://simonwillison.net/tags/llm/) on my blog.
     * [Model options](https://llm.datasette.io/en/stable/usage.html#model-options)
     * [Attachments](https://llm.datasette.io/en/stable/usage.html#attachments)
     * [System prompts](https://llm.datasette.io/en/stable/usage.html#system-prompts)
+    * [Message histories](https://llm.datasette.io/en/stable/usage.html#message-histories)
     * [Tools](https://llm.datasette.io/en/stable/usage.html#tools)
     * [Extracting fenced code blocks](https://llm.datasette.io/en/stable/usage.html#extracting-fenced-code-blocks)
     * [Schemas](https://llm.datasette.io/en/stable/usage.html#schemas)

--- a/docs/help.md
+++ b/docs/help.md
@@ -119,6 +119,9 @@ Usage: llm prompt [OPTIONS] [PROMPT]
 
 Options:
   -s, --system TEXT               System prompt to use
+  --messages TEXT                 JSON array, path to JSON file, or - for stdin
+  -M, --message ROLE TEXT         Append a text message with role system, user
+                                  or assistant
   -m, --model TEXT                Model to use
   -d, --database FILE             Path to log database
   -q, --query TEXT                Use first model matching these strings

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -120,6 +120,241 @@ cat llm/utils.py | llm -t pytest
 ```
 See {ref}`prompt templates <prompt-templates>` for more.
 
+(usage-message-history)=
+### Message histories
+
+The `--messages` option can be used to start a prompt with an explicit list of messages, instead of a single user prompt. This is useful when you already have a transcript from another system, when you want to test how a model responds after a specific conversation history, or when you want to replay a saved structured prompt.
+
+The messages are sent to the model in the order provided. Each message has a `role` and a list of `parts`:
+
+```json
+[
+  {
+    "role": "system",
+    "parts": [
+      {
+        "type": "text",
+        "text": "You are a helpful pirate."
+      }
+    ]
+  },
+  {
+    "role": "user",
+    "parts": [
+      {
+        "type": "text",
+        "text": "What is the capital of France?"
+      }
+    ]
+  },
+  {
+    "role": "assistant",
+    "parts": [
+      {
+        "type": "text",
+        "text": "Paris, matey."
+      }
+    ]
+  },
+  {
+    "role": "user",
+    "parts": [
+      {
+        "type": "text",
+        "text": "And Germany?"
+      }
+    ]
+  }
+]
+```
+
+You can pass this JSON directly to `--messages`:
+
+```bash
+llm --messages '[
+  {
+    "role": "system",
+    "parts": [{"type": "text", "text": "You are a helpful pirate."}]
+  },
+  {
+    "role": "user",
+    "parts": [{"type": "text", "text": "What is the capital of France?"}]
+  },
+  {
+    "role": "assistant",
+    "parts": [{"type": "text", "text": "Paris, matey."}]
+  },
+  {
+    "role": "user",
+    "parts": [{"type": "text", "text": "And Germany?"}]
+  }
+]'
+```
+
+If the argument to `--messages` is the path to an existing file, LLM will read the messages from that file instead:
+
+```bash
+llm --messages messages.json
+```
+
+Use `--messages -` to read the JSON from standard input:
+
+```bash
+cat messages.json | llm --messages -
+```
+
+The parsing rules are:
+
+- `--messages -` reads JSON from standard input.
+- `--messages path/to/file.json` reads JSON from that file, if the path exists.
+- Otherwise, the argument is parsed as a JSON string.
+
+The `--messages` JSON should be an array of messages using LLM's serialized `Message` format. This is the same format produced by the Python API's `Message.to_dict()` method and accepted by `Message.from_dict()`.
+
+Each message has:
+
+- `role`: usually `system`, `user`, `assistant` or `tool`.
+- `parts`: a list of structured parts, most commonly text parts such as `{"type": "text", "text": "Hello"}`.
+
+For text-only conversations the `parts` list will usually contain a single text part. More advanced transcripts can include other part types such as `attachment`, `tool_call`, `tool_result` and `reasoning`.
+
+Here is a user message with an image attachment:
+
+```json
+[
+  {
+    "role": "user",
+    "parts": [
+      {
+        "type": "text",
+        "text": "Describe this image"
+      },
+      {
+        "type": "attachment",
+        "attachment": {
+          "path": "photo.jpg",
+          "type": "image/jpeg"
+        }
+      }
+    ]
+  }
+]
+```
+
+Attachments in messages can use `path`, `url` or base64-encoded `content`:
+
+```json
+{
+  "type": "attachment",
+  "attachment": {
+    "url": "https://static.simonwillison.net/static/2024/pelicans.jpg",
+    "type": "image/jpeg"
+  }
+}
+```
+
+For shorter text-only transcripts you can use `-M/--message`. This option takes two arguments: a role and the message text. It can be used more than once:
+
+```bash
+llm \
+  -M system "You are a helpful pirate." \
+  -M user "What is the capital of France?" \
+  -M assistant "Paris, matey." \
+  -M user "And Germany?"
+```
+
+This is equivalent to passing the JSON message list shown above. The `-M/--message` option is intended for text messages, so it supports the `system`, `user` and `assistant` roles. Use `--messages` for attachments, tool calls, tool results, reasoning parts or provider-specific metadata.
+
+You can combine `--messages` with `-M/--message` to load an existing transcript and then append one or more text messages:
+
+```bash
+llm --messages transcript.json -M user "Summarize the conversation so far"
+```
+
+You can also provide a regular prompt argument. When `--messages` or `-M/--message` is used, any prompt argument is appended as a final `user` message:
+
+```bash
+llm --messages transcript.json "Now suggest three follow-up questions"
+```
+
+If standard input is used for the prompt, that input is also appended as a final `user` message:
+
+```bash
+cat notes.txt | llm --messages transcript.json "Use these notes to answer the last question"
+```
+
+This appends one final user message containing the piped content followed by the prompt argument, matching the normal `llm` prompt behavior.
+
+The exception is `--messages -`, which uses standard input for the message JSON. In that case standard input is not also available as a prompt:
+
+```bash
+cat transcript.json | llm --messages - "Now continue"
+```
+
+When using explicit messages, options that would otherwise construct parts of the same prompt cannot be combined with `--messages` or `-M/--message`. Use messages for those inputs instead.
+
+These options are not used with explicit messages:
+
+- `-s/--system`: use a `system` message.
+- `-a/--attachment` and `--attachment-type`: use an `attachment` part.
+- `-f/--fragment` and `--system-fragment`: expand the fragment yourself and include it as a `text` part.
+
+Other prompt options still apply as usual, including `-m/--model`, `-o/--option`, `--schema`, `--no-stream`, `-x/--extract`, `--log`, `--no-log`, `--key`, `--async`, `--usage` and `-R/--hide-reasoning`.
+
+Explicit message histories are different from {ref}`continuing a conversation <usage-conversation>` using `-c/--continue` or `--cid/--conversation`. The conversation options load a previous conversation from LLM's log database and continue it, automatically using the same model if you do not specify one. The `--messages` option uses the message list you provide and starts a new logged conversation unless you disable logging with `--no-log`.
+
+If a message history contains tool calls or tool results, use the same serialized part format:
+
+```json
+[
+  {
+    "role": "user",
+    "parts": [
+      {
+        "type": "text",
+        "text": "What is 12345 * 67890?"
+      }
+    ]
+  },
+  {
+    "role": "assistant",
+    "parts": [
+      {
+        "type": "tool_call",
+        "name": "multiply",
+        "arguments": {
+          "x": 12345,
+          "y": 67890
+        },
+        "tool_call_id": "tc_01example"
+      }
+    ]
+  },
+  {
+    "role": "tool",
+    "parts": [
+      {
+        "type": "tool_result",
+        "name": "multiply",
+        "output": "838102050",
+        "tool_call_id": "tc_01example"
+      }
+    ]
+  },
+  {
+    "role": "user",
+    "parts": [
+      {
+        "type": "text",
+        "text": "Now add 1"
+      }
+    ]
+  }
+]
+```
+
+If you provide tools using `-T/--tool` or `--functions`, LLM can use those tools when continuing from a message history. For advanced tool resume workflows, include any previous assistant `tool_call` parts and matching `tool_result` parts in the message history so the model sees the same chain of events.
+
 (usage-tools)=
 ### Tools
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -132,7 +132,6 @@ The messages are sent to the model in the order provided. Each message has a `ro
     "role": "system",
     "parts": [
       {
-        "type": "text",
         "text": "You are a helpful pirate."
       }
     ]
@@ -141,7 +140,6 @@ The messages are sent to the model in the order provided. Each message has a `ro
     "role": "user",
     "parts": [
       {
-        "type": "text",
         "text": "What is the capital of France?"
       }
     ]
@@ -150,7 +148,6 @@ The messages are sent to the model in the order provided. Each message has a `ro
     "role": "assistant",
     "parts": [
       {
-        "type": "text",
         "text": "Paris, matey."
       }
     ]
@@ -159,7 +156,6 @@ The messages are sent to the model in the order provided. Each message has a `ro
     "role": "user",
     "parts": [
       {
-        "type": "text",
         "text": "And Germany?"
       }
     ]
@@ -173,19 +169,19 @@ You can pass this JSON directly to `--messages`:
 llm --messages '[
   {
     "role": "system",
-    "parts": [{"type": "text", "text": "You are a helpful pirate."}]
+    "parts": [{"text": "You are a helpful pirate."}]
   },
   {
     "role": "user",
-    "parts": [{"type": "text", "text": "What is the capital of France?"}]
+    "parts": [{"text": "What is the capital of France?"}]
   },
   {
     "role": "assistant",
-    "parts": [{"type": "text", "text": "Paris, matey."}]
+    "parts": [{"text": "Paris, matey."}]
   },
   {
     "role": "user",
-    "parts": [{"type": "text", "text": "And Germany?"}]
+    "parts": [{"text": "And Germany?"}]
   }
 ]'
 ```
@@ -208,14 +204,14 @@ The parsing rules are:
 - `--messages path/to/file.json` reads JSON from that file, if the path exists.
 - Otherwise, the argument is parsed as a JSON string.
 
-The `--messages` JSON should be an array of messages using LLM's serialized `Message` format. This is the same format produced by the Python API's `Message.to_dict()` method and accepted by `Message.from_dict()`.
+The `--messages` JSON should be an array of messages accepted by `Message.from_dict()`. The Python API's `Message.to_dict()` method produces the canonical serialized form, which includes a `type` for every part.
 
 Each message has:
 
 - `role`: usually `system`, `user`, `assistant` or `tool`.
-- `parts`: a list of structured parts, most commonly text parts such as `{"type": "text", "text": "Hello"}`.
+- `parts`: a list of structured parts, most commonly text parts such as `{"text": "Hello"}`.
 
-For text-only conversations the `parts` list will usually contain a single text part. More advanced transcripts can include other part types such as `attachment`, `tool_call`, `tool_result` and `reasoning`.
+If a part omits `type` it defaults to `text`. More advanced parts must specify their type, such as `attachment`, `tool_call`, `tool_result` or `reasoning`.
 
 Here is a user message with an image attachment:
 
@@ -225,7 +221,6 @@ Here is a user message with an image attachment:
     "role": "user",
     "parts": [
       {
-        "type": "text",
         "text": "Describe this image"
       },
       {
@@ -311,7 +306,6 @@ If a message history contains tool calls or tool results, use the same serialize
     "role": "user",
     "parts": [
       {
-        "type": "text",
         "text": "What is 12345 * 67890?"
       }
     ]
@@ -345,7 +339,6 @@ If a message history contains tool calls or tool results, use the same serialize
     "role": "user",
     "parts": [
       {
-        "type": "text",
         "text": "Now add 1"
       }
     ]

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -42,6 +42,7 @@ from llm import (
     remove_alias,
 )
 from llm.models import _BaseConversation, ChainResponse
+from llm.parts import Message, TextPart
 
 from .migrations import migrate
 from .plugins import pm, load_plugins
@@ -341,6 +342,52 @@ def schema_option(fn):
     return fn
 
 
+def _message_from_text(role: str, text: str) -> Message:
+    return Message(role=role, parts=[TextPart(text=text)])
+
+
+def _load_messages(value: str) -> List[Message]:
+    if value == "-":
+        message_json = sys.stdin.read()
+    else:
+        path = pathlib.Path(value)
+        try:
+            if path.exists():
+                try:
+                    message_json = path.read_text("utf-8")
+                except OSError as ex:
+                    raise click.ClickException(
+                        "Could not read --messages file: {}".format(ex)
+                    )
+            else:
+                message_json = value
+        except OSError:
+            # The argument is probably a long JSON string rather than a path.
+            message_json = value
+
+    try:
+        data = json.loads(message_json)
+    except json.JSONDecodeError as ex:
+        raise click.ClickException("--messages must be valid JSON: {}".format(ex))
+
+    if not isinstance(data, list):
+        raise click.ClickException("--messages must be a JSON array")
+
+    messages = []
+    for index, item in enumerate(data):
+        if not isinstance(item, dict):
+            raise click.ClickException(
+                "--messages item {} must be an object".format(index)
+            )
+        try:
+            messages.append(Message.from_dict(item))
+        except Exception as ex:
+            raise click.ClickException(
+                "Invalid --messages item {}: {}".format(index, ex)
+            )
+    return messages
+
+
 @click.group(
     cls=DefaultGroup,
     default="prompt",
@@ -378,6 +425,20 @@ def cli():
 @cli.command(name="prompt")
 @click.argument("prompt", required=False)
 @click.option("-s", "--system", help="System prompt to use")
+@click.option(
+    "messages_input",
+    "--messages",
+    help="JSON array, path to JSON file, or - for stdin",
+)
+@click.option(
+    "message_entries",
+    "-M",
+    "--message",
+    type=(click.Choice(["system", "user", "assistant"]), str),
+    multiple=True,
+    metavar="ROLE TEXT",
+    help="Append a text message with role system, user or assistant",
+)
 @click.option("model_id", "-m", "--model", help="Model to use", envvar="LLM_MODEL")
 @click.option(
     "-d",
@@ -519,6 +580,8 @@ def cli():
 def prompt(
     prompt,
     system,
+    messages_input,
+    message_entries,
     model_id,
     database,
     queries,
@@ -580,6 +643,28 @@ def prompt(
     if log and no_log:
         raise click.ClickException("--log and --no-log are mutually exclusive")
 
+    explicit_messages_requested = messages_input is not None or bool(message_entries)
+    if explicit_messages_requested:
+        disallowed_options = []
+        for option, value in (
+            ("-s/--system", system),
+            ("-a/--attachment", attachments),
+            ("--attachment-type", attachment_types),
+            ("-f/--fragment", fragments),
+            ("--system-fragment", system_fragments),
+            ("--continue", _continue),
+            ("--cid/--conversation", conversation_id),
+            ("--save", save),
+        ):
+            if value:
+                disallowed_options.append(option)
+        if disallowed_options:
+            raise click.ClickException(
+                "--messages/--message cannot be used with {}".format(
+                    ", ".join(disallowed_options)
+                )
+            )
+
     if queries and not model_id:
         # Use -q options to find model with shortest model_id
         matches = []
@@ -618,6 +703,15 @@ def prompt(
         # Convert that schema into multiple "items" of the same schema
         schema = multi_schema(schema)
 
+    explicit_messages = None
+    if explicit_messages_requested:
+        explicit_messages = []
+        if messages_input is not None:
+            explicit_messages.extend(_load_messages(messages_input))
+        explicit_messages.extend(
+            _message_from_text(role, text) for role, text in message_entries
+        )
+
     def read_prompt():
         nonlocal prompt, schema
 
@@ -640,6 +734,7 @@ def prompt(
             and not attachment_types
             and not schema
             and not fragments
+            and not explicit_messages_requested
         ):
             # Hang waiting for input to stdin (unless --save)
             prompt = sys.stdin.read()
@@ -854,6 +949,8 @@ def prompt(
         kwargs["key"] = key
 
     prompt = read_prompt()
+    if explicit_messages is not None and prompt:
+        explicit_messages.append(_message_from_text("user", prompt))
     response = None
 
     try:
@@ -903,6 +1000,7 @@ def prompt(
                 if should_stream:
                     response = prompt_method(
                         prompt,
+                        messages=explicit_messages,
                         attachments=resolved_attachments,
                         system=system,
                         schema=schema,
@@ -918,6 +1016,7 @@ def prompt(
                 else:
                     response = prompt_method(
                         prompt,
+                        messages=explicit_messages,
                         fragments=resolved_fragments,
                         attachments=resolved_attachments,
                         schema=schema,
@@ -937,6 +1036,7 @@ def prompt(
         else:
             response = prompt_method(
                 prompt,
+                messages=explicit_messages,
                 fragments=resolved_fragments,
                 attachments=resolved_attachments,
                 system=system,

--- a/llm/parts.py
+++ b/llm/parts.py
@@ -13,7 +13,7 @@ content are equal.
 
 import base64
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, cast
 
 from .models import Attachment
 from .serialization import (
@@ -63,6 +63,12 @@ class Part:
 
     @staticmethod
     def from_dict(d: PartDict) -> "Part":
+        if "type" not in d:
+            text_part = cast(TextPartDict, d)
+            return TextPart(
+                text=text_part["text"],
+                provider_metadata=text_part.get("provider_metadata"),
+            )
         if d["type"] == "text":
             return TextPart(
                 text=d["text"],

--- a/tests/test_cli_messages.py
+++ b/tests/test_cli_messages.py
@@ -1,0 +1,145 @@
+import json
+
+from click.testing import CliRunner
+
+import llm
+from llm.cli import cli
+
+
+def test_prompt_messages_json_string(mock_model):
+    mock_model.enqueue(["Berlin"])
+    messages = [
+        llm.system("You are a helpful pirate.").to_dict(),
+        llm.user("What is the capital of France?").to_dict(),
+        llm.assistant("Paris, matey.").to_dict(),
+    ]
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "prompt",
+            "-m",
+            "mock",
+            "--no-stream",
+            "--messages",
+            json.dumps(messages),
+            "And Germany?",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert result.output == "Berlin\n"
+    assert mock_model.history[0][0].messages == [
+        llm.system("You are a helpful pirate."),
+        llm.user("What is the capital of France?"),
+        llm.assistant("Paris, matey."),
+        llm.user("And Germany?"),
+    ]
+
+
+def test_prompt_messages_from_file_and_message_options(mock_model, tmp_path):
+    mock_model.enqueue(["Summary"])
+    messages_path = tmp_path / "messages.json"
+    messages_path.write_text(
+        json.dumps([llm.user("What happened?").to_dict()]), "utf-8"
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "prompt",
+            "-m",
+            "mock",
+            "--no-stream",
+            "--messages",
+            str(messages_path),
+            "-M",
+            "assistant",
+            "Lots happened.",
+            "--message",
+            "user",
+            "Summarize it.",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert result.output == "Summary\n"
+    assert mock_model.history[0][0].messages == [
+        llm.user("What happened?"),
+        llm.assistant("Lots happened."),
+        llm.user("Summarize it."),
+    ]
+
+
+def test_prompt_message_appends_prompt_from_stdin(mock_model):
+    mock_model.enqueue(["ok"])
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "prompt",
+            "-m",
+            "mock",
+            "--no-stream",
+            "-M",
+            "system",
+            "Be concise.",
+            "question",
+        ],
+        input="context",
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert result.output == "ok\n"
+    assert mock_model.history[0][0].messages == [
+        llm.system("Be concise."),
+        llm.user("context question"),
+    ]
+
+
+def test_prompt_messages_dash_reads_stdin_for_messages_not_prompt(mock_model):
+    mock_model.enqueue(["continued"])
+    messages = json.dumps([llm.user("Earlier question").to_dict()])
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "prompt",
+            "-m",
+            "mock",
+            "--no-stream",
+            "--messages",
+            "-",
+            "Now continue",
+        ],
+        input=messages,
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert result.output == "continued\n"
+    assert mock_model.history[0][0].messages == [
+        llm.user("Earlier question"),
+        llm.user("Now continue"),
+    ]
+
+
+def test_prompt_messages_cannot_use_system_option():
+    result = CliRunner().invoke(
+        cli,
+        [
+            "prompt",
+            "-m",
+            "mock",
+            "--messages",
+            "[]",
+            "-s",
+            "Use a system message instead",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "--messages/--message cannot be used with -s/--system" in result.output

--- a/tests/test_cli_messages.py
+++ b/tests/test_cli_messages.py
@@ -38,6 +38,36 @@ def test_prompt_messages_json_string(mock_model):
     ]
 
 
+def test_prompt_messages_missing_part_type_defaults_to_text(mock_model):
+    mock_model.enqueue(["continued"])
+    messages = [
+        {"role": "user", "parts": [{"text": "Earlier question"}]},
+        {"role": "assistant", "parts": [{"text": "Earlier answer"}]},
+    ]
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "prompt",
+            "-m",
+            "mock",
+            "--no-stream",
+            "--messages",
+            json.dumps(messages),
+            "Now continue",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert result.output == "continued\n"
+    assert mock_model.history[0][0].messages == [
+        llm.user("Earlier question"),
+        llm.assistant("Earlier answer"),
+        llm.user("Now continue"),
+    ]
+
+
 def test_prompt_messages_from_file_and_message_options(mock_model, tmp_path):
     mock_model.enqueue(["Summary"])
     messages_path = tmp_path / "messages.json"

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -16,6 +16,9 @@ class TestTextPart:
     def test_to_dict_shape(self):
         assert llm.parts.TextPart(text="hi").to_dict() == {"type": "text", "text": "hi"}
 
+    def test_from_dict_defaults_missing_type_to_text(self):
+        assert llm.parts.Part.from_dict({"text": "hi"}) == llm.parts.TextPart(text="hi")
+
     def test_with_provider_metadata(self):
         part = llm.parts.TextPart(
             text="hi", provider_metadata={"openai": {"flag": True}}


### PR DESCRIPTION
## Summary

This implements the documentation-driven `llm prompt` message-history workflow introduced on the branch:

- adds `--messages` to load serialized `Message` JSON from an inline string, file path, or `-` for stdin
- adds repeatable `-M/--message ROLE TEXT` entries for text-only `system`, `user`, and `assistant` messages
- appends any regular prompt input as a final `user` message when explicit messages are used
- rejects prompt-construction options that conflict with explicit message histories
- adds focused CLI tests for JSON string, file, stdin, `-M`, prompt appending, and conflict handling

## Impact

Users can replay or extend structured message histories from the CLI using the same serialized message format supported by the Python API.

## Validation

- `uv run pytest tests/test_cli_messages.py`
- `uv run pytest tests/test_cli_messages.py tests/test_parts.py tests/test_llm.py`
- `uv run pytest`