### PR TITLE
Only register bundled OpenAI models when an OpenAI key is configured

### DIFF
--- a/docs/openai-models.md
+++ b/docs/openai-models.md
@@ -17,6 +17,8 @@ llm keys set openai
 ```
 Then paste in the API key.
 
+The bundled OpenAI models are only listed by `llm models` once an OpenAI key has been configured this way (or via the `OPENAI_API_KEY` environment variable). Without a key they are hidden, since they cannot be used. Models you add through {ref}`extra-openai-models.yaml <openai-extra-models>` are always listed regardless.
+
 (openai-models-language)=
 
 ## OpenAI language models

--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -43,6 +43,11 @@ import yaml
 
 @hookimpl
 def register_models(register):
+    # Only register bundled models when an OpenAI key is set; extra models below
+    # always load via _register.
+    _register = register
+    if not llm.get_key(key_alias="openai", env_var="OPENAI_API_KEY"):
+        register = lambda *args, **kwargs: None  # noqa: E731
     # GPT-4o
     register(
         Chat("gpt-4o", vision=True, supports_schema=True, supports_tools=True),
@@ -371,7 +376,7 @@ def register_models(register):
             chat_model.needs_key = extra_model["api_key_name"]
             if async_model:
                 async_model.needs_key = extra_model["api_key_name"]
-        register(
+        _register(
             chat_model,
             async_model,
             aliases=aliases,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,8 @@ def templates_path(user_path):
 @pytest.fixture(autouse=True)
 def env_setup(monkeypatch, user_path):
     monkeypatch.setenv("LLM_USER_PATH", str(user_path))
+    # Bundled OpenAI models need a key to register; no-key tests delete it.
+    monkeypatch.setenv("OPENAI_API_KEY", "test-openai-key")
 
 
 class MockModel(llm.Model):

--- a/tests/test_cli_openai_models.py
+++ b/tests/test_cli_openai_models.py
@@ -43,6 +43,41 @@ def test_openai_models(mocked_models):
     )
 
 
+@pytest.mark.parametrize("source", ("env", "keys_file", "none"))
+def test_bundled_openai_models_require_key(monkeypatch, tmpdir, source):
+    # Bundled models register only with an OpenAI key (env or keys.json).
+    user_dir = tmpdir / "user-dir"
+    user_dir.mkdir()
+    monkeypatch.setenv("LLM_USER_PATH", str(user_dir))
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    if source == "env":
+        monkeypatch.setenv("OPENAI_API_KEY", "x")
+    elif source == "keys_file":
+        (user_dir / "keys.json").write_text(json.dumps({"openai": "x"}), "utf-8")
+
+    model_ids = {m.model.model_id for m in llm.get_models_with_aliases()}
+    if source == "none":
+        assert "gpt-4o" not in model_ids
+        assert "gpt-5" not in model_ids
+    else:
+        assert "gpt-4o" in model_ids
+        assert "gpt-5" in model_ids
+
+
+def test_extra_openai_models_load_without_key(monkeypatch, tmpdir):
+    # Extra models load without an OpenAI key.
+    user_dir = tmpdir / "user-dir"
+    user_dir.mkdir()
+    monkeypatch.setenv("LLM_USER_PATH", str(user_dir))
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    (user_dir / "extra-openai-models.yaml").write_text(
+        "- model_id: my-local-model\n  model_name: my-local-model\n", "utf-8"
+    )
+    model_ids = {m.model.model_id for m in llm.get_models_with_aliases()}
+    assert "my-local-model" in model_ids
+    assert "gpt-4o" not in model_ids
+
+
 def test_openai_options_min_max():
     options = {
         "temperature": [0, 2],


### PR DESCRIPTION
## What

The default OpenAI plugin always registered its bundled models (`gpt-4o`, `gpt-5.x`, `o`-series, ~50 of them) even when no OpenAI API key is configured, so `llm models` listed models that can never actually be used.

This gates the bundled registrations behind a key check — present means either the `openai` entry in `keys.json` or the `OPENAI_API_KEY` env var. With no key, the bundled OpenAI models are hidden from `llm models`.

Models added via `extra-openai-models.yaml` **always** load regardless, since they often target other providers / their own keys.

## How

In `register_models()`, when no OpenAI key resolves, the local `register` is swapped for a no-op for the bundled section only; the original is kept as `_register` and used for the `extra-openai-models.yaml` loop.

## Tests

- `tests/conftest.py`: the suite exercises the bundled models, so the autouse fixture now sets a dummy `OPENAI_API_KEY`. Tests for the no-key path delete it explicitly.
- New `test_bundled_openai_models_require_key` (env / keys.json / none) and `test_extra_openai_models_load_without_key`.
- Full suite passes; `black --check` and `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)