### PR TITLE
fix: follow redirects and strip charset in URL attachment handling

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -263,9 +263,12 @@ def resolve_attachment(value):
     if "://" in value:
         # Confirm URL exists and try to guess type
         try:
-            response = httpx.head(value)
+            response = httpx.head(value, follow_redirects=True)
             response.raise_for_status()
-            mimetype = response.headers.get("content-type")
+            mimetype = response.headers.get("content-type", "")
+            # Strip parameters (e.g. "charset=utf-8") so "image/jpeg; charset=utf-8"
+            # becomes "image/jpeg" for consistent matching against attachment_types.
+            mimetype = mimetype.split(";")[0].strip()
         except httpx.HTTPError as ex:
             raise AttachmentError(str(ex))
         return Attachment(type=mimetype, path=None, url=value, content=None)

--- a/llm/models.py
+++ b/llm/models.py
@@ -91,9 +91,12 @@ class Attachment:
         if self.path:
             return mimetype_from_path(self.path)
         if self.url:
-            response = httpx.head(self.url)
+            response = httpx.head(self.url, follow_redirects=True)
             response.raise_for_status()
-            return response.headers.get("content-type")
+            content_type = response.headers.get("content-type", "")
+            # Strip parameters (e.g. "charset=utf-8") so "image/jpeg; charset=utf-8"
+            # becomes "image/jpeg" for consistent matching against attachment_types.
+            return content_type.split(";")[0].strip()
         if self.content:
             return mimetype_from_string(self.content)
         raise ValueError("Attachment has no type and no content to derive it from")
@@ -105,7 +108,7 @@ class Attachment:
             if self.path:
                 content = Path(self.path).read_bytes()
             elif self.url:
-                response = httpx.get(self.url)
+                response = httpx.get(self.url, follow_redirects=True)
                 response.raise_for_status()
                 content = response.content
         return content

--- a/tests/test_attachment_url_fixes.py
+++ b/tests/test_attachment_url_fixes.py
@@ -1,0 +1,141 @@
+"""Tests for attachment URL redirect following and Content-Type charset stripping.
+
+Fixes https://github.com/simonw/llm/issues/1046
+
+Two bugs fixed:
+1. httpx.head() and httpx.get() in Attachment.resolve_type() and content_bytes()
+   did not follow redirects, causing redirected image URLs to fail.
+2. Content-Type headers from HTTP responses may include charset params like
+   "image/jpeg; charset=utf-8" which wouldn't match attachment_types sets
+   like {"image/jpeg", "image/png", ...} used by model plugins.
+"""
+import pytest
+
+import llm
+from llm.cli import resolve_attachment
+
+
+class TestAttachmentResolveTypeCharsetStripping:
+    """Content-Type headers may include charset params like
+    'image/jpeg; charset=utf-8'. These should be stripped so that
+    the type matches against model.attachment_types sets like
+    {'image/jpeg', 'image/png', ...}."""
+
+    def test_resolve_type_strips_charset_from_url_content_type(self, httpx_mock):
+        """When a URL returns Content-Type with charset, resolve_type()
+        should strip it down to just the MIME type."""
+        httpx_mock.add_response(
+            url="https://example.com/photo.jpg",
+            headers={"content-type": "image/jpeg; charset=utf-8"},
+            content=b"\xff\xd8\xff\xe0",
+        )
+        attachment = llm.Attachment(
+            type=None, path=None, url="https://example.com/photo.jpg", content=None
+        )
+        # Before the fix, this would return "image/jpeg; charset=utf-8"
+        # which wouldn't match {"image/jpeg"} in attachment_types
+        assert attachment.resolve_type() == "image/jpeg"
+
+    def test_resolve_type_preserves_plain_content_type(self, httpx_mock):
+        """When Content-Type has no charset, resolve_type() should return it as-is."""
+        httpx_mock.add_response(
+            url="https://example.com/photo.png",
+            headers={"content-type": "image/png"},
+            content=b"\x89PNG\r\n\x1a\n",
+        )
+        attachment = llm.Attachment(
+            type=None, path=None, url="https://example.com/photo.png", content=None
+        )
+        assert attachment.resolve_type() == "image/png"
+
+    def test_resolve_type_handles_multi_param_content_type(self, httpx_mock):
+        """Content-Type may have multiple parameters."""
+        httpx_mock.add_response(
+            url="https://example.com/image.webp",
+            headers={"content-type": "image/webp; charset=binary; boundary=foo"},
+            content=b"RIFF",
+        )
+        attachment = llm.Attachment(
+            type=None, path=None, url="https://example.com/image.webp", content=None
+        )
+        assert attachment.resolve_type() == "image/webp"
+
+
+class TestAttachmentFollowsRedirects:
+    """URL attachments should follow HTTP redirects when resolving
+    type and fetching content."""
+
+    def test_resolve_type_follows_redirects(self, httpx_mock):
+        """resolve_type() should follow 301/302 redirects."""
+        httpx_mock.add_response(
+            url="https://example.com/redirect",
+            status_code=302,
+            headers={"location": "https://cdn.example.com/image.jpg"},
+        )
+        httpx_mock.add_response(
+            url="https://cdn.example.com/image.jpg",
+            headers={"content-type": "image/jpeg"},
+            content=b"\xff\xd8\xff\xe0",
+        )
+        attachment = llm.Attachment(
+            type=None, path=None, url="https://example.com/redirect", content=None
+        )
+        assert attachment.resolve_type() == "image/jpeg"
+
+    def test_content_bytes_follows_redirects(self, httpx_mock):
+        """content_bytes() should follow 301/302 redirects."""
+        image_data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+        httpx_mock.add_response(
+            url="https://example.com/redirect",
+            status_code=301,
+            headers={"location": "https://cdn.example.com/image.png"},
+        )
+        httpx_mock.add_response(
+            url="https://cdn.example.com/image.png",
+            content=image_data,
+        )
+        attachment = llm.Attachment(
+            type="image/png", path=None, url="https://example.com/redirect", content=None
+        )
+        assert attachment.content_bytes() == image_data
+
+
+class TestResolveAttachmentCharsetStripping:
+    """Test the CLI's resolve_attachment function strips charset params."""
+
+    def test_resolve_attachment_strips_charset(self, httpx_mock):
+        """resolve_attachment should strip charset from Content-Type header."""
+        httpx_mock.add_response(
+            url="https://example.com/photo.jpg",
+            headers={"content-type": "image/jpeg; charset=utf-8"},
+            content=b"\xff\xd8\xff\xe0",
+        )
+        attachment = resolve_attachment("https://example.com/photo.jpg")
+        assert attachment.type == "image/jpeg"
+        assert attachment.url == "https://example.com/photo.jpg"
+
+    def test_resolve_attachment_preserves_plain_type(self, httpx_mock):
+        """resolve_attachment should preserve Content-Type without charset."""
+        httpx_mock.add_response(
+            url="https://example.com/photo.png",
+            headers={"content-type": "image/png"},
+            content=b"\x89PNG\r\n\x1a\n",
+        )
+        attachment = resolve_attachment("https://example.com/photo.png")
+        assert attachment.type == "image/png"
+
+    def test_resolve_attachment_follows_redirects(self, httpx_mock):
+        """resolve_attachment should follow 301/302 redirects when checking URL type."""
+        httpx_mock.add_response(
+            url="https://short.url/img",
+            status_code=301,
+            headers={"location": "https://cdn.example.com/image.jpg"},
+        )
+        httpx_mock.add_response(
+            url="https://cdn.example.com/image.jpg",
+            headers={"content-type": "image/jpeg"},
+            content=b"\xff\xd8\xff\xe0",
+        )
+        attachment = resolve_attachment("https://short.url/img")
+        assert attachment.type == "image/jpeg"
+        assert attachment.url == "https://short.url/img"


### PR DESCRIPTION
## Summary

Fixes #1046

When attaching images via URL, two bugs caused failures:

### Bug 1: HTTP redirects not followed
`httpx.head()` and `httpx.get()` in `Attachment.resolve_type()` and `Attachment.content_bytes()` did not follow HTTP redirects (301/302). Any image URL that redirects — CDNs, short links, etc. — would fail instead of fetching the actual image.

This is inconsistent with the fragment loader in `cli.py` which already uses `follow_redirects=True` (line 161).

### Bug 2: Content-Type charset params not stripped
HTTP responses may return `Content-Type: image/jpeg; charset=utf-8`, but this full string was stored as the attachment type. When checked against model `attachment_types` sets like `{"image/jpeg", "image/png", ...}`, the charset-augmented string would not match, causing errors like:

```
This model does not support attachments of type image/jpeg; charset=utf-8
```

### Changes

**`llm/models.py`**
- `Attachment.resolve_type()`: Added `follow_redirects=True` to `httpx.head()` and stripped charset params from Content-Type header
- `Attachment.content_bytes()`: Added `follow_redirects=True` to `httpx.get()`

**`llm/cli.py`**
- `resolve_attachment()`: Added `follow_redirects=True` to `httpx.head()` and stripped charset params from Content-Type header

### Testing

8 new tests in `tests/test_attachment_url_fixes.py`:
- 3 tests for charset stripping in `Attachment.resolve_type()`
- 2 tests for redirect following in `Attachment` class methods
- 3 tests for charset stripping and redirect following in `resolve_attachment()`

All existing tests continue to pass.

### Note on the original issue

The original report (#1046) described different OCR results between URL and filepath attachments with Ollama. Subsequent investigation by @andrejartuchov-prog found the bytes were identical between both paths, suggesting qwen2.5-VL nondeterminism rather than an attachment bug. However, this PR fixes two real, reproducible bugs in URL attachment handling that would cause failures for redirected URLs and servers returning charset params.