### PR TITLE
Add llm-unorouter to plugin directory

### DIFF
--- a/docs/plugins/directory.md
+++ b/docs/plugins/directory.md
@@ -33,6 +33,7 @@ These plugins can be used to interact with remotely hosted models via their API:
 - **[llm-replicate](https://github.com/simonw/llm-replicate)** adds support for remote models hosted on [Replicate](https://replicate.com/), including Llama 2 from Meta AI.
 - **[llm-fireworks](https://github.com/simonw/llm-fireworks)** supports models hosted by [Fireworks AI](https://fireworks.ai/).
 - **[llm-openrouter](https://github.com/simonw/llm-openrouter)** provides access to models hosted on [OpenRouter](https://openrouter.ai/).
+- **[llm-unorouter](https://github.com/0-don/llm-unorouter)** by 0-don provides access to 200+ models hosted on [UnoRouter](https://unorouter.com/), an open-source gateway where models with a `:free` suffix cost nothing.
 - **[llm-cohere](https://github.com/Accudio/llm-cohere)** by Alistair Shepherd provides `cohere-generate` and `cohere-summarize` API models, powered by [Cohere](https://cohere.com/).
 - **[llm-bedrock](https://github.com/simonw/llm-bedrock)** adds support for Nova by Amazon via Amazon Bedrock.
 - **[llm-bedrock-anthropic](https://github.com/sblakey/llm-bedrock-anthropic)** by Sean Blakey adds support for Claude and Claude Instant by Anthropic via Amazon Bedrock.


### PR DESCRIPTION
Adds [llm-unorouter](https://github.com/0-don/llm-unorouter) ([PyPI](https://pypi.org/project/llm-unorouter/)) to the remote APIs section, next to llm-openrouter which it mirrors structurally.

UnoRouter is an open-source OpenAI-compatible gateway serving 200+ models (Claude, GPT, Gemini, DeepSeek, Kimi, GLM, Qwen and more) behind one API key; models with a `:free` suffix cost nothing. The plugin registers the live model list dynamically from `/v1/models` and adds `llm unorouter models [--free]` / `llm unorouter refresh` commands.

Tested against a fresh `pip install llm && llm install llm-unorouter`: 332 models register and prompts stream.