### PR TITLE
Route a leading "--" to the default command (#245)

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1,6 +1,6 @@
 import asyncio
 import click
-from click_default_group import DefaultGroup
+from click_default_group import DefaultGroup as _DefaultGroup
 from dataclasses import asdict
 from importlib.metadata import version
 import io
@@ -339,6 +339,17 @@ def schema_option(fn):
         help="JSON schema, filepath or ID",
     )(fn)
     return fn
+
+
+class DefaultGroup(_DefaultGroup):
+    def parse_args(self, ctx, args):
+        # Route a leading "--" to the default command so that
+        # `llm -- "--dashed prompt"` behaves like `llm prompt -- "..."`.
+        # Otherwise the group consumes the "--" and the default command sees
+        # the text as an unknown option (issue #245).
+        if args and args[0] == "--" and self.default_cmd_name:
+            args.insert(0, self.default_cmd_name)
+        return super().parse_args(ctx, args)
 
 
 @click.group(

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -19,6 +19,16 @@ def test_version():
         assert result.output.startswith("cli, version ")
 
 
+def test_prompt_with_dashes_via_double_dash():
+    # A prompt that looks like an option must reach the prompt command through
+    # "--", even when the default command is used implicitly (issue #245).
+    runner = CliRunner()
+    assert runner.invoke(cli, ["models", "default", "echo"]).exit_code == 0
+    result = runner.invoke(cli, ["--", "--find me"], catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+    assert '"prompt": "--find me"' in result.output
+
+
 @pytest.mark.parametrize("custom_database_path", (False, True))
 def test_llm_prompt_creates_log_database(
     mocked_openai_chat, tmpdir, monkeypatch, custom_database_path


### PR DESCRIPTION
Fixes #245.

`llm -- "--find me"` fails with `Error: No such option '--find me'`, while the explicit `llm prompt -- "--find me"` works. The `DefaultGroup` consumes the `--` separator before the implicit default `prompt` command sees it, so the text is parsed as an option.

This adds a small `DefaultGroup` subclass that prepends the default command name when the first argument is `--`, so the separator reaches the `prompt` command exactly as it does for the explicit form. It only triggers when the args start with a literal `--`; every other invocation is unchanged.

**Verification**
- `llm -- "--find me"` now runs the prompt (previously a usage error).
- Added a regression test. `pytest tests/test_llm.py` (69 passed) and `tests/test_cli_options.py` (6 passed) are green; `ruff check` and `black --check` are clean.
