### PR TITLE
Fix --continue picking most recently created conversation instead of most recently used

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1318,11 +1318,14 @@ def load_conversation(
     db = sqlite_utils.Database(log_path)
     migrate(db)
     if conversation_id is None:
-        # Return the most recent conversation, or None if there are none
-        matches = list(db["conversations"].rows_where(order_by="id desc", limit=1))
-        if matches:
-            conversation_id = matches[0]["id"]
-        else:
+        # Return the most recently *used* conversation (by last response), or None
+        try:
+            conversation_id = next(
+                db.query(
+                    "select conversation_id from responses order by id desc limit 1"
+                )
+            )["conversation_id"]
+        except StopIteration:
             return None
     try:
         row = cast(sqlite_utils.db.Table, db["conversations"]).get(conversation_id)

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -889,6 +889,44 @@ def test_llm_prompt_continue_with_database(
     assert sqlite_utils.Database(db_path)["responses"].count == 2
 
 
+def test_continue_uses_most_recently_used_conversation(mock_model, user_path):
+    # Regression test for: --continue should resume the most recently *used*
+    # conversation, not the most recently *created* one.
+    mock_model.enqueue(["resp-A1"])
+    mock_model.enqueue(["resp-B1"])
+    mock_model.enqueue(["resp-A2"])
+    mock_model.enqueue(["resp-A3"])
+
+    runner = CliRunner()
+    log_db = sqlite_utils.Database(str(user_path / "logs.db"))
+
+    # Start conversation A
+    r = runner.invoke(cli, ["prompt-A", "-m", "mock", "--no-stream"], catch_exceptions=False)
+    assert r.exit_code == 0, r.output
+    conv_a_id = list(log_db["responses"].rows)[0]["conversation_id"]
+
+    # Start a NEW conversation B (this gets a higher conversations.id)
+    r = runner.invoke(cli, ["prompt-B", "-m", "mock", "--no-stream"], catch_exceptions=False)
+    assert r.exit_code == 0, r.output
+
+    # Explicitly continue conversation A (making it the most recently *used*)
+    r = runner.invoke(
+        cli,
+        ["prompt-A2", "-m", "mock", "--no-stream", "--continue", "--conversation", conv_a_id],
+        catch_exceptions=False,
+    )
+    assert r.exit_code == 0, r.output
+
+    # --continue with no id should pick up conversation A, not conversation B
+    r = runner.invoke(cli, ["prompt-A3", "-m", "mock", "--no-stream", "--continue"], catch_exceptions=False)
+    assert r.exit_code == 0, r.output
+
+    rows = list(log_db["responses"].rows)
+    assert len(rows) == 4
+    # The last response should belong to conversation A, not B
+    assert rows[-1]["conversation_id"] == conv_a_id
+
+
 def test_default_exports():
     "Check key exports in the llm __all__ list"
     for name in ("Model", "AsyncModel", "get_model", "get_async_model", "schema_dsl"):


### PR DESCRIPTION
When you continue an older conversation with `llm -c --conversation <id>` and then run `llm --continue` without an id, it should resume that same conversation. Instead it was picking the most recently *created* conversation (sorted by `conversations.id`), not the most recently *used* one.

The fix queries `responses` ordered by `id desc` to find the conversation with the most recent response, matching what `llm logs --current` already does.

Fixes #1140