### PR TITLE
Preserve streaming timings from OpenAI-compatible providers.

### DIFF
--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -1986,8 +1986,12 @@ def combine_chunks(chunks: List) -> dict:
     # those later on
     logprobs = []
     usage = {}
+    provider_extras = {}
 
     for item in chunks:
+        item_dump = item.model_dump()
+        if item_dump.get("timings") is not None:
+            provider_extras["timings"] = item_dump["timings"]
         if item.usage:
             usage = item.usage.model_dump()
         for choice in item.choices:
@@ -2017,6 +2021,7 @@ def combine_chunks(chunks: List) -> dict:
     }
     if logprobs:
         combined["logprobs"] = logprobs
+    combined.update(provider_extras)
     if chunks:
         for key in ("id", "object", "model", "created", "index"):
             value = getattr(chunks[0], key, None)

--- a/tests/test_cli_openai_models.py
+++ b/tests/test_cli_openai_models.py
@@ -2,6 +2,8 @@ from click.testing import CliRunner
 import json
 import llm
 from llm.cli import cli
+from llm.default_plugins.openai_models import combine_chunks
+from openai.types.chat.chat_completion_chunk import ChatCompletionChunk
 import pytest
 import sqlite_utils
 
@@ -41,6 +43,52 @@ def test_openai_models(mocked_models):
         "ada:2020-05-03        openai      2020-05-03T20:26:40+00:00\n"
         "babbage:2020-05-03    openai      2020-05-03T20:26:40+00:00\n"
     )
+
+
+def test_combine_chunks_preserves_streaming_timings():
+    chunks = [
+        ChatCompletionChunk.model_validate(
+            {
+                "id": "chatcmpl-llamacpp",
+                "object": "chat.completion.chunk",
+                "created": 1779911036,
+                "model": "qwen36",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"role": "assistant", "content": "Hi"},
+                        "finish_reason": None,
+                    }
+                ],
+            }
+        ),
+        ChatCompletionChunk.model_validate(
+            {
+                "id": "chatcmpl-llamacpp",
+                "object": "chat.completion.chunk",
+                "created": 1779911036,
+                "model": "qwen36",
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 22,
+                    "completion_tokens": 7,
+                    "total_tokens": 29,
+                },
+                "timings": {
+                    "prompt_per_second": 9.953251387913042,
+                    "predicted_per_second": 6.667936749857116,
+                },
+            }
+        ),
+    ]
+
+    combined = combine_chunks(chunks)
+
+    assert combined["content"] == "Hi"
+    assert combined["usage"]["prompt_tokens"] == 22
+    assert combined["usage"]["completion_tokens"] == 7
+    assert combined["timings"]["prompt_per_second"] == 9.953251387913042
+    assert combined["timings"]["predicted_per_second"] == 6.667936749857116
 
 
 def test_openai_options_min_max():


### PR DESCRIPTION
llama.cpp's OpenAI-compatible streaming endpoint can include token/sec metrics in a top-level `timings` field on the final streamed chunk. `llm` was already preserving usage from that chunk, but `combine_chunks()` discarded provider-specific timing metadata, so `llm logs --json` could not show the throughput data even when the provider returned it.

In this patch, `timings` is captured while combining streamed chunks and include it in the persisted response JSON. Add a regression test using a llama.cpp-style streaming response.

Co-Authored-By: Codex (GPT-5.5)