### PR TITLE
Fix --xl -r extracting code from oldest response instead of most recent

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -2038,8 +2038,9 @@ def logs_list(
             ]
         output = json.dumps(list(rows), indent=2)
     elif extract or extract_last:
-        # Extract and return first code block
-        for row in rows:
+        # When -r is set, restrict to the same row -r would display (rows[-1])
+        search_rows = [rows[-1]] if (response and rows) else rows
+        for row in search_rows:
             output = extract_fenced_code_block(row["response"], last=extract_last)
             if output is not None:
                 break

--- a/tests/test_llm_logs.py
+++ b/tests/test_llm_logs.py
@@ -276,6 +276,36 @@ def test_logs_extract_last_code(args, log_path):
     assert result.output == 'print("hello word")\n\n'
 
 
+def test_logs_extract_with_response_uses_latest(user_path):
+    "Test that --xl -r extracts from the same response that -r shows, not an older one"
+    log_path = str(user_path / "logs_extract_r.db")
+    db = sqlite_utils.Database(log_path)
+    migrate(db)
+    start = datetime.datetime.now(datetime.timezone.utc)
+    for i, code in enumerate(["old_cmd", "new_cmd"]):
+        db["responses"].insert(
+            {
+                "id": str(monotonic_ulid()).lower(),
+                "system": "sys",
+                "prompt": f"prompt {i}",
+                "response": f"turn {i}\n```bash\n{code}\n```",
+                "model": "gpt4",
+                "datetime_utc": (start + datetime.timedelta(seconds=i)).isoformat(),
+                "conversation_id": "conv1",
+                "input_tokens": 1,
+                "output_tokens": 1,
+            }
+        )
+    runner = CliRunner()
+    # -r alone shows the most recent response
+    r = runner.invoke(cli, ["logs", "-r", "-p", log_path], catch_exceptions=False)
+    assert "new_cmd" in r.output
+    # --xl -r must extract from that same most-recent response
+    result = runner.invoke(cli, ["logs", "--xl", "-r", "-p", log_path], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert result.output == "new_cmd\n\n"
+
+
 @pytest.mark.parametrize("arg", ("-s", "--short"))
 @pytest.mark.parametrize("usage", (None, "-u", "--usage"))
 def test_logs_short(log_path, arg, usage):


### PR DESCRIPTION
When a conversation has multiple responses and you run `llm logs --xl -r`, the extracted code block comes from the oldest response in the conversation rather than the most recent one. This happens because the extract loop iterates `rows` from the start (oldest after the DESC-then-reverse ordering), while `-r` correctly reads from `rows[-1]` (newest). The fix restricts the search to `rows[-1]` when `-r` is active, so both flags operate on the same response. Fixes #821.