### PR TITLE
Fix llm_time timezone_offset format for negative UTC offsets

### DIFF
--- a/llm/tools.py
+++ b/llm/tools.py
@@ -20,12 +20,12 @@ def llm_time() -> dict:
 
     # Calculate offset
     offset_seconds = -time.timezone if not is_dst else -time.altzone
-    offset_hours = offset_seconds // 3600
-    offset_minutes = (offset_seconds % 3600) // 60
+    abs_seconds = abs(offset_seconds)
+    offset_hours = abs_seconds // 3600
+    offset_minutes = (abs_seconds % 3600) // 60
+    sign = "+" if offset_seconds >= 0 else "-"
 
-    timezone_offset = (
-        f"UTC{'+' if offset_hours >= 0 else ''}{offset_hours:02d}:{offset_minutes:02d}"
-    )
+    timezone_offset = f"UTC{sign}{offset_hours:02d}:{offset_minutes:02d}"
 
     return {
         "utc_time": utc_time.strftime("%Y-%m-%d %H:%M:%S UTC"),

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -378,6 +378,28 @@ def test_default_tool_llm_time():
     }
 
 
+def test_llm_time_timezone_offset_format(monkeypatch):
+    from unittest.mock import MagicMock
+
+    mock_tm = MagicMock()
+    mock_tm.tm_isdst = 0
+
+    # Simulate UTC-5 (EST): time.timezone = 18000 (seconds west of UTC)
+    monkeypatch.setattr(time, "timezone", 18000)
+    monkeypatch.setattr(time, "altzone", 14400)
+    monkeypatch.setattr(time, "localtime", lambda: mock_tm)
+    monkeypatch.setattr(time, "tzname", ("EST", "EDT"))
+    info = llm_time()
+    assert info["timezone_offset"] == "UTC-05:00"
+
+    # Simulate UTC+5:30 (IST): time.timezone = -19800
+    monkeypatch.setattr(time, "timezone", -19800)
+    monkeypatch.setattr(time, "altzone", -19800)
+    monkeypatch.setattr(time, "tzname", ("IST", "IST"))
+    info = llm_time()
+    assert info["timezone_offset"] == "UTC+05:30"
+
+
 def test_incorrect_tool_usage():
     model = llm.get_model("echo")
 


### PR DESCRIPTION
The `timezone_offset` field in `llm_time()` produced malformed strings for west-of-UTC zones: `"UTC-5:00"` instead of `"UTC-05:00"` because Python's `:02d` format specifier only zero-pads positive numbers. Additionally, floor division on negative `offset_seconds` yielded the wrong hour for sub-hour offsets (e.g. UTC-3:30 became UTC-4:50 instead of UTC-3:30). The fix computes hours and minutes from `abs(offset_seconds)` and tracks the sign separately, producing correctly zero-padded offsets like `"UTC-05:00"` and `"UTC+05:30"`.

---
_Generated by [Claude Code](https://claude.ai/code/session_016N3BTVKr1wrKv6CJUaADTW)_