### PR TITLE
Fix embed/embed_multi not updating content column when store=True re-run

### DIFF
--- a/llm/embeddings.py
+++ b/llm/embeddings.py
@@ -134,6 +134,14 @@ class Collection:
         if self.db["embeddings"].count_where(
             "content_hash = ? and collection_id = ?", [content_hash, self.id]
         ):
+            if store:
+                content_col = "content" if isinstance(value, str) else "content_blob"
+                self.db.execute(
+                    "UPDATE embeddings SET {} = ? WHERE collection_id = ? AND id = ? AND {} IS NULL".format(
+                        content_col, content_col
+                    ),
+                    [value, self.id, id],
+                )
             return
         embedding = self.model().embed(value)
         cast(Table, self.db["embeddings"]).insert(
@@ -207,11 +215,23 @@ class Collection:
                     + [item_and_hash[1] for item_and_hash in items_and_hashes],
                 )
             ]
-            filtered_batch = [item for item in batch if item[0] not in existing_ids]
+            existing_ids_set = set(existing_ids)
+            filtered_batch = [item for item in batch if item[0] not in existing_ids_set]
             embeddings = list(
                 self.model().embed_multi(item[1] for item in filtered_batch)
             )
             with self.db.conn:
+                if store and existing_ids_set:
+                    for item in batch:
+                        if item[0] in existing_ids_set:
+                            item_id, value, _ = item
+                            content_col = "content" if isinstance(value, str) else "content_blob"
+                            self.db.execute(
+                                "UPDATE embeddings SET {} = ? WHERE collection_id = ? AND id = ? AND {} IS NULL".format(
+                                    content_col, content_col
+                                ),
+                                [value, collection_id, item_id],
+                            )
                 cast(Table, self.db["embeddings"]).insert_all(
                     (
                         {

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -185,3 +185,30 @@ def test_binary_only_and_text_only_embedding_models():
         list(text_only.embed_multi([b"hello world"]))
 
     list(text_only.embed_multi(["hello world"]))
+
+
+def test_embed_store_updates_null_content():
+    # Embedding without --store then re-embedding with --store should populate content.
+    db = sqlite_utils.Database(memory=True)
+    c = llm.Collection("test", db, model_id="embed-demo")
+    c.embed("1", "hello world")
+    row = next(db["embeddings"].rows_where("id = '1'"))
+    assert row["content"] is None
+
+    c.embed("1", "hello world", store=True)
+    row = next(db["embeddings"].rows_where("id = '1'"))
+    assert row["content"] == "hello world"
+
+
+def test_embed_multi_store_updates_null_content():
+    # embed_multi without store then with store should populate the content column.
+    db = sqlite_utils.Database(memory=True)
+    c = llm.Collection("test", db, model_id="embed-demo")
+    c.embed_multi([("1", "hello"), ("2", "world")])
+    for row in db["embeddings"].rows:
+        assert row["content"] is None
+
+    c.embed_multi([("1", "hello"), ("2", "world")], store=True)
+    rows = {row["id"]: row for row in db["embeddings"].rows}
+    assert rows["1"]["content"] == "hello"
+    assert rows["2"]["content"] == "world"


### PR DESCRIPTION
If you first run embed or embed_multi without --store, then re-run with --store, the content column stays NULL because the content_hash match causes an early return. This makes it impossible to add content storage to an existing collection without deleting and recreating it.

The fix checks whether the existing record already has content populated, and if not, updates it in place without re-computing the embedding.

Fixes #224