### PR TITLE
Fix condense_json dedup skipping prior turns with no fragments

### DIFF
--- a/llm/models.py
+++ b/llm/models.py
@@ -1435,18 +1435,18 @@ class _BaseResponse:
         replacements = {}
         # Include replacements from previous responses
         for previous_response in conversation.responses[:-1]:
+            replacements[f"r:{previous_response.id}"] = (
+                previous_response.text_or_raise()
+            )
             for fragment in (previous_response.prompt.fragments or []) + (
                 previous_response.prompt.system_fragments or []
             ):
                 fragment_id = ensure_fragment(db, fragment)
                 replacements[f"f:{fragment_id}"] = fragment
-                replacements[f"r:{previous_response.id}"] = (
-                    previous_response.text_or_raise()
-                )
 
         for i, fragment in enumerate(self.prompt.fragments):
             fragment_id = ensure_fragment(db, fragment)
-            replacements[f"f{fragment_id}"] = fragment
+            replacements[f"f:{fragment_id}"] = fragment
             db["prompt_fragments"].insert(
                 {
                     "response_id": response_id,
@@ -1456,7 +1456,7 @@ class _BaseResponse:
             )
         for i, fragment in enumerate(self.prompt.system_fragments):
             fragment_id = ensure_fragment(db, fragment)
-            replacements[f"f{fragment_id}"] = fragment
+            replacements[f"f:{fragment_id}"] = fragment
             db["system_fragments"].insert(
                 {
                     "response_id": response_id,

--- a/tests/test_llm_logs.py
+++ b/tests/test_llm_logs.py
@@ -1182,3 +1182,42 @@ def test_logs_markdown_omits_reasoning_heading_when_empty(log_path):
     result = runner.invoke(cli, ["logs", "-p", str(log_path)], catch_exceptions=False)
     assert result.exit_code == 0
     assert "## Reasoning" not in result.output
+
+
+def test_log_to_db_deduplicates_previous_turn_without_fragments(logs_db, mock_model):
+    """Prior-turn response text must be condensed even when that turn had no
+    fragments. Bug: replacements[r:{id}] was set inside the for-fragment loop
+    so turns with no fragments were never registered and the full text was
+    stored verbatim in the next turn's prompt_json (issue #1530)."""
+    r1_text = "A long unique response from turn one that should be condensed"
+
+    mock_model.enqueue([r1_text])
+    mock_model.enqueue(["turn two answer"])
+
+    conv = mock_model.conversation()
+
+    r1 = conv.prompt("Turn one question")
+    r1.text()
+    r1._prompt_json = {"messages": [{"role": "user", "content": "Turn one question"}]}
+    r1.log_to_db(logs_db)
+
+    r2 = conv.prompt("Turn two question")
+    r2.text()
+    # Simulate what a real model sets: the full conversation history including
+    # turn 1's response text verbatim in the assistant message.
+    r2._prompt_json = {
+        "messages": [
+            {"role": "user", "content": "Turn one question"},
+            {"role": "assistant", "content": r1_text},
+            {"role": "user", "content": "Turn two question"},
+        ]
+    }
+    r2.log_to_db(logs_db)
+
+    rows = list(logs_db["responses"].rows)
+    assert len(rows) == 2
+    stored = json.loads(rows[1]["prompt_json"])
+    messages = stored["messages"]
+    assistant_msg = next(m for m in messages if m["role"] == "assistant")
+    # The prior-turn response must be replaced by a condensed marker, not stored verbatim.
+    assert assistant_msg["content"] == {"$": f"r:{r1.id}"}


### PR DESCRIPTION
In log_to_db, the line that registers a prior turn's response text as a condense_json replacement was inside the inner for-fragment loop. Any previous turn with no fragments — the common case for plain-text exchanges — never had its response text added to the replacements dict, so the full text was stored verbatim in the next turn's prompt_json rather than being condensed to a compact marker.

Also standardises the fragment marker key format: current-turn fragments were keyed f"{id}" (no colon) while prior-turn fragments used f":{id}" (with colon), causing the same fragment to receive different marker keys depending on which turn logged it. Both now use the f":{id}" form already used for response markers.

Fixes #1530

---
_Generated by [Claude Code](https://claude.ai/code/session_01JK1PGUBztsk4JZSY3iSXp1)_