### PR TITLE
Set busy_timeout in migrate() to prevent locking errors under parallel invocations

### DIFF
--- a/llm/migrations.py
+++ b/llm/migrations.py
@@ -6,6 +6,7 @@ migration = MIGRATIONS.append
 
 
 def migrate(db):
+    db.conn.execute("PRAGMA busy_timeout=5000")
     ensure_migrations_table(db)
     already_applied = {r["name"] for r in db["_llm_migrations"].rows}
     for fn in MIGRATIONS:

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -25,6 +25,13 @@ EXPECTED = {
 }
 
 
+def test_migrate_sets_busy_timeout():
+    db = sqlite_utils.Database(memory=True)
+    migrate(db)
+    timeout = db.conn.execute("PRAGMA busy_timeout").fetchone()[0]
+    assert timeout == 5000
+
+
 def test_migrate_blank():
     db = sqlite_utils.Database(memory=True)
     migrate(db)


### PR DESCRIPTION
When multiple llm processes run concurrently (e.g. via xargs), they all call migrate() on the same logs.db right after opening it. SQLite's default busy timeout is 0 ms, so any process that finds the database locked immediately raises OperationalError. Setting PRAGMA busy_timeout=5000 makes SQLite wait up to 5 seconds for the lock to clear before failing, which is the standard fix for this class of SQLite multi-process contention. Fixes #789

---
_Generated by [Claude Code](https://claude.ai/code/session_011KHJuenHnLSXG4p8DiYepi)_