### PR TITLE
Fix after_call not firing when model calls a non-existent tool

### DIFF
--- a/llm/models.py
+++ b/llm/models.py
@@ -1884,14 +1884,20 @@ class Response(_BaseResponse):
 
             if tool is None:
                 msg = 'tool "{}" does not exist'.format(tool_call.name)
-                tool_results.append(
-                    ToolResult(
-                        name=tool_call.name,
-                        output="Error: " + msg,
-                        tool_call_id=tool_call.tool_call_id,
-                        exception=KeyError(msg),
-                    )
+                tool_result_obj = ToolResult(
+                    name=tool_call.name,
+                    output="Error: " + msg,
+                    tool_call_id=tool_call.tool_call_id,
+                    exception=KeyError(msg),
                 )
+                if after_call:
+                    cb_result = after_call(tool, tool_call, tool_result_obj)
+                    if inspect.isawaitable(cb_result):
+                        raise TypeError(
+                            "Asynchronous 'after_call' callback provided to a synchronous tool execution context. "
+                            "Please use an async chain/response or a synchronous callback."
+                        )
+                tool_results.append(tool_result_obj)
                 continue
 
             if not tool.implementation:
@@ -2242,17 +2248,17 @@ class AsyncResponse(_BaseResponse):
                         break
                 reason = "does not exist" if tool is None else "has no implementation"
                 msg = 'tool "{}" {}'.format(tc.name, reason)
-                indexed_results.append(
-                    (
-                        idx,
-                        ToolResult(
-                            name=tc.name,
-                            output="Error: " + msg,
-                            tool_call_id=tc.tool_call_id,
-                            exception=KeyError(msg),
-                        ),
-                    )
+                tr_obj = ToolResult(
+                    name=tc.name,
+                    output="Error: " + msg,
+                    tool_call_id=tc.tool_call_id,
+                    exception=KeyError(msg),
                 )
+                if after_call:
+                    cb2 = after_call(tool, tc, tr_obj)
+                    if inspect.isawaitable(cb2):
+                        await cb2
+                indexed_results.append((idx, tr_obj))
                 continue
 
             if inspect.iscoroutinefunction(tool.implementation):

--- a/llm/models.py
+++ b/llm/models.py
@@ -1934,14 +1934,20 @@ class Response(_BaseResponse):
 
             if tool is None:
                 msg = f'tool "{tool_call.name}" does not exist'
-                tool_results.append(
-                    ToolResult(
-                        name=tool_call.name,
-                        output="Error: " + msg,
-                        tool_call_id=tool_call.tool_call_id,
-                        exception=KeyError(msg),
-                    )
+                tool_result_obj = ToolResult(
+                    name=tool_call.name,
+                    output="Error: " + msg,
+                    tool_call_id=tool_call.tool_call_id,
+                    exception=KeyError(msg),
                 )
+                if after_call:
+                    cb_result = after_call(tool, tool_call, tool_result_obj)
+                    if inspect.isawaitable(cb_result):
+                        raise TypeError(
+                            "Asynchronous 'after_call' callback provided to a synchronous tool execution context. "
+                            "Please use an async chain/response or a synchronous callback."
+                        )
+                tool_results.append(tool_result_obj)
                 continue
 
             if not tool.implementation:
@@ -2299,17 +2305,21 @@ class AsyncResponse(_BaseResponse):
                         break
                 reason = "does not exist" if tool is None else "has no implementation"
                 msg = f'tool "{tc.name}" {reason}'
-                indexed_results.append(
-                    (
-                        idx,
-                        ToolResult(
-                            name=tc.name,
-                            output="Error: " + msg,
-                            tool_call_id=tc.tool_call_id,
-                            exception=KeyError(msg),
-                        ),
-                    )
+                tool_result_obj = ToolResult(
+                    name=tc.name,
+                    output="Error: " + msg,
+                    tool_call_id=tc.tool_call_id,
+                    exception=KeyError(msg),
                 )
+                if after_call:
+                    try:
+                        cb = after_call(tool, tc, tool_result_obj)
+                        if inspect.isawaitable(cb):
+                            await cb
+                    except Exception as ex:  # noqa: BLE001
+                        failures.append((idx, ex))
+                        break
+                indexed_results.append((idx, tool_result_obj))
                 continue
 
             if inspect.iscoroutinefunction(tool.implementation):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -898,3 +898,42 @@ async def test_async_tool_without_implementation_produces_error_result():
     assert [(r.name, r.output) for r in second.prompt.tool_results] == [
         ("no_impl", 'Error: tool "no_impl" has no implementation'),
     ]
+
+
+def test_after_call_fires_for_missing_tool():
+    after_calls = []
+
+    def after(tool, tool_call, tool_result):
+        after_calls.append((tool, tool_call.name, tool_result.output))
+
+    model = llm.get_model("echo")
+    response = model.chain(
+        json.dumps({"tool_calls": [{"name": "missing_tool"}]}),
+        tools=[llm_time],
+        after_call=after,
+    )
+    response.text()
+    assert len(after_calls) == 1
+    assert after_calls[0][0] is None
+    assert after_calls[0][1] == "missing_tool"
+    assert after_calls[0][2] == 'Error: tool "missing_tool" does not exist'
+
+
+@pytest.mark.asyncio
+async def test_async_after_call_fires_for_missing_tool():
+    after_calls = []
+
+    async def after(tool, tool_call, tool_result):
+        after_calls.append((tool, tool_call.name, tool_result.output))
+
+    model = llm.get_async_model("echo")
+    response = model.chain(
+        json.dumps({"tool_calls": [{"name": "missing_tool"}]}),
+        tools=[llm_time],
+        after_call=after,
+    )
+    await response.text()
+    assert len(after_calls) == 1
+    assert after_calls[0][0] is None
+    assert after_calls[0][1] == "missing_tool"
+    assert after_calls[0][2] == 'Error: tool "missing_tool" does not exist'

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1222,3 +1222,46 @@ async def test_async_tool_without_implementation_produces_error_result():
     assert [(r.name, r.output) for r in second.prompt.tool_results] == [
         ("no_impl", 'Error: tool "no_impl" has no implementation'),
     ]
+
+
+def test_after_call_fires_for_missing_tool():
+    after_calls = []
+
+    def real_tool() -> str:
+        return "ok"
+
+    def after(tool, tool_call, tool_result):
+        after_calls.append((tool.name if tool else None, tool_call.name, tool_result.output))
+
+    model = llm.get_model("echo")
+    chain_response = model.chain(
+        json.dumps({"tool_calls": [{"name": "missing_tool"}, {"name": "real_tool"}]}),
+        tools=[real_tool],
+        after_call=after,
+    )
+    chain_response.text()
+
+    assert (None, "missing_tool", 'Error: tool "missing_tool" does not exist') in after_calls
+    assert ("real_tool", "real_tool", "ok") in after_calls
+
+
+@pytest.mark.asyncio
+async def test_async_after_call_fires_for_missing_tool():
+    after_calls = []
+
+    async def real_tool() -> str:
+        return "ok"
+
+    async def after(tool, tool_call, tool_result):
+        after_calls.append((tool.name if tool else None, tool_call.name, tool_result.output))
+
+    model = llm.get_async_model("echo")
+    chain_response = model.chain(
+        json.dumps({"tool_calls": [{"name": "missing_tool"}, {"name": "real_tool"}]}),
+        tools=[real_tool],
+        after_call=after,
+    )
+    await chain_response.text()
+
+    assert (None, "missing_tool", 'Error: tool "missing_tool" does not exist') in after_calls
+    assert ("real_tool", "real_tool", "ok") in after_calls


### PR DESCRIPTION
When a model calls a tool by a name that does not appear in the configured tool list, the sync and async executors returned an error ToolResult but skipped the after_call hook entirely, so --td produced no debug output for those failed calls. Both paths now invoke after_call with tool=None before continuing, matching the existing behaviour of before_call for unknown tools. Fixes #1151