### PR TITLE
Don't crash on an empty or malformed keys.json

### DIFF
--- a/llm/__init__.py
+++ b/llm/__init__.py
@@ -402,10 +402,19 @@ def get_key(
 
 def load_keys():
     path = user_dir() / "keys.json"
-    if path.exists():
-        return json.loads(path.read_text())
-    else:
+    if not path.exists():
         return {}
+    try:
+        keys = json.loads(path.read_text())
+    except json.JSONDecodeError:
+        # An empty or hand-corrupted keys.json should not crash every command
+        # that needs a key; treat it as having no usable keys.
+        return {}
+    # keys.json is expected to be a JSON object; anything else (e.g. an array)
+    # is not usable and would break callers that index it by name.
+    if not isinstance(keys, dict):
+        return {}
+    return keys
 
 
 def user_dir():

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -35,6 +35,7 @@ from llm import (
     get_model,
     get_model_aliases,
     get_models_with_aliases,
+    load_keys,
     user_dir,
     set_alias,
     set_default_model,
@@ -1365,11 +1366,10 @@ def keys():
 @keys.command(name="list")
 def keys_list():
     "List names of all stored keys"
-    path = user_dir() / "keys.json"
-    if not path.exists():
+    keys = load_keys()
+    if not keys:
         click.echo("No keys found")
         return
-    keys = json.loads(path.read_text())
     for key in sorted(keys.keys()):
         if key != "// Note":
             click.echo(key)
@@ -1392,10 +1392,9 @@ def keys_get(name):
     \b
         export OPENAI_API_KEY=$(llm keys get openai)
     """
-    path = user_dir() / "keys.json"
-    if not path.exists():
+    keys = load_keys()
+    if not keys:
         raise click.ClickException("No keys found")
-    keys = json.loads(path.read_text())
     try:
         click.echo(keys[name])
     except KeyError:

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -64,6 +64,26 @@ def test_keys_list(monkeypatch, tmpdir, args):
     assert result2.output.strip() == "openai"
 
 
+@pytest.mark.parametrize("bad_content", ("", "   ", "{not json", "[1, 2, 3]"))
+def test_keys_list_and_get_survive_malformed_keys_json(
+    monkeypatch, tmpdir, bad_content
+):
+    user_path = tmpdir / "user/keys"
+    pathlib.Path(user_path).mkdir(parents=True)
+    monkeypatch.setenv("LLM_USER_PATH", str(user_path))
+    keys_path = user_path / "keys.json"
+    keys_path.write_text(bad_content, "utf-8")
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["keys", "list"])
+    assert result.exit_code == 0
+    assert result.output.strip() == "No keys found"
+
+    result2 = runner.invoke(cli, ["keys", "get", "openai"])
+    assert result2.exit_code == 1
+    assert "No keys found" in result2.output
+
+
 @pytest.mark.httpx_mock(
     assert_all_requests_were_expected=False, can_send_already_matched_responses=True
 )


### PR DESCRIPTION
`load_keys()` called `json.loads()` directly, so an empty or hand-corrupted `keys.json` crashed `llm keys list`, `llm keys get`, and any command that looks up a key with a `JSONDecodeError`. A non-dict JSON value (e.g. an array) also slipped through to callers that index it by name.

Guard both cases in `load_keys()` and route `keys_list`/`keys_get` through it so the handling lives in one place. Adds a parametrized test over empty, whitespace, invalid, and array contents.
