### PR TITLE
Refresh stored embedding rows when store or metadata changes

### DIFF
--- a/llm/embeddings.py
+++ b/llm/embeddings.py
@@ -22,6 +22,42 @@ class Collection:
     class DoesNotExist(Exception):
         pass
 
+    @staticmethod
+    def _stored_fields(
+        value: Union[str, bytes],
+        metadata: Optional[Dict[str, Any]],
+        store: bool,
+    ) -> Dict[str, Any]:
+        return {
+            "content": value if (store and isinstance(value, str)) else None,
+            "content_blob": value if (store and isinstance(value, bytes)) else None,
+            "metadata": json.dumps(metadata) if metadata else None,
+        }
+
+    def _update_stored_fields(
+        self,
+        id: str,
+        content_hash: bytes,
+        fields: Dict[str, Any],
+        updated: int,
+    ) -> None:
+        self.db.execute(
+            """
+            update embeddings
+            set content = ?, content_blob = ?, metadata = ?, updated = ?
+            where collection_id = ? and id = ? and content_hash = ?
+            """,
+            [
+                fields["content"],
+                fields["content_blob"],
+                fields["metadata"],
+                updated,
+                self.id,
+                id,
+                content_hash,
+            ],
+        )
+
     def __init__(
         self,
         name: str,
@@ -132,19 +168,24 @@ class Collection:
 
         content_hash = self.content_hash(value)
         if self.db["embeddings"].count_where(
-            "content_hash = ? and collection_id = ?", [content_hash, self.id]
+            "id = ? and content_hash = ? and collection_id = ?",
+            [id, content_hash, self.id],
         ):
+            fields = self._stored_fields(value, metadata, store)
+            with self.db.conn:
+                self._update_stored_fields(id, content_hash, fields, int(time.time()))
             return
         embedding = self.model().embed(value)
+        fields = self._stored_fields(value, metadata, store)
         cast(Table, self.db["embeddings"]).insert(
             {
                 "collection_id": self.id,
                 "id": id,
                 "embedding": encode(embedding),
-                "content": value if (store and isinstance(value, str)) else None,
-                "content_blob": value if (store and isinstance(value, bytes)) else None,
+                "content": fields["content"],
+                "content_blob": fields["content_blob"],
                 "content_hash": content_hash,
-                "metadata": json.dumps(metadata) if metadata else None,
+                "metadata": fields["metadata"],
                 "updated": int(time.time()),
             },
             replace=True,
@@ -193,47 +234,53 @@ class Collection:
             batch = list(islice(iterator, batch_size))
             if not batch:
                 break
-            # Calculate hashes first
             items_and_hashes = [(item, self.content_hash(item[1])) for item in batch]
-            # Any of those hashes already exist?
-            existing_ids = [
-                row["id"]
+            existing_pairs = {
+                (row["id"], row["content_hash"])
                 for row in self.db.query(
                     """
-                    select id from embeddings
+                    select id, content_hash from embeddings
                     where collection_id = ? and content_hash in ({})
                     """.format(",".join("?" for _ in items_and_hashes)),
                     [collection_id]
                     + [item_and_hash[1] for item_and_hash in items_and_hashes],
                 )
-            ]
-            filtered_batch = [item for item in batch if item[0] not in existing_ids]
-            embeddings = list(
-                self.model().embed_multi(item[1] for item in filtered_batch)
+            }
+            existing_items = []
+            new_items = []
+            for item, content_hash in items_and_hashes:
+                if (item[0], content_hash) in existing_pairs:
+                    existing_items.append((item, content_hash))
+                else:
+                    new_items.append((item, content_hash))
+            embeddings = (
+                list(self.model().embed_multi(item[1] for item, _ in new_items))
+                if new_items
+                else []
             )
+            now = int(time.time())
             with self.db.conn:
-                cast(Table, self.db["embeddings"]).insert_all(
-                    (
-                        {
-                            "collection_id": collection_id,
-                            "id": id,
-                            "embedding": llm.encode(embedding),
-                            "content": (
-                                value if (store and isinstance(value, str)) else None
-                            ),
-                            "content_blob": (
-                                value if (store and isinstance(value, bytes)) else None
-                            ),
-                            "content_hash": self.content_hash(value),
-                            "metadata": json.dumps(metadata) if metadata else None,
-                            "updated": int(time.time()),
-                        }
-                        for (embedding, (id, value, metadata)) in zip(
-                            embeddings, filtered_batch
-                        )
-                    ),
-                    replace=True,
-                )
+                for (id, value, metadata), content_hash in existing_items:
+                    fields = self._stored_fields(value, metadata, store)
+                    self._update_stored_fields(id, content_hash, fields, now)
+                if new_items:
+                    cast(Table, self.db["embeddings"]).insert_all(
+                        (
+                            {
+                                "collection_id": collection_id,
+                                "id": id,
+                                "embedding": llm.encode(embedding),
+                                **self._stored_fields(value, metadata, store),
+                                "content_hash": content_hash,
+                                "updated": now,
+                            }
+                            for (
+                                embedding,
+                                ((id, value, metadata), content_hash),
+                            ) in zip(embeddings, new_items)
+                        ),
+                        replace=True,
+                    )
 
     def similar_by_vector(
         self,

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -55,6 +55,62 @@ def test_embed_metadata(collection):
     assert entry.content == "hello yet again"
 
 
+def test_embed_updates_store_and_metadata_for_existing_hash(embed_demo):
+    db = sqlite_utils.Database(memory=True)
+    collection = llm.Collection("test", db, model_id="embed-demo")
+
+    collection.embed("1", "hello world")
+    row = next(db["embeddings"].rows_where("id = ?", ["1"]))
+    assert row["content"] is None
+    assert row["metadata"] is None
+    assert embed_demo.embedded_content == ["hello world"]
+
+    collection.embed("1", "hello world", metadata={"foo": "bar"}, store=True)
+    row = next(db["embeddings"].rows_where("id = ?", ["1"]))
+    assert row["content"] == "hello world"
+    assert json.loads(row["metadata"]) == {"foo": "bar"}
+    assert embed_demo.embedded_content == ["hello world"]
+
+    collection.embed("1", "hello world")
+    row = next(db["embeddings"].rows_where("id = ?", ["1"]))
+    assert row["content"] is None
+    assert row["metadata"] is None
+    assert embed_demo.embedded_content == ["hello world"]
+
+
+def test_embed_updates_content_blob_for_existing_hash(embed_demo):
+    db = sqlite_utils.Database(memory=True)
+    collection = llm.Collection("test", db, model_id="embed-demo")
+    content = b"hello world"
+
+    collection.embed("1", content)
+    row = next(db["embeddings"].rows_where("id = ?", ["1"]))
+    assert row["content"] is None
+    assert row["content_blob"] is None
+    assert embed_demo.embedded_content == [content]
+
+    collection.embed("1", content, store=True)
+    row = next(db["embeddings"].rows_where("id = ?", ["1"]))
+    assert row["content"] is None
+    assert row["content_blob"] == content
+    assert embed_demo.embedded_content == [content]
+
+
+def test_embed_inserts_new_id_for_existing_hash(embed_demo):
+    db = sqlite_utils.Database(memory=True)
+    collection = llm.Collection("test", db, model_id="embed-demo")
+
+    collection.embed("1", "same text")
+    assert embed_demo.embedded_content == ["same text"]
+
+    collection.embed("2", "same text", store=True)
+    rows = {row["id"]: row for row in db["embeddings"].rows}
+    assert set(rows) == {"1", "2"}
+    assert rows["1"]["content"] is None
+    assert rows["2"]["content"] == "same text"
+    assert embed_demo.embedded_content == ["same text", "same text"]
+
+
 def test_collection(collection):
     assert collection.id == 1
     assert collection.count() == 2
@@ -144,6 +200,95 @@ def test_embed_multi(with_metadata, batch_size, expected_batches):
     assert all(row["content_hash"] is not None for row in rows)
     # Check batch count
     assert collection.model().batch_count == expected_batches
+
+
+def test_embed_multi_updates_store_and_metadata_for_existing_hash(embed_demo):
+    db = sqlite_utils.Database(memory=True)
+    collection = llm.Collection("test", db, model_id="embed-demo")
+    entries = (("1", "hello world"), ("2", "goodbye world"))
+
+    collection.embed_multi(entries)
+    rows = {row["id"]: row for row in db["embeddings"].rows}
+    assert rows["1"]["content"] is None
+    assert rows["2"]["content"] is None
+    assert embed_demo.embedded_content == ["hello world", "goodbye world"]
+
+    collection.embed_multi(entries, store=True)
+    rows = {row["id"]: row for row in db["embeddings"].rows}
+    assert rows["1"]["content"] == "hello world"
+    assert rows["2"]["content"] == "goodbye world"
+    assert embed_demo.embedded_content == ["hello world", "goodbye world"]
+
+    collection.embed_multi_with_metadata(
+        (
+            ("1", "hello world", {"label": "first"}),
+            ("2", "goodbye world", {"label": "second"}),
+        ),
+        store=True,
+    )
+    rows = {row["id"]: row for row in db["embeddings"].rows}
+    assert json.loads(rows["1"]["metadata"]) == {"label": "first"}
+    assert json.loads(rows["2"]["metadata"]) == {"label": "second"}
+    assert embed_demo.embedded_content == ["hello world", "goodbye world"]
+
+
+def test_existing_hash_refresh_only_updates_matching_id(embed_demo):
+    db = sqlite_utils.Database(memory=True)
+    collection = llm.Collection("test", db, model_id="embed-demo")
+    duplicate_entries = (("1", "same text"), ("2", "same text"))
+
+    collection.embed_multi(duplicate_entries, store=True)
+    rows = {row["id"]: row for row in db["embeddings"].rows}
+    assert len(rows) == 2
+    assert rows["1"]["metadata"] is None
+    assert rows["2"]["metadata"] is None
+    assert embed_demo.embedded_content == ["same text", "same text"]
+
+    collection.embed("1", "same text", metadata={"owner": "one"}, store=True)
+    rows = {row["id"]: row for row in db["embeddings"].rows}
+    assert json.loads(rows["1"]["metadata"]) == {"owner": "one"}
+    assert rows["2"]["metadata"] is None
+    assert embed_demo.embedded_content == ["same text", "same text"]
+
+    collection.embed_multi_with_metadata(
+        (("2", "same text", {"owner": "two"}),),
+        store=True,
+    )
+    rows = {row["id"]: row for row in db["embeddings"].rows}
+    assert json.loads(rows["1"]["metadata"]) == {"owner": "one"}
+    assert json.loads(rows["2"]["metadata"]) == {"owner": "two"}
+    assert embed_demo.embedded_content == ["same text", "same text"]
+
+
+def test_embed_multi_inserts_new_id_for_existing_hash(embed_demo):
+    db = sqlite_utils.Database(memory=True)
+    collection = llm.Collection("test", db, model_id="embed-demo")
+
+    collection.embed("1", "same text")
+    assert embed_demo.embedded_content == ["same text"]
+
+    collection.embed_multi((("2", "same text"),), store=True)
+    rows = {row["id"]: row for row in db["embeddings"].rows}
+    assert set(rows) == {"1", "2"}
+    assert rows["1"]["content"] is None
+    assert rows["2"]["content"] == "same text"
+    assert embed_demo.embedded_content == ["same text", "same text"]
+
+
+def test_embed_multi_updates_changed_id_when_old_hash_is_in_batch(embed_demo):
+    db = sqlite_utils.Database(memory=True)
+    collection = llm.Collection("test", db, model_id="embed-demo")
+
+    collection.embed("1", "old text", store=True)
+    assert embed_demo.embedded_content == ["old text"]
+
+    collection.embed_multi((("1", "new text"), ("2", "old text")), store=True)
+    rows = {row["id"]: row for row in db["embeddings"].rows}
+    assert rows["1"]["content"] == "new text"
+    assert rows["1"]["content_hash"] == collection.content_hash("new text")
+    assert rows["2"]["content"] == "old text"
+    assert rows["2"]["content_hash"] == collection.content_hash("old text")
+    assert embed_demo.embedded_content == ["old text", "new text", "old text"]
 
 
 def test_collection_delete(collection):


### PR DESCRIPTION
## Summary
- Refresh stored `content`, `content_blob`, and `metadata` when repeat embedding calls target an existing row with the same ID and content hash
- Avoid recalculating embeddings for exact existing rows while preserving normal insert/replace behavior for new IDs or changed content
- Add regression coverage for store/metadata refresh, binary content, duplicate-content rows, new IDs sharing content, and changed-content batch cases

## Why
Fixes #224.

The existing `embed()` and `embed_multi_with_metadata()` paths can notice that a `content_hash` is already present and skip work before updating stored content or metadata. That makes rerunning `embed` / `embed-multi` with `--store` or new metadata leave the stored columns stale.

## Tests
- `uv run --group dev pytest tests/test_embed.py -k "updates_store_and_metadata_for_existing_hash or updates_content_blob_for_existing_hash or embed_inserts_new_id_for_existing_hash or existing_hash_refresh_only_updates_matching_id or embed_multi_inserts_new_id_for_existing_hash or embed_multi_updates_changed_id_when_old_hash_is_in_batch"`: 7 passed, 15 deselected
- `uv run --group dev pytest tests/test_embed.py`: 22 passed
- `uv run --group dev pytest tests/test_embed_cli.py`: 91 passed
- `uv run --group dev ruff check llm/embeddings.py tests/test_embed.py`: passed
- `uv run --group dev black --target-version py312 --check llm/embeddings.py tests/test_embed.py`: 2 files unchanged
- `git diff --check`: passed
- `uv run --group dev pytest`: 789 passed

## Scope
- Same-collection, same-ID refresh of stored content/blob/metadata for already embedded content
- Preserves new-ID insertion and changed-content replacement behavior
- Does not implement cross-collection or cross-model embedding reuse
- Does not close #1397 / #1405's broader duplicate-content-under-new-ID deduplication behavior
