### PR TITLE
feat: add random choice default tool

### DIFF
--- a/llm/default_plugins/default_tools.py
+++ b/llm/default_plugins/default_tools.py
@@ -1,8 +1,9 @@
 import llm
-from llm.tools import llm_time, llm_version
+from llm.tools import llm_random_choice, llm_time, llm_version
 
 
 @llm.hookimpl
 def register_tools(register):
     register(llm_version)
     register(llm_time)
+    register(llm_random_choice)

--- a/llm/tools.py
+++ b/llm/tools.py
@@ -1,3 +1,4 @@
+import random
 import time
 from datetime import datetime, timezone
 from importlib.metadata import version
@@ -35,3 +36,8 @@ def llm_time() -> dict:
         "timezone_offset": timezone_offset,
         "is_dst": is_dst,
     }
+
+
+def llm_random_choice(choices: list[str]) -> str:
+    "Return a random choice from a list of strings"
+    return random.choice(choices)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -12,7 +12,7 @@ from click.testing import CliRunner
 import llm
 from llm import CancelToolCall, cli
 from llm.migrations import migrate
-from llm.tools import llm_time
+from llm.tools import llm_random_choice, llm_time
 
 API_KEY = os.environ.get("PYTEST_OPENAI_API_KEY", None) or "badkey"
 
@@ -378,6 +378,33 @@ def test_default_tool_llm_time():
         "utc_time",
         "is_dst",
     }
+
+
+def test_default_tool_llm_random_choice(monkeypatch):
+    monkeypatch.setattr("llm.tools.random.choice", lambda choices: choices[-1])
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.cli,
+        [
+            "-m",
+            "echo",
+            "-T",
+            "llm_random_choice",
+            json.dumps(
+                {
+                    "tool_calls": [
+                        {
+                            "name": "llm_random_choice",
+                            "arguments": {"choices": ["red", "green", "blue"]},
+                        }
+                    ]
+                }
+            ),
+        ],
+    )
+    assert result.exit_code == 0
+    assert '"output": "blue"' in result.output
+    assert llm_random_choice(["one", "two"]) == "two"
 
 
 def test_incorrect_tool_usage():


### PR DESCRIPTION
## Summary

Adds the `llm_random_choice` default tool proposed in #1178. The tool accepts a list of strings and returns one entry using `random.choice`, and is registered alongside `llm_version` and `llm_time`.

The regression test patches the chooser deterministically and invokes the tool through the real `llm -T` CLI path, covering registration, argument decoding, and the returned tool result.

Fixes #1178.

## Testing

- `uv run pytest tests/test_tools.py` (35 passed)
- `uv run ruff check llm/tools.py llm/default_plugins/default_tools.py tests/test_tools.py`
- `uv run black --check llm/tools.py llm/default_plugins/default_tools.py tests/test_tools.py`
- `git diff --check`
