### PR TITLE
Add count mode to logs command

### DIFF
--- a/docs/help.md
+++ b/docs/help.md
@@ -344,8 +344,9 @@ Usage: llm logs list [OPTIONS]
   Show logged prompts and their responses
 
 Options:
-  -n, --count INTEGER         Number of entries to show - defaults to 3, use 0
+  -n, --limit INTEGER         Number of entries to show - defaults to 3, use 0
                               for all
+  --count                     Output the number of matching log entries
   -d, --database FILE         Path to log database
   -m, --model TEXT            Filter by model or model alias
   -q, --query TEXT            Search for logs matching this string

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -85,6 +85,10 @@ Or `-n 0` to see everything that has ever been logged:
 ```bash
 llm logs -n 0
 ```
+Use `--count` to output the number of logs matching the current filters:
+```bash
+llm logs --tools --count
+```
 You can truncate the display of the prompts and responses using the `-t/--truncate` option. This can help make the JSON output more readable - though the `--short` option is usually better.
 ```bash
 llm logs -n 1 -t --json

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1695,10 +1695,16 @@ def logs_json_for_response_ids(db, ids):
 @logs.command(name="list")
 @click.option(
     "-n",
-    "--count",
+    "--limit",
     type=int,
     default=None,
     help="Number of entries to show - defaults to 3, use 0 for all",
+)
+@click.option(
+    "count_only",
+    "--count",
+    is_flag=True,
+    help="Output the number of matching log entries",
 )
 @click.option(
     "-p",
@@ -1794,7 +1800,8 @@ def logs_json_for_response_ids(db, ids):
     help="Expand fragments to show their content",
 )
 def logs_list(
-    count,
+    limit,
+    count_only,
     path,
     database,
     model,
@@ -1866,11 +1873,11 @@ def logs_list(
             raise click.ClickException("No conversations found")
 
     # For --conversation set limit 0, if not explicitly set
-    if count is None:
+    if limit is None:
         if conversation_id:
-            count = 0
+            limit = 0
         else:
-            count = 3
+            limit = 3
 
     model_id = None
     if model:
@@ -1889,7 +1896,7 @@ def logs_list(
     try:
         rows = merged_log_rows(
             store,
-            count=count if count and count > 0 else None,
+            count=None if count_only else (limit if limit and limit > 0 else None),
             model_id=model_id,
             thread_id=conversation_id,
             fragment_hashes=fragment_hashes,
@@ -1910,6 +1917,10 @@ def logs_list(
                 "documentation at https://sqlite.org/fts5.html#full_text_query_syntax"
             )
         raise
+
+    if count_only:
+        click.echo(len(rows))
+        return
 
     # Newest first out of the query, but read chronologically - except
     # for search results, which are already most-relevant first.

--- a/tests/test_llm_logs.py
+++ b/tests/test_llm_logs.py
@@ -227,6 +227,39 @@ def test_logs_json(n, log_path):
     assert len(logs) == expected_length
 
 
+def test_logs_limit_long_option(log_path):
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["logs", "--limit", "2", "-p", str(log_path), "--json"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert len(json.loads(result.output)) == 2
+
+
+@pytest.mark.parametrize(
+    "args, expected",
+    (
+        ([], 100),
+        (["--model", "davinci"], 100),
+        (["--model", "missing"], 0),
+        (["--query", "prompt"], 100),
+        (["--query", "missing"], 0),
+        (["--limit", "2"], 100),
+    ),
+)
+def test_logs_count(args, expected, log_path):
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["logs", "--count", "-p", str(log_path)] + args,
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert result.output == f"{expected}\n"
+
+
 @pytest.mark.parametrize(
     "args", (["-r"], ["--response"], ["list", "-r"], ["list", "--response"])
 )
@@ -1114,6 +1147,7 @@ def test_logs_tools(logs_db):
     logs_tools_output = runner.invoke(cli, ["logs", "--tools"]).output
     assert "badger" not in logs_tools_output
     assert "three" in logs_tools_output
+    assert runner.invoke(cli, ["logs", "--tools", "--count"]).output == "1\n"
 
 
 def test_logs_repeated_tools_use_short_hash(logs_db):


### PR DESCRIPTION
## Summary

- keep `-n` for limiting displayed logs and rename its long form to `--limit`
- add `llm logs --count` using the existing query construction so all filters are respected
- document the new mode and update generated CLI help
- cover unfiltered, model, search, limit-independent, and tool-filtered counts

Closes #1071

## Validation

- `uv run pytest tests/test_llm_logs.py -q` (83 passed)
- `uv run black --check .`
- `uv run ruff check .`
- targeted Cog check for `docs/help.md` and `docs/logging.md`

The full suite reached 707 passing tests; its embedding migration failures reproduce unchanged on clean `upstream/main` with the locally resolved `sqlite-utils` version (`cannot commit - no transaction is active`).