### PR TITLE
Return 0.0 from cosine_similarity for zero-magnitude vectors

### DIFF
--- a/llm/__init__.py
+++ b/llm/__init__.py
@@ -476,6 +476,10 @@ def cosine_similarity(a, b):
     dot_product = sum(x * y for x, y in zip(a, b))
     magnitude_a = sum(x * x for x in a) ** 0.5
     magnitude_b = sum(x * x for x in b) ** 0.5
+    if magnitude_a == 0 or magnitude_b == 0:
+        # A zero-magnitude vector has no direction; treat similarity as 0
+        # rather than raising ZeroDivisionError.
+        return 0.0
     return dot_product / (magnitude_a * magnitude_b)
 
 

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -11,6 +11,15 @@ def test_demo_plugin():
     assert model.embed("hello world") == [5, 5] + [0] * 14
 
 
+def test_cosine_similarity_zero_vector():
+    # A zero-magnitude vector has no direction; cosine_similarity should return
+    # 0.0 rather than raising ZeroDivisionError (it's used by similar_by_vector).
+    assert llm.cosine_similarity([0.0, 0.0], [1.0, 2.0]) == 0.0
+    assert llm.cosine_similarity([1.0, 2.0], [0.0, 0.0]) == 0.0
+    # non-zero vectors still work
+    assert llm.cosine_similarity([1.0, 0.0], [2.0, 0.0]) == pytest.approx(1.0)
+
+
 @pytest.mark.parametrize(
     "batch_size,expected_batches",
     (


### PR DESCRIPTION
cosine_similarity raised ZeroDivisionError when either vector has zero magnitude — e.g. a degenerate/empty embedding stored in the DB, which similar_by_vector then compares against, crashing the similarity search. Return 0.0 for a zero vector instead (the usual convention). Added a test.