### PR TITLE
Fix truncate_string returning more than max_length characters

### DIFF
--- a/llm/utils.py
+++ b/llm/utils.py
@@ -470,6 +470,11 @@ def truncate_string(
         # Subtract 5 for the "... " separator
         cutoff = (max_length - 5) // 2
         return text[:cutoff] + "... " + text[-cutoff:]
+    elif max_length < 3:
+        # No room for the "..." marker, so hard-truncate to fit. Without this
+        # max_length - 3 goes negative and slices from the end, returning more
+        # than max_length characters.
+        return text[:max_length]
     else:
         # Fall back to simple truncation for very small max_length
         return text[: max_length - 3] + "..."

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -288,6 +288,12 @@ def test_schema_dsl_multi():
             "12345...",
         ),  # Too small for keep_end, use regular
         ("1234567890", 9, False, True, "12... 90"),  # Just enough for keep_end
+        # max_length too small to fit the "..." marker: the result must still
+        # honor the limit rather than returning more than max_length characters.
+        ("Hello, world!", 2, False, False, "He"),
+        ("Hello, world!", 1, False, False, "H"),
+        ("Hello, world!", 0, False, False, ""),
+        ("Hello, world!", 2, False, True, "He"),  # keep_end with no room either
     ],
 )
 def test_truncate_string(text, max_length, normalize_whitespace, keep_end, expected):


### PR DESCRIPTION
`truncate_string` can return a string longer than `max_length` — longer than the input, even — when `max_length` is below 3.

The simple-truncation branch does `text[:max_length - 3] + "..."`. With `max_length` of 0, 1 or 2 the slice index goes negative, so `text[:max_length - 3]` slices from the *end* and keeps almost the whole string before the ellipsis is appended. For instance `truncate_string("Hello, world!", 2)` returns `"Hello, world..."`.

There's no room for the `...` marker below 3 characters, so I hard-truncate to `text[:max_length]` there instead. Behaviour for `max_length >= 3` is unchanged. Added a few small-`max_length` cases to the existing `test_truncate_string` parametrize.