### PR TITLE
Fix KeyError when displaying logs for tools without a properties key

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -2238,7 +2238,7 @@ def logs_list(
                                 textwrap.indent(
                                     (tool["description"] or "").rstrip(), "    "
                                 ),
-                                json.dumps(tool["input_schema"]["properties"]),
+                                json.dumps(tool["input_schema"].get("properties", {})),
                             )
                         )
             if row["tool_results"]:

--- a/tests/test_llm_logs.py
+++ b/tests/test_llm_logs.py
@@ -1071,6 +1071,40 @@ def test_logs_tool_call_argument_formatting(logs_db):
     ) in normalized_output
 
 
+def test_logs_tool_schema_without_properties(logs_db):
+    runner = CliRunner()
+    code = textwrap.dedent("""
+    def ping():
+        return "pong"
+    """)
+    result1 = runner.invoke(
+        cli,
+        [
+            "-m",
+            "echo",
+            "--functions",
+            code,
+            json.dumps({"tool_calls": [{"name": "ping"}]}),
+        ],
+    )
+    assert result1.exit_code == 0
+
+    # Simulate a plugin-defined tool whose input_schema omits the "properties" key.
+    # In practice this can happen when a plugin creates Tool(name=...) directly with
+    # input_schema={} instead of going through Tool.function(), which always adds
+    # "properties" via Pydantic. Rewrite the stored schema to reproduce the crash.
+    from llm.cli import logs_db_path
+    import pathlib
+
+    db = sqlite_utils.Database(pathlib.Path(logs_db_path()))
+    db.execute("UPDATE tools SET input_schema = '{}' WHERE name = 'ping'")
+
+    # Should not raise KeyError: 'properties'
+    result2 = runner.invoke(cli, ["logs", "-c"])
+    assert result2.exit_code == 0
+    assert "Arguments" in result2.output
+
+
 def test_logs_backup(logs_db):
     assert not logs_db.tables
     runner = CliRunner()


### PR DESCRIPTION
In `llm/cli.py` line 2241, `logs_list` accesses `tool["input_schema"]["properties"]` when rendering the tool section of `llm logs`. A plugin can create a `Tool` instance directly with the default `input_schema={}` rather than going through `Tool.function()`, which always adds a `"properties"` key via Pydantic. Any such tool stored in the database causes `llm logs` to abort with `KeyError: 'properties'`. The fix changes the access to `tool["input_schema"].get("properties", {})`, and a new test reproduces the crash by rewriting a logged tool's schema to omit that key.

---
_Generated by [Claude Code](https://claude.ai/code/session_019bFwrH9ZknFMcVEZvCV1h6)_