### PR TITLE
[codex] Fall back to file extension for attachment mimetypes

### DIFF
--- a/llm/utils.py
+++ b/llm/utils.py
@@ -3,6 +3,7 @@ import hashlib
 import httpx
 import itertools
 import json
+import mimetypes
 import pathlib
 import puremagic
 import re
@@ -45,9 +46,11 @@ def mimetype_from_string(content) -> Optional[str]:
 def mimetype_from_path(path) -> Optional[str]:
     try:
         type_ = puremagic.from_file(path, mime=True)
-        return MIME_TYPE_FIXES.get(type_, type_)
     except puremagic.PureError:
-        return None
+        type_ = None
+    if not type_:
+        type_ = mimetypes.guess_type(path)[0]
+    return MIME_TYPE_FIXES.get(type_, type_) if type_ else None
 
 
 def dicts_to_table_string(

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -3,7 +3,7 @@ import os
 import sys
 from unittest.mock import ANY
 import llm
-from llm import cli
+from llm import cli, utils
 import pytest
 
 TINY_PNG = (
@@ -17,6 +17,25 @@ TINY_PNG = (
 )
 
 TINY_WAV = b"RIFF$\x00\x00\x00WAVEfmt \x10\x00\x00\x00\x01\x00\x01\x00D\xac\x00\x00"
+
+
+@pytest.mark.parametrize(
+    "puremagic_result", ["", utils.puremagic.PureError("no match")]
+)
+def test_mimetype_from_path_falls_back_to_file_extension(
+    monkeypatch, tmp_path, puremagic_result
+):
+    path = tmp_path / "video.mp4"
+    path.write_bytes(b"not enough data for magic detection")
+
+    def fake_from_file(path, mime=True):
+        if isinstance(puremagic_result, utils.puremagic.PureError):
+            raise puremagic_result
+        return puremagic_result
+
+    monkeypatch.setattr(utils.puremagic, "from_file", fake_from_file)
+
+    assert utils.mimetype_from_path(path) == "video/mp4"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- fall back to `mimetypes.guess_type()` when `puremagic.from_file(..., mime=True)` raises `PureError` or returns an empty value
- keep the existing `puremagic` detection and MIME fixups for successful detections
- add regression coverage for both empty-string and exception fallback paths

Fixes #1340.

## Validation

- `uv run pytest tests/test_attachments.py -q`
- `uv run ruff check llm/utils.py tests/test_attachments.py`
- `uv run black --fast --check llm/utils.py tests/test_attachments.py`
- `uv run pytest tests/test_attachments.py tests/test_cli_openai_models.py tests/test_llm.py -q`
- `git diff --check`