### PR TITLE
Document uv upgrade caveat for installed plugins

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -33,6 +33,13 @@ For `uv`:
 ```bash
 uv tool upgrade llm
 ```
+If you have installed plugins using `llm install ...`, `uv tool upgrade llm`
+may remove those plugins while replacing the tool environment.
+Upgrade LLM from inside its own environment instead:
+```bash
+llm install -U llm
+```
+Or reinstall your plugins after running `uv tool upgrade llm`.
 For Homebrew:
 ```bash
 brew upgrade llm


### PR DESCRIPTION
## Summary

- Document that `uv tool upgrade llm` may remove plugins installed with `llm install ...` while replacing the tool environment.
- Suggest upgrading from inside the existing LLM environment with `llm install -U llm`, or reinstalling plugins after the uv upgrade.

Fixes #1113.

## Testing

- Built the Sphinx HTML docs with warnings treated as errors using local target-installed dependencies:
  `python -c "import sys; sys.path.insert(0, r'.docs-deps'); from sphinx.cmd.build import main; raise SystemExit(main(['-W','-b','html','docs','docs/_build/codex-html-escalated']))"`