### PR TITLE
fix: do not commit inside the content_hash embeddings migration

### DIFF
--- a/llm/embeddings_migrations.py
+++ b/llm/embeddings_migrations.py
@@ -62,17 +62,16 @@ def m004_store_content_hash(db):
     db.conn.create_function("temp_md5", 1, md5)
     db.conn.create_function("temp_random_md5", 0, random_md5)
 
-    with db.conn:
-        db.execute("""
-            update embeddings
-            set content_hash = temp_md5(content)
-            where content is not null
-        """)
-        db.execute("""
-            update embeddings
-            set content_hash = temp_random_md5()
-            where content is null
-        """)
+    db.execute("""
+        update embeddings
+        set content_hash = temp_md5(content)
+        where content is not null
+    """)
+    db.execute("""
+        update embeddings
+        set content_hash = temp_random_md5()
+        where content is null
+    """)
 
     db["embeddings"].create_index(["content_hash"])
 

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -117,6 +117,18 @@ def test_migrations_for_embeddings():
     assert db["embeddings"].foreign_keys[0].other_table == "collections"
 
 
+@pytest.mark.skipif(
+    not hasattr(sqlite_utils.Database, "atomic"),
+    reason="sqlite-utils 4 and higher run each migration inside a transaction",
+)
+def test_embeddings_migrations_do_not_commit():
+    # https://github.com/simonw/llm/issues/1523
+    db = sqlite_utils.Database(memory=True)
+    for migration in embeddings_migrations.pending(db):
+        with db.atomic():
+            migration.fn(db)
+
+
 def test_backfill_content_hash():
     db = sqlite_utils.Database(memory=True)
     # Run migrations up to but not including m004_store_content_hash


### PR DESCRIPTION
Closes #1523.

## The bug

Every embeddings command fails on a fresh install today:

```
sqlite3.OperationalError: cannot commit - no transaction is active
```

`pyproject.toml` allows `sqlite-utils>=3.37` and `sqlite-migrate>=0.1a2`, so a new install now resolves to sqlite-utils 4.1 and sqlite-migrate 0.2 — and 0.2 is just a shim that re-exports `sqlite_utils.Migrations`.

That matters because `sqlite_utils.Migrations.apply()` runs each migration inside `db.atomic()`, i.e. `BEGIN` ... `COMMIT`. `m004_store_content_hash` wrapped its two backfill `UPDATE`s in `with db.conn:`, and the stdlib connection context manager commits on exit — so it ended the transaction `atomic()` had opened, and `atomic()`'s own `COMMIT` then had nothing left to commit.

This is why `test_embed.py` is currently red on `main`.

## The fix

Drop the `with db.conn:` wrapper and let the enclosing transaction do its job — the same shape as 67adad2, which fixed `m003_add_updated` for sqlite-utils 4.

I deliberately did not use `db.atomic()` here: it doesn't exist in sqlite-utils 3.x, which `pyproject.toml` still supports.

## Verification

- New test `test_embeddings_migrations_do_not_commit` fails on `main` with the exact `OperationalError` above and passes with the fix. It's skipped on sqlite-utils 3.x, where migrations already commit internally (`transform()` does), so the invariant cannot hold there and the bug cannot occur.
- Full suite green on **both** stacks: 765 passed on sqlite-utils 4.1 (currently red on `main`), 764 passed + 1 skipped on 3.39.
- Checked the backfill is still durable, not just crash-free: applied the migrations to a file-backed DB with rows seeded before `m004`, reopened it on a fresh connection, and confirmed `content_hash` is persisted — on 4.1 and on 3.39.
- `black --check .`, `mypy llm` and `ruff check .` all pass.

## One thing I left alone

#1523 also reports `embed-multi` masking the failure as *"You need to specify an embedding model"*. That's the broad `except ValueError` around `Collection(...)` in `cli.py` — but it does not catch this crash, which is an `OperationalError`. The `ValueError` the reporter hit came from `m003`'s old `db.query()` call, already fixed in 67adad2. Narrowing that `except` is a real question but a separate judgement call, so I've left it for you.
