### PR TITLE
Add llm-gonkabroker to plugin directory

### DIFF
--- a/docs/plugins/directory.md
+++ b/docs/plugins/directory.md
@@ -41,6 +41,7 @@ These plugins can be used to interact with remotely hosted models via their API:
 - **[llm-deepseek](https://github.com/abrasumente233/llm-deepseek)** adds support for the [DeepSeek](https://deepseek.com)'s DeepSeek-Chat and DeepSeek-Coder models.
 - **[llm-lambda-labs](https://github.com/simonw/llm-lambda-labs)** provides access to models hosted by [Lambda Labs](https://docs.lambdalabs.com/public-cloud/lambda-chat-api/), including the Nous Hermes 3 series.
 - **[llm-venice](https://github.com/ar-jan/llm-venice)** provides access to uncensored models hosted by privacy-focused [Venice AI](https://docs.venice.ai/), including Llama 3.1 405B.
+- **[llm-gonkabroker](https://github.com/gonkabroker/gonkabroker-integrations/tree/master/llm)** provides access to open-source models running on the decentralized [Gonka](https://gonka.ai) network, served via [Gonka Broker](https://gonkabroker.com)'s OpenAI-compatible API.
 
 If an API model host provides an OpenAI-compatible API you can also [configure LLM to talk to it](https://llm.datasette.io/en/stable/other-models.html#openai-compatible-models) without needing an extra plugin.
 


### PR DESCRIPTION
Adds `llm-gonkabroker` to the Remote APIs section of the plugin directory.

The plugin provides access to open-source models running on the decentralized Gonka network, served through Gonka Broker's OpenAI-compatible API. It is published on PyPI (`llm install llm-gonkabroker`) and registers the broker's models from its public `/v1/models` endpoint, reusing the openai_models Chat/AsyncChat base.

- PyPI: https://pypi.org/project/llm-gonkabroker/
- Source: https://github.com/gonkabroker/gonkabroker-integrations/tree/master/llm
