### PR TITLE
Preserve empty attachment content

### DIFF
--- a/llm/models.py
+++ b/llm/models.py
@@ -73,7 +73,7 @@ class Attachment:
     def id(self):
         # Hash of the binary content, or of '{"url": "https://..."}' for URL attachments
         if self._id is None:
-            if self.content:
+            if self.content is not None:
                 self._id = hashlib.sha256(self.content).hexdigest()
             elif self.path:
                 self._id = hashlib.sha256(Path(self.path).read_bytes()).hexdigest()
@@ -101,7 +101,7 @@ class Attachment:
     def content_bytes(self):
         "Return the binary content, reading from path or URL if needed."
         content = self.content
-        if not content:
+        if content is None:
             if self.path:
                 content = Path(self.path).read_bytes()
             elif self.url:
@@ -122,7 +122,7 @@ class Attachment:
             info.append(f'path="{self.path}"')
         if self.url:
             info.append(f'url="{self.url}"')
-        if self.content:
+        if self.content is not None:
             info.append(f"content={len(self.content)} bytes")
         return " ".join(info) + ">"
 

--- a/llm/parts.py
+++ b/llm/parts.py
@@ -36,7 +36,7 @@ def _attachment_to_dict(att: Attachment) -> AttachmentDict:
         d["url"] = att.url
     if att.path:
         d["path"] = att.path
-    if att.content:
+    if att.content is not None:
         d["content"] = base64.b64encode(att.content).decode("ascii")
     return d  # type: ignore[return-value]
 

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -123,6 +123,12 @@ class TestAttachmentPart:
         restored = llm.parts.Part.from_dict(json.loads(json.dumps(part.to_dict())))
         assert restored.attachment.content == b"\x00\x01\x02"
 
+    def test_roundtrip_with_empty_bytes(self):
+        att = llm.Attachment(type="application/octet-stream", content=b"")
+        part = llm.parts.AttachmentPart(attachment=att)
+        restored = llm.parts.Part.from_dict(json.loads(json.dumps(part.to_dict())))
+        assert restored.attachment.content == b""
+
 
 class TestUnknownPart:
     def test_from_dict_unknown_type_raises(self):


### PR DESCRIPTION
Fixes attachment serialization for explicit empty byte content. Before this change, an Attachment with empty bytes was treated like missing content in truthiness checks, so AttachmentPart.to_dict omitted it and JSON round trips restored None instead of empty bytes. Tests: uv run pytest tests/test_parts.py; git diff --check.