### PR TITLE
Add OpenAI Responses client timeout options

### DIFF
--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -1006,6 +1006,7 @@ def build_options_class(
     image_detail_original=False,
     chat_completions=False,
     service_tier=False,
+    responses_client_options=False,
 ):
     fields = {
         "json_object": (
@@ -1026,6 +1027,23 @@ def build_options_class(
                     "off; set to true to fall back to the Chat Completions code "
                     "path for compatibility."
                 ),
+                default=None,
+            ),
+        )
+    if responses_client_options:
+        fields["timeout"] = (
+            float | None,
+            Field(
+                description="Request timeout in seconds for the OpenAI client.",
+                gt=0,
+                default=None,
+            ),
+        )
+        fields["max_retries"] = (
+            int | None,
+            Field(
+                description="Maximum number of OpenAI client retries.",
+                ge=0,
                 default=None,
             ),
         )
@@ -1314,7 +1332,7 @@ class _Shared:
             input=input_tokens, output=output_tokens, details=simplify_usage_dict(usage)
         )
 
-    def get_client(self, key, *, async_=False):
+    def get_client(self, key, *, async_=False, timeout=None, max_retries=None):
         kwargs = {}
         if self.api_base:
             kwargs["base_url"] = self.api_base
@@ -1332,6 +1350,10 @@ class _Shared:
             kwargs["api_key"] = "DUMMY_KEY"
         if self.headers:
             kwargs["default_headers"] = self.headers
+        if timeout is not None:
+            kwargs["timeout"] = timeout
+        if max_retries is not None:
+            kwargs["max_retries"] = max_retries
         if os.environ.get("LLM_OPENAI_SHOW_RESPONSES"):
             kwargs["http_client"] = logging_client()
         if async_:
@@ -1347,6 +1369,8 @@ class _Shared:
         # Responses models reuse their Options object when explicitly routed
         # through the Chat Completions compatibility path.
         kwargs.pop("reasoning_summary", None)
+        kwargs.pop("timeout", None)
+        kwargs.pop("max_retries", None)
         if "max_tokens" not in kwargs and self.default_max_tokens is not None:
             kwargs["max_tokens"] = self.default_max_tokens
         if json_object:
@@ -2040,6 +2064,8 @@ class _SharedResponses(_Shared):
         opts.pop("json_object", None)
         opts.pop("chat_completions", None)
         opts.pop("image_detail", None)
+        opts.pop("timeout", None)
+        opts.pop("max_retries", None)
         max_tokens = opts.pop("max_tokens", None)
         reasoning_effort = opts.pop("reasoning_effort", None)
         reasoning_summary = opts.pop("reasoning_summary", None)
@@ -2473,6 +2499,7 @@ class Responses(_SharedResponses, KeyModel):
             image_detail_original=image_detail_original,
             chat_completions=True,
             service_tier=service_tier,
+            responses_client_options=True,
         )
 
     def execute(
@@ -2500,7 +2527,11 @@ class Responses(_SharedResponses, KeyModel):
         )
         kwargs = self._finalize_responses_kwargs(prompt, stream, instructions)
 
-        client = self.get_client(key)
+        client = self.get_client(
+            key,
+            timeout=getattr(prompt.options, "timeout", None),
+            max_retries=getattr(prompt.options, "max_retries", None),
+        )
         usage = None
         had_reasoning = False
         if stream:
@@ -2717,6 +2748,7 @@ class AsyncResponses(_SharedResponses, AsyncKeyModel):
             image_detail_original=image_detail_original,
             chat_completions=True,
             service_tier=service_tier,
+            responses_client_options=True,
         )
 
     async def execute(
@@ -2747,7 +2779,12 @@ class AsyncResponses(_SharedResponses, AsyncKeyModel):
         )
         kwargs = self._finalize_responses_kwargs(prompt, stream, instructions)
 
-        client = self.get_client(key, async_=True)
+        client = self.get_client(
+            key,
+            async_=True,
+            timeout=getattr(prompt.options, "timeout", None),
+            max_retries=getattr(prompt.options, "max_retries", None),
+        )
         usage = None
         had_reasoning = False
         if stream:

--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -572,6 +572,7 @@ def build_options_class(
     verbosity=False,
     image_detail_original=False,
     chat_completions=False,
+    responses_client_options=False,
 ):
     fields = {
         "json_object": (
@@ -592,6 +593,23 @@ def build_options_class(
                     "off; set to true to fall back to the Chat Completions code "
                     "path for compatibility."
                 ),
+                default=None,
+            ),
+        )
+    if responses_client_options:
+        fields["timeout"] = (
+            float | None,
+            Field(
+                description="Request timeout in seconds for the OpenAI client.",
+                gt=0,
+                default=None,
+            ),
+        )
+        fields["max_retries"] = (
+            int | None,
+            Field(
+                description="Maximum number of OpenAI client retries.",
+                ge=0,
                 default=None,
             ),
         )
@@ -838,7 +856,7 @@ class _Shared:
             input=input_tokens, output=output_tokens, details=simplify_usage_dict(usage)
         )
 
-    def get_client(self, key, *, async_=False):
+    def get_client(self, key, *, async_=False, timeout=None, max_retries=None):
         kwargs = {}
         if self.api_base:
             kwargs["base_url"] = self.api_base
@@ -856,6 +874,10 @@ class _Shared:
             kwargs["api_key"] = "DUMMY_KEY"
         if self.headers:
             kwargs["default_headers"] = self.headers
+        if timeout is not None:
+            kwargs["timeout"] = timeout
+        if max_retries is not None:
+            kwargs["max_retries"] = max_retries
         if os.environ.get("LLM_OPENAI_SHOW_RESPONSES"):
             kwargs["http_client"] = logging_client()
         if async_:
@@ -868,6 +890,8 @@ class _Shared:
         json_object = kwargs.pop("json_object", None)
         kwargs.pop("image_detail", None)
         kwargs.pop("chat_completions", None)
+        kwargs.pop("timeout", None)
+        kwargs.pop("max_retries", None)
         if "max_tokens" not in kwargs and self.default_max_tokens is not None:
             kwargs["max_tokens"] = self.default_max_tokens
         if json_object:
@@ -1292,6 +1316,8 @@ class _SharedResponses(_Shared):
         opts.pop("json_object", None)
         opts.pop("chat_completions", None)
         opts.pop("image_detail", None)
+        opts.pop("timeout", None)
+        opts.pop("max_retries", None)
         max_tokens = opts.pop("max_tokens", None)
         reasoning_effort = opts.pop("reasoning_effort", None)
         verbosity = opts.pop("verbosity", None)
@@ -1468,6 +1494,7 @@ class Responses(_SharedResponses, KeyModel):
             verbosity=verbosity,
             image_detail_original=image_detail_original,
             chat_completions=True,
+            responses_client_options=True,
         )
 
     def execute(
@@ -1499,7 +1526,11 @@ class Responses(_SharedResponses, KeyModel):
         if self._reasoning:
             kwargs["include"] = ["reasoning.encrypted_content"]
 
-        client = self.get_client(key)
+        client = self.get_client(
+            key,
+            timeout=getattr(prompt.options, "timeout", None),
+            max_retries=getattr(prompt.options, "max_retries", None),
+        )
         usage = None
         had_reasoning = False
         if stream:
@@ -1695,6 +1726,7 @@ class AsyncResponses(_SharedResponses, AsyncKeyModel):
             verbosity=verbosity,
             image_detail_original=image_detail_original,
             chat_completions=True,
+            responses_client_options=True,
         )
 
     async def execute(
@@ -1729,7 +1761,12 @@ class AsyncResponses(_SharedResponses, AsyncKeyModel):
         if self._reasoning:
             kwargs["include"] = ["reasoning.encrypted_content"]
 
-        client = self.get_client(key, async_=True)
+        client = self.get_client(
+            key,
+            async_=True,
+            timeout=getattr(prompt.options, "timeout", None),
+            max_retries=getattr(prompt.options, "max_retries", None),
+        )
         usage = None
         had_reasoning = False
         if stream:

--- a/tests/test_cli_openai_models.py
+++ b/tests/test_cli_openai_models.py
@@ -135,6 +135,12 @@ def test_gpt5_verbosity_option_is_sent_to_openai_chat_completions(httpx_mock):
             "-o",
             "verbosity",
             "high",
+            "-o",
+            "timeout",
+            "7200",
+            "-o",
+            "max_retries",
+            "0",
             "--no-stream",
             "--key",
             "x",
@@ -146,6 +152,8 @@ def test_gpt5_verbosity_option_is_sent_to_openai_chat_completions(httpx_mock):
     request_body = json.loads(httpx_mock.get_requests()[-1].content)
     assert request_body["verbosity"] == "high"
     assert "text" not in request_body
+    assert "timeout" not in request_body
+    assert "max_retries" not in request_body
 
 
 def test_gpt5_verbosity_option_is_sent_to_openai_responses_by_default(httpx_mock):
@@ -190,6 +198,12 @@ def test_gpt5_verbosity_option_is_sent_to_openai_responses_by_default(httpx_mock
             "-o",
             "verbosity",
             "high",
+            "-o",
+            "timeout",
+            "7200",
+            "-o",
+            "max_retries",
+            "0",
             "--no-stream",
             "--key",
             "x",
@@ -202,6 +216,8 @@ def test_gpt5_verbosity_option_is_sent_to_openai_responses_by_default(httpx_mock
     assert request_body["text"]["verbosity"] == "high"
     assert request_body["include"] == ["reasoning.encrypted_content"]
     assert "verbosity" not in request_body
+    assert "timeout" not in request_body
+    assert "max_retries" not in request_body
 
 
 def test_gpt5_verbosity_option_validates_allowed_values():

--- a/tests/test_openai_responses.py
+++ b/tests/test_openai_responses.py
@@ -8,6 +8,7 @@ from pytest_httpx import IteratorStream
 
 import llm
 from llm.default_plugins.openai_models import CodeInterpreter, Responses, WebSearch
+from llm.default_plugins import openai_models
 
 API_KEY = os.environ.get("PYTEST_OPENAI_API_KEY", None) or "badkey"
 
@@ -577,6 +578,38 @@ def test_responses_model_is_registered():
         "reasoning_summary"
         not in Chat("reasoning-chat-model", reasoning=True).Options.model_fields
     )
+    assert "timeout" in model.Options.model_fields
+    assert "max_retries" in model.Options.model_fields
+
+    async_model = llm.get_async_model("gpt-5.5")
+    assert "timeout" in async_model.Options.model_fields
+    assert "max_retries" in async_model.Options.model_fields
+
+
+def test_responses_client_options_are_passed_to_openai_clients(monkeypatch):
+    captured_sync = {}
+    captured_async = {}
+
+    class FakeOpenAI:
+        def __init__(self, **kwargs):
+            captured_sync.update(kwargs)
+
+    class FakeAsyncOpenAI:
+        def __init__(self, **kwargs):
+            captured_async.update(kwargs)
+
+    monkeypatch.setattr(openai_models.openai, "OpenAI", FakeOpenAI)
+    monkeypatch.setattr(openai_models.openai, "AsyncOpenAI", FakeAsyncOpenAI)
+
+    model = llm.get_model("gpt-5.5")
+    model.get_client("test-key", timeout=7200.0, max_retries=0)
+    assert captured_sync["timeout"] == 7200.0
+    assert captured_sync["max_retries"] == 0
+
+    async_model = llm.get_async_model("gpt-5.5")
+    async_model.get_client("test-key", async_=True, timeout=7200.0, max_retries=0)
+    assert captured_async["timeout"] == 7200.0
+    assert captured_async["max_retries"] == 0
 
 
 def test_chat_completions_opt_out_dispatches_to_chat(httpx_mock):
@@ -890,6 +923,22 @@ def test_responses_kwargs_packs_reasoning_and_verbosity():
     kwargs = model._build_responses_kwargs(p, stream=False)
     assert kwargs["reasoning"] == {"summary": "auto", "effort": "low"}
     assert kwargs["text"]["verbosity"] == "low"
+
+
+def test_responses_client_options_do_not_leak_into_request_kwargs():
+    model = llm.get_model("gpt-5.5")
+    options = model.Options(timeout=7200, max_retries=0)
+
+    class FakePrompt:
+        pass
+
+    p = FakePrompt()
+    p.options = options
+    p.tools = []
+    p.schema = None
+    kwargs = model._build_responses_kwargs(p, stream=False)
+    assert "timeout" not in kwargs
+    assert "max_retries" not in kwargs
 
 
 def test_responses_kwargs_sets_reasoning_summary_without_effort():

--- a/tests/test_openai_responses.py
+++ b/tests/test_openai_responses.py
@@ -7,6 +7,7 @@ import pytest
 from pytest_httpx import IteratorStream
 
 import llm
+from llm.default_plugins import openai_models
 
 API_KEY = os.environ.get("PYTEST_OPENAI_API_KEY", None) or "badkey"
 
@@ -69,6 +70,38 @@ def test_responses_model_is_registered():
     assert "Responses" in type(model).__name__
     # The chat_completions opt-out option must be exposed.
     assert "chat_completions" in model.Options.model_fields
+    assert "timeout" in model.Options.model_fields
+    assert "max_retries" in model.Options.model_fields
+
+    async_model = llm.get_async_model("gpt-5.5")
+    assert "timeout" in async_model.Options.model_fields
+    assert "max_retries" in async_model.Options.model_fields
+
+
+def test_responses_client_options_are_passed_to_openai_clients(monkeypatch):
+    captured_sync = {}
+    captured_async = {}
+
+    class FakeOpenAI:
+        def __init__(self, **kwargs):
+            captured_sync.update(kwargs)
+
+    class FakeAsyncOpenAI:
+        def __init__(self, **kwargs):
+            captured_async.update(kwargs)
+
+    monkeypatch.setattr(openai_models.openai, "OpenAI", FakeOpenAI)
+    monkeypatch.setattr(openai_models.openai, "AsyncOpenAI", FakeAsyncOpenAI)
+
+    model = llm.get_model("gpt-5.5")
+    model.get_client("test-key", timeout=7200.0, max_retries=0)
+    assert captured_sync["timeout"] == 7200.0
+    assert captured_sync["max_retries"] == 0
+
+    async_model = llm.get_async_model("gpt-5.5")
+    async_model.get_client("test-key", async_=True, timeout=7200.0, max_retries=0)
+    assert captured_async["timeout"] == 7200.0
+    assert captured_async["max_retries"] == 0
 
 
 def test_chat_completions_opt_out_dispatches_to_chat(httpx_mock):
@@ -374,6 +407,22 @@ def test_responses_kwargs_packs_reasoning_and_verbosity():
     kwargs = model._build_responses_kwargs(p, stream=False)
     assert kwargs["reasoning"] == {"summary": "auto", "effort": "low"}
     assert kwargs["text"]["verbosity"] == "low"
+
+
+def test_responses_client_options_do_not_leak_into_request_kwargs():
+    model = llm.get_model("gpt-5.5")
+    options = model.Options(timeout=7200, max_retries=0)
+
+    class FakePrompt:
+        pass
+
+    p = FakePrompt()
+    p.options = options
+    p.tools = []
+    p.schema = None
+    kwargs = model._build_responses_kwargs(p, stream=False)
+    assert "timeout" not in kwargs
+    assert "max_retries" not in kwargs
 
 
 def test_responses_kwargs_sets_reasoning_summary_without_effort():


### PR DESCRIPTION
## Summary
- add `timeout` and `max_retries` options for Responses-routed OpenAI models
- pass those options to `OpenAI(...)` / `AsyncOpenAI(...)` client construction
- keep those client-only options out of both Responses and fallback Chat Completions request bodies

Closes #1504

## Tests
- `python -m pytest tests/test_openai_responses.py tests/test_cli_openai_models.py -q`
- `python -m ruff check llm/default_plugins/openai_models.py tests/test_openai_responses.py tests/test_cli_openai_models.py`
- `python -m black --check llm/default_plugins/openai_models.py tests/test_openai_responses.py tests/test_cli_openai_models.py`
- `git diff --check`