### PR TITLE
Deduplicate variable names in Template MissingVariables error

### DIFF
--- a/llm/templates.py
+++ b/llm/templates.py
@@ -76,7 +76,7 @@ class Template(BaseModel):
         # Confirm all variables in text are provided
         string_template = string.Template(text)
         vars = cls.extract_vars(string_template)
-        missing = [p for p in vars if p not in params]
+        missing = list(dict.fromkeys(p for p in vars if p not in params))
         if missing:
             raise cls.MissingVariables(
                 "Missing variables: {}".format(", ".join(missing))

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -21,6 +21,9 @@ from llm.plugins import pm
         ("S: $input", "system", None, {}, "S: input", "system", None),
         ("No vars", None, None, {}, "No vars", None, None),
         ("$one and $two", None, None, {}, None, None, "Missing variables: one, two"),
+        # A variable reused in the template is reported once, not once per use.
+        ("$name and $name", None, None, {}, None, None, "Missing variables: name"),
+        ("$a $b $a", None, None, {}, None, None, "Missing variables: a, b"),
         ("$one and $two", None, None, {"one": 1, "two": 2}, "1 and 2", None, None),
         ("$one and $two", None, {"one": 1}, {"two": 2}, "1 and 2", None, None),
         ("$one and $$2", None, None, {"one": 1}, "1 and $2", None, None),


### PR DESCRIPTION
When a template reuses the same variable and it isn't supplied, the error currently lists it once per textual occurrence:

```python
Template(name="t", prompt="Dear $name, from $name").evaluate("input", {})
# llm.templates.MissingVariables: Missing variables: name, name
```

A variable is either missing or not, so reporting it N times is incorrect. `Template.interpolate` builds `missing = [p for p in vars if p not in params]` without de-duplicating.

This de-duplicates the missing list while preserving first-seen order, so `"Dear $name, from $name"` reports `Missing variables: name` and `"$a $b $a"` reports `Missing variables: a, b`. The existing distinct-variable message (`Missing variables: one, two`) is unchanged.

Adds two parametrized cases to `tests/test_templates.py::test_template_evaluate`. Full `tests/test_templates.py` suite passes (47).