### PR TITLE
Fix after_call not invoked for unknown tool names

### DIFF
--- a/llm/models.py
+++ b/llm/models.py
@@ -1884,14 +1884,20 @@ class Response(_BaseResponse):
 
             if tool is None:
                 msg = 'tool "{}" does not exist'.format(tool_call.name)
-                tool_results.append(
-                    ToolResult(
-                        name=tool_call.name,
-                        output="Error: " + msg,
-                        tool_call_id=tool_call.tool_call_id,
-                        exception=KeyError(msg),
-                    )
+                _tr = ToolResult(
+                    name=tool_call.name,
+                    output="Error: " + msg,
+                    tool_call_id=tool_call.tool_call_id,
+                    exception=KeyError(msg),
                 )
+                if after_call:
+                    cb_result = after_call(None, tool_call, _tr)
+                    if inspect.isawaitable(cb_result):
+                        raise TypeError(
+                            "Asynchronous 'after_call' callback provided to a synchronous tool execution context. "
+                            "Please use an async chain/response or a synchronous callback."
+                        )
+                tool_results.append(_tr)
                 continue
 
             if not tool.implementation:
@@ -2242,17 +2248,21 @@ class AsyncResponse(_BaseResponse):
                         break
                 reason = "does not exist" if tool is None else "has no implementation"
                 msg = 'tool "{}" {}'.format(tc.name, reason)
-                indexed_results.append(
-                    (
-                        idx,
-                        ToolResult(
-                            name=tc.name,
-                            output="Error: " + msg,
-                            tool_call_id=tc.tool_call_id,
-                            exception=KeyError(msg),
-                        ),
-                    )
+                _tr = ToolResult(
+                    name=tc.name,
+                    output="Error: " + msg,
+                    tool_call_id=tc.tool_call_id,
+                    exception=KeyError(msg),
                 )
+                if after_call:
+                    try:
+                        cb2 = after_call(None, tc, _tr)
+                        if inspect.isawaitable(cb2):
+                            await cb2
+                    except Exception as ex:
+                        failures.append((idx, ex))
+                        break
+                indexed_results.append((idx, _tr))
                 continue
 
             if inspect.iscoroutinefunction(tool.implementation):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -392,6 +392,51 @@ def test_incorrect_tool_usage():
     assert 'Error: tool \\"bad_tool\\" does not exist' in output
 
 
+def test_after_call_invoked_for_unknown_tool():
+    # Regression test for https://github.com/simonw/llm/issues/1151
+    # after_call must fire even when the model names a tool that doesn't exist.
+    model = llm.get_model("echo")
+    after_collected = []
+
+    def after(*args):
+        after_collected.append(args)
+
+    chain_response = model.chain(
+        json.dumps({"tool_calls": [{"name": "bad_tool"}]}),
+        tools=[llm_time],
+        after_call=after,
+    )
+    chain_response.text()
+    assert len(after_collected) == 1
+    tool_arg, tool_call_arg, result_arg = after_collected[0]
+    assert tool_arg is None
+    assert tool_call_arg.name == "bad_tool"
+    assert "does not exist" in result_arg.output
+
+
+@pytest.mark.asyncio
+async def test_after_call_invoked_for_unknown_tool_async():
+    # Regression test for https://github.com/simonw/llm/issues/1151
+    # after_call must fire even when the model names a tool that doesn't exist (async path).
+    model = llm.get_async_model("echo")
+    after_collected = []
+
+    async def after(*args):
+        after_collected.append(args)
+
+    chain_response = model.chain(
+        json.dumps({"tool_calls": [{"name": "bad_tool"}]}),
+        tools=[llm_time],
+        after_call=after,
+    )
+    await chain_response.text()
+    assert len(after_collected) == 1
+    tool_arg, tool_call_arg, result_arg = after_collected[0]
+    assert tool_arg is None
+    assert tool_call_arg.name == "bad_tool"
+    assert "does not exist" in result_arg.output
+
+
 def test_tool_returning_attachment():
     model = llm.get_model("echo")
 


### PR DESCRIPTION
When a tool response references a tool name not in the registered tools list, the `after_call` callback was silently skipped in both the sync and async code paths, preventing callers from observing or cleaning up after the call. This fixes both paths to always invoke `after_call` regardless of whether the tool name is recognized. Fixes #1151

---
_Generated by [Claude Code](https://claude.ai/code/session_013z7cuMj9hfx3VxhuQJvYUA)_