### PR TITLE
Make m013_usage migration idempotent to recover interrupted migrations

### DIFF
--- a/llm/migrations.py
+++ b/llm/migrations.py
@@ -234,9 +234,16 @@ def m012_attachments_tables(db):
 
 @migration
 def m013_usage(db):
-    db["responses"].add_column("input_tokens", int)
-    db["responses"].add_column("output_tokens", int)
-    db["responses"].add_column("token_details", str)
+    # Idempotent, in case a previous run was interrupted after some of
+    # these columns were added but before the migration was recorded:
+    # https://github.com/simonw/llm/issues/1036
+    existing = db["responses"].columns_dict
+    if "input_tokens" not in existing:
+        db["responses"].add_column("input_tokens", int)
+    if "output_tokens" not in existing:
+        db["responses"].add_column("output_tokens", int)
+    if "token_details" not in existing:
+        db["responses"].add_column("token_details", str)
 
 
 @migration

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -160,3 +160,18 @@ def test_backfill_content_hash():
     assert row1["content_hash"] is not None
     # This should be a hash of 'goodbye world'
     assert row2["content_hash"] == llm.Collection.content_hash("goodbye world")
+
+
+def test_migrate_recovers_from_interrupted_m013():
+    # https://github.com/simonw/llm/issues/1036
+    # Simulates a first run that was interrupted after m013_usage added its
+    # columns but before the migration was recorded in _llm_migrations.
+    # Re-running migrate() used to fail with:
+    #   sqlite3.OperationalError: duplicate column name: input_tokens
+    db = sqlite_utils.Database(memory=True)
+    migrate(db)
+    db["_llm_migrations"].delete_where("name = ?", ["m013_usage"])
+    migrate(db)
+    assert db["responses"].columns_dict == EXPECTED
+    applied = {row["name"] for row in db["_llm_migrations"].rows}
+    assert "m013_usage" in applied


### PR DESCRIPTION
Refs #1036

## The bug

`migrate()` applies each migration and records it in `_llm_migrations` as two separate auto-committed steps. `m013_usage` issues three `ALTER TABLE` statements, each committed individually. If the process is interrupted after the first `ALTER` but before the migration is recorded (Ctrl-C, terminal closed, crash elsewhere on a slow first run), the database is left with the `input_tokens` column present but `m013_usage` unrecorded.

Every subsequent invocation then re-runs `m013_usage` and dies with:

```
sqlite3.OperationalError: duplicate column name: input_tokens
```

which permanently wedges `llm` until the user deletes `logs.db` — exactly the workaround reported in #1036.

## The fix

Make `m013_usage` idempotent by checking `columns_dict` before each `add_column`, following the same pattern `m001_initial` already uses. Re-running after an interruption now completes the migration and records it.

## Test

`test_migrate_recovers_from_interrupted_m013` simulates the interrupted state (columns added, migration not recorded) by deleting the `m013_usage` row from `_llm_migrations` after a full migrate, then re-running `migrate()`.

Fails before the fix with `duplicate column name: input_tokens`, passes after. The other migration tests pass unchanged (`test_migrations_for_embeddings` and `test_backfill_content_hash` fail on my machine both with and without this change — local SQLite version issue, appears related to the same family as #1511).

Note: other multi-statement migrations (e.g. `m014_schemas`) can wedge the same way. Happy to guard those too in a follow-up if you'd like this pattern applied across the board, or alternatively wrap apply+record in a single transaction in `migrate()` itself.
