### PR TITLE
Recognize ${var} braced syntax in template variables

### DIFF
--- a/llm/templates.py
+++ b/llm/templates.py
@@ -86,7 +86,7 @@ class Template(BaseModel):
     def extract_vars(string_template: string.Template) -> List[str]:
         """Extract and return the list of named variable identifiers from a string.Template."""
         return [
-            match.group("named")
+            match.group("named") or match.group("braced")
             for match in string_template.pattern.finditer(string_template.template)
-            if match.group("named")
+            if match.group("named") or match.group("braced")
         ]

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -31,6 +31,22 @@ import yaml
             None,
             None,
         ),
+        # Braced ${var} syntax should behave the same as $var
+        ("S: ${input}", None, None, {}, "S: input", None, None),
+        ("Dear ${name}", None, None, {}, None, None, "Missing variables: name"),
+        ("Dear ${name}", None, None, {"name": "Alice"}, "Dear Alice", None, None),
+        ("Dear ${name}", None, {"name": "Bob"}, {}, "Dear Bob", None, None),
+        # Mix of $var and ${var}
+        ("$one and ${two}", None, None, {}, None, None, "Missing variables: one, two"),
+        (
+            "$one and ${two}",
+            None,
+            None,
+            {"one": 1, "two": 2},
+            "1 and 2",
+            None,
+            None,
+        ),
     ),
 )
 def test_template_evaluate(


### PR DESCRIPTION
## The bug

`Template.extract_vars` only collected the `named` capture group from `string.Template`'s regex, which holds `$var` matches. Braced `${var}` matches land in the `braced` group, so they were invisible to both `Template.vars()` and the missing-variable check in `interpolate()`.

`${var}` is standard, valid `string.Template` syntax, so this produces two user-facing problems:

1. **Bare traceback instead of a friendly error.** A template referencing an undefined `${var}` reaches `string.Template.substitute()` with the variable missing, which raises `KeyError`. `interpolate()` is supposed to catch missing variables up front and raise `Template.MissingVariables`, which the CLI converts into a clean `Error: Missing variables: ...` message. Because the braced var was never collected, the `KeyError` escapes and the user sees a Python traceback.

2. **`${input}` silently breaks stdin.** The CLI gates reading stdin on `"input" in template_obj.vars()`. A template using `${input}` reports no variables, so stdin is never read and the placeholder resolves to nothing.

## Root cause

`llm/templates.py`, `extract_vars`:

```python
return [
    match.group("named")
    for match in string_template.pattern.finditer(string_template.template)
    if match.group("named")
]
```

`string.Template`'s pattern has separate `named` (`$var`) and `braced` (`${var}`) groups. Only `named` was read.

## The fix

Fall back to the `braced` group so `${var}` and `$var` are treated identically:

```python
return [
    match.group("named") or match.group("braced")
    for match in string_template.pattern.finditer(string_template.template)
    if match.group("named") or match.group("braced")
]
```

## Reproduction (before the fix)

```python
from llm import Template
t = Template(name="x", prompt="Dear ${name}, welcome")
t.vars()              # set()              -> should be {"name"}
t.evaluate("hi", {})  # raises KeyError    -> should raise Template.MissingVariables
```

`$name` (unbraced) behaves correctly; only the braced form is broken — the asymmetry is the bug.

## Red -> green proof

Added cases to the existing `test_template_evaluate` parametrization in `tests/test_templates.py` covering braced substitution, braced missing-variable detection, and a mix of `$var` / `${var}`.

On `main` these fail, e.g.:

```
FAILED test_template_evaluate[$one and ${two}-...-Missing variables: one, two]
  AssertionError: assert 'Missing variables: one' == 'Missing variables: one, two'
```

(`${two}` was invisible, so only `one` was reported missing.) With the fix, the full `test_template_evaluate` set passes, and the broader template/utils/llm suites stay green.