### PR TITLE
Handle ${braced} variables in template missing-variable detection

### DIFF
--- a/llm/templates.py
+++ b/llm/templates.py
@@ -85,8 +85,13 @@ class Template(BaseModel):
     @staticmethod
     def extract_vars(string_template: string.Template) -> List[str]:
         """Extract and return the list of named variable identifiers from a string.Template."""
+        # Both `$name` (the "named" group) and `${name}` (the "braced" group)
+        # are valid string.Template references and are handled by substitute().
+        # Collecting only "named" misses braced variables, so vars() would
+        # under-report them and interpolate() would raise a raw KeyError from
+        # substitute() instead of the friendly MissingVariables error.
         return [
-            match.group("named")
+            match.group("named") or match.group("braced")
             for match in string_template.pattern.finditer(string_template.template)
-            if match.group("named")
+            if match.group("named") or match.group("braced")
         ]

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -31,6 +31,30 @@ import yaml
             None,
             None,
         ),
+        # Braced ${var} syntax must be treated the same as $var.
+        ("${greeting} world", None, None, {"greeting": "hi"}, "hi world", None, None),
+        ("${count}x", None, None, {"count": 5}, "5x", None, None),
+        ("$one and ${two}", None, None, {"one": 1, "two": 2}, "1 and 2", None, None),
+        # A missing braced variable must raise the friendly MissingVariables
+        # error, not a raw KeyError from string.Template.substitute.
+        (
+            "${one} and ${two}",
+            None,
+            None,
+            {},
+            None,
+            None,
+            "Missing variables: one, two",
+        ),
+        (
+            "$one and ${two}",
+            None,
+            None,
+            {"one": 1},
+            None,
+            None,
+            "Missing variables: two",
+        ),
     ),
 )
 def test_template_evaluate(
@@ -45,6 +69,15 @@ def test_template_evaluate(
         prompt, system = t.evaluate("input", params)
         assert prompt == expected_prompt
         assert system == expected_system
+
+
+def test_template_vars_includes_braced():
+    # vars() must report both $var and ${var} references; previously the
+    # braced form was silently dropped, which also broke the
+    # `"input" in template.vars()` checks in the CLI.
+    t = Template(name="t", prompt="$a and ${b}", system="${c} then $d")
+    assert t.vars() == {"a", "b", "c", "d"}
+    assert "input" in Template(name="t2", prompt="reply to ${input}").vars()
 
 
 def test_templates_list_no_templates_found():


### PR DESCRIPTION
`Template.extract_vars` only collected the `named` group from `string.Template`'s pattern, so `${braced}` variables were dropped. As a result `.vars()` under-reported them and `interpolate()` raised a raw `KeyError` from `substitute()` instead of the friendly `MissingVariables` error. This also broke the `"input" in template.vars()` checks in the CLI.

Collect the `braced` group as well. Adds tests for braced substitution, the missing-variable message, and `.vars()`.
