### PR TITLE
docs: fix f-string prefix and typo in plugin-hooks example

### DIFF
--- a/docs/plugins/plugin-hooks.md
+++ b/docs/plugins/plugin-hooks.md
@@ -241,7 +241,7 @@ Fragment loader plugins differ from template loader plugins in that you can stac
 
 A fragment loader can return one or more string fragments or attachments, or a mixture of the two. The fragments will be concatenated together into the prompt string, while any attachments will be added to the list of attachments to be sent to the model.
 
-The `prefix` specifies the loader. The `argument` will be passed to that registered callback..
+The `prefix` specifies the loader. The `argument` will be passed to that registered callback.
 
 The callback works in a very similar way to template loaders, but returns either a single `llm.Fragment`, a list of `llm.Fragment` objects, a single `llm.Attachment`, or a list that can mix `llm.Attachment` and `llm.Fragment` objects.
 
@@ -278,8 +278,8 @@ def my_fragment_loader(argument: str) -> llm.Fragment:
 def my_fragment_loader(argument: str) -> list[llm.Fragment]:
     "Docs go here."
     return [
-        llm.Fragment("Fragment 1 content", "my-fragments:{argument}"),
-        llm.Fragment("Fragment 2 content", "my-fragments:{argument}"),
+        llm.Fragment("Fragment 1 content", f"my-fragments:{argument}"),
+        llm.Fragment("Fragment 2 content", f"my-fragments:{argument}"),
         llm.Attachment(path="/path/to/image.png"),
     ]
 ```


### PR DESCRIPTION
Two small fixes in docs/plugins/plugin-hooks.md, `register_fragment_loaders` section:

1. Line 244: remove stray double period (`callback..` → `callback.`).
2. Lines 281-282: add missing `f` prefix on the second example's fragment source strings. Without it, `{argument}` renders literally instead of interpolating. The first example (line 269) does this correctly via `.format(argument)`; this makes the second consistent.

Verified by running the interpolation locally: without the `f`, the source is the literal `my-fragments:{argument}`.