### PR TITLE
docs: clarify model listing API key requirements

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -2497,7 +2497,11 @@ def render_model_with_options(model_id, *, async_=False):
 )
 @click.option("model_ids", "-m", "--model", help="Specific model IDs", multiple=True)
 def models_list(options, async_, schemas, tools, query, model_ids):
-    "List available models"
+    """List available models.
+
+    Some plugins only register their models after an API key is configured.
+    Run 'llm keys set' to store API keys for installed model providers.
+    """
     models_that_have_shown_options = set()
     for model_with_aliases in get_models_with_aliases():
         if async_ and not model_with_aliases.async_model:

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -523,6 +523,14 @@ def test_llm_models_options(user_path):
     assert "AsyncMockModel (async): mock" not in result.output
 
 
+def test_llm_models_help_mentions_api_keys():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["models", "list", "--help"])
+    assert result.exit_code == 0
+    assert "Some plugins only register their models after an API key" in result.output
+    assert "llm keys set" in result.output
+
+
 def test_prompt_options_shows_selected_model_options(user_path):
     runner = CliRunner()
     result = runner.invoke(cli, ["-m", "gpt-5.5", "--options"], catch_exceptions=False)


### PR DESCRIPTION
## Summary

Clarifies the `llm models list --help` output so users know that some plugins only register models after an API key is configured. The help text points users to `llm keys set`, and a regression test covers both messages.

Fixes #1175.

## Testing

- `uv run pytest tests/test_llm.py -k "models_help_mentions_api_keys or llm_models_options"` (2 passed)
- `uv run ruff check llm/cli.py tests/test_llm.py`
- `uv run black --check llm/cli.py tests/test_llm.py`
- `git diff --check`

The full suite reached 701 passing tests but has existing embedding migration failures with `sqlite-utils 4.1.1` (`sqlite3.OperationalError: cannot commit - no transaction is active`), consistent with the open compatibility report in #1523. The changed model-list tests pass independently.
