### PR TITLE
Fix fragment filter using OR instead of EXISTS...UNION

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1780,19 +1780,22 @@ def logs_list(
 
         for i, fragment_hash in enumerate(fragment_hashes):
             exists_clause = f"""
-            exists (
-                select 1 from prompt_fragments
-                where prompt_fragments.response_id = responses.id
-                and prompt_fragments.fragment_id in (
-                    select fragments.id from fragments
-                    where hash = :f{i}
+            (
+                exists (
+                    select 1 from prompt_fragments
+                    where prompt_fragments.response_id = responses.id
+                    and prompt_fragments.fragment_id in (
+                        select fragments.id from fragments
+                        where hash = :f{i}
+                    )
                 )
-                union
-                select 1 from system_fragments
-                where system_fragments.response_id = responses.id
-                and system_fragments.fragment_id in (
-                    select fragments.id from fragments
-                    where hash = :f{i}
+                or exists (
+                    select 1 from system_fragments
+                    where system_fragments.response_id = responses.id
+                    and system_fragments.fragment_id in (
+                        select fragments.id from fragments
+                        where hash = :f{i}
+                    )
                 )
             )
             """


### PR DESCRIPTION
Fixes #1511.

The `-f`/`--fragment` filter on `llm logs` was building a single `EXISTS(...)` wrapping a `UNION` of two correlated subqueries (one against `prompt_fragments`, one against `system_fragments`). On SQLite 3.51.0 that combination silently drops matches once both tables have a matching row somewhere, even if only one of them actually correlates to the response being checked - see the issue for a minimal repro that has nothing to do with this codebase.

The fix here just swaps it for `(exists (...) or exists (...))`, which is the same logic without going through a compound `SELECT` inside the `EXISTS`. No behavior change intended beyond "it actually filters correctly now."

Before this change, `tests/test_llm_logs.py` had 5 failing tests on my machine (all fragment-filter related). After the change the full suite passes: 760 passed, 1 skipped, 8 xfailed, 13 xpassed.
