### PR TITLE
Un-skip and fix Windows tests (#409)

### DIFF
--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -9,7 +9,6 @@ import sys
 import textwrap
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Expected to fail on Windows")
 def test_chat_basic(mock_model, logs_db):
     runner = CliRunner()
     mock_model.enqueue(["one world"])
@@ -134,7 +133,6 @@ def test_chat_basic(mock_model, logs_db):
     ]
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Expected to fail on Windows")
 def test_chat_system(mock_model, logs_db):
     runner = CliRunner()
     mock_model.enqueue(["I am mean"])
@@ -179,7 +177,6 @@ def test_chat_system(mock_model, logs_db):
     ]
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Expected to fail on Windows")
 def test_chat_options(mock_model, logs_db, user_path):
     options_path = user_path / "model_options.json"
     options_path.write_text(json.dumps({"mock": {"max_tokens": "5"}}), "utf-8")
@@ -242,7 +239,6 @@ def test_chat_options(mock_model, logs_db, user_path):
     ]
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Expected to fail on Windows")
 @pytest.mark.parametrize(
     "input,expected",
     (
@@ -312,7 +308,6 @@ def test_llm_chat_creates_log_database(tmpdir, monkeypatch, custom_database_path
     assert sqlite_utils.Database(db_path)["responses"].count == 2
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Expected to fail on Windows")
 def test_chat_tools(logs_db):
     runner = CliRunner()
     functions = textwrap.dedent("""
@@ -378,7 +373,10 @@ def test_chat_tools(logs_db):
     )
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Expected to fail on Windows")
+@pytest.mark.xfail(
+    sys.platform == "win32",
+    reason="Windows drive-letter paths (C:\\...) are misread as fragment prefixes",
+)
 def test_chat_fragments(tmpdir):
     path1 = str(tmpdir / "frag1.txt")
     path2 = str(tmpdir / "frag2.txt")

--- a/tests/test_chat_templates.py
+++ b/tests/test_chat_templates.py
@@ -4,7 +4,6 @@ import llm.cli
 import pytest
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Expected to fail on Windows")
 def test_chat_template_system_only_no_duplicate_prompt(
     mock_model, logs_db, templates_path
 ):
@@ -30,7 +29,10 @@ def test_chat_template_system_only_no_duplicate_prompt(
     assert rows[0]["system"] == "Speak in French"
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Expected to fail on Windows")
+@pytest.mark.xfail(
+    sys.platform == "win32",
+    reason="Windows drive-letter paths (C:\\...) are misread as fragment prefixes",
+)
 def test_chat_system_fragments_only_first_turn(tmpdir, mock_model, logs_db):
     # Create a system fragment file
     sys_frag_path = str(tmpdir / "sys.txt")
@@ -62,7 +64,6 @@ def test_chat_system_fragments_only_first_turn(tmpdir, mock_model, logs_db):
     assert sys_frags[0]["response_id"] != second_id
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Expected to fail on Windows")
 def test_chat_template_loads_tools_into_logs(logs_db, templates_path):
     # Template that specifies tools; ensure chat picks them up
     (templates_path / "mytools.yaml").write_text(

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -6,7 +6,6 @@ import pytest
 import sys
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Expected to fail on Windows")
 @pytest.mark.parametrize("env", ({}, {"LLM_USER_PATH": "/tmp/llm-keys-test"}))
 def test_keys_in_user_path(monkeypatch, env, user_path):
     for key, value in env.items():
@@ -15,13 +14,13 @@ def test_keys_in_user_path(monkeypatch, env, user_path):
     result = runner.invoke(cli, ["keys", "path"])
     assert result.exit_code == 0
     if env:
-        expected = env["LLM_USER_PATH"] + "/keys.json"
+        base = env["LLM_USER_PATH"]
     else:
-        expected = user_path + "/keys.json"
+        base = str(user_path)
+    expected = str(pathlib.Path(base) / "keys.json")
     assert result.output.strip() == expected
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Expected to fail on Windows")
 def test_keys_set(monkeypatch, tmpdir):
     user_path = tmpdir / "user/keys"
     monkeypatch.setenv("LLM_USER_PATH", str(user_path))
@@ -31,8 +30,9 @@ def test_keys_set(monkeypatch, tmpdir):
     result = runner.invoke(cli, ["keys", "set", "openai"], input="foo")
     assert result.exit_code == 0
     assert keys_path.exists()
-    # Should be chmod 600
-    assert oct(keys_path.stat().mode)[-3:] == "600"
+    # Should be chmod 600 - not enforceable on Windows, which lacks POSIX file modes
+    if sys.platform != "win32":
+        assert oct(keys_path.stat().mode)[-3:] == "600"
     content = keys_path.read_text("utf-8")
     assert json.loads(content) == {
         "// Note": "This file stores secret API credentials. Do not share!",
@@ -40,7 +40,6 @@ def test_keys_set(monkeypatch, tmpdir):
     }
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Expected to fail on Windows")
 def test_keys_get(monkeypatch, tmpdir):
     user_path = tmpdir / "user/keys"
     monkeypatch.setenv("LLM_USER_PATH", str(user_path))

--- a/tests/test_llm_logs.py
+++ b/tests/test_llm_logs.py
@@ -9,7 +9,6 @@ import pathlib
 import pytest
 import re
 import sqlite_utils
-import sys
 import textwrap
 import time
 from ulid import ULID
@@ -315,7 +314,6 @@ def test_logs_short(log_path, arg, usage):
     assert output == expected
 
 
-@pytest.mark.xfail(sys.platform == "win32", reason="Expected to fail on Windows")
 @pytest.mark.parametrize("env", ({}, {"LLM_USER_PATH": "/tmp/llm-user-path"}))
 def test_logs_path(monkeypatch, env, user_path):
     for key, value in env.items():
@@ -324,9 +322,10 @@ def test_logs_path(monkeypatch, env, user_path):
     result = runner.invoke(cli, ["logs", "path"])
     assert result.exit_code == 0
     if env:
-        expected = env["LLM_USER_PATH"] + "/logs.db"
+        base = env["LLM_USER_PATH"]
     else:
-        expected = str(user_path) + "/logs.db"
+        base = str(user_path)
+    expected = str(pathlib.Path(base) / "logs.db")
     assert result.output.strip() == expected
 
 


### PR DESCRIPTION
Fixes #409.

On Windows today, many tests marked `@pytest.mark.xfail(sys.platform == "win32")` actually pass — the markers are stale (the `test_chat` ones appear to have been fixed by the addition of `pyreadline3`). This removes the stale markers and fixes the handful that were genuinely failing:

- **Removed 8 now-passing `xfail` markers** in `test_chat.py`, `test_chat_templates.py`, and `test_keys.py`.
- **Fixed hardcoded `/` path separators** in `test_keys_in_user_path` and `test_logs_path` by normalizing the expected paths with `pathlib` (correct on every platform).
- **Guarded the `chmod 600` assertion** in `test_keys_set` to non-Windows, since Windows has no POSIX file modes.
- Removed the now-unused `import sys` from `test_llm_logs.py`.

Two `fragments` tests still `xfail` on Windows — they surface a genuine bug where drive-letter paths (`C:\...`) are parsed as fragment prefixes (`Error: Unknown fragment prefix: C`). I've updated their `reason` strings to document the real cause and am happy to send a follow-up PR for the underlying fix.

### Verification

Run on Windows 11 / Python 3.14 for the affected files:

```
94 passed, 2 xfailed
```

`black` and `ruff` are both clean.
