### PR TITLE
Coerce tool arguments using function annotations

### DIFF
--- a/llm/models.py
+++ b/llm/models.py
@@ -150,8 +150,15 @@ class Tool:
     input_schema: dict = field(default_factory=dict)
     implementation: Callable | None = None
     plugin: str | None = None  # plugin tool came from, e.g. 'llm_tools_sqlite'
+    _input_model: type[BaseModel] | None = field(
+        default=None, init=False, repr=False, compare=False
+    )
 
     def __post_init__(self):
+        if inspect.isclass(self.input_schema) and issubclass(
+            self.input_schema, BaseModel
+        ):
+            self._input_model = self.input_schema
         # Convert Pydantic model to JSON schema if needed
         self.input_schema = _ensure_dict_schema(self.input_schema)
 
@@ -224,6 +231,11 @@ def _implementation_arguments(tool: "Tool", tool_call: "ToolCall") -> dict:
     the ToolCall object itself - a ``**kwargs`` catch-all does not count.
     """
     arguments = dict(tool_call.arguments)
+    if tool._input_model is not None:
+        validated = tool._input_model.model_validate(arguments)
+        arguments.update(
+            {name: getattr(validated, name) for name in tool._input_model.model_fields}
+        )
     if _accepts_llm_tool_call(tool.implementation):
         arguments["llm_tool_call"] = tool_call
     return arguments

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -8,6 +8,7 @@ from importlib.metadata import version
 import pytest
 import sqlite_utils
 from click.testing import CliRunner
+from pydantic import ValidationError
 
 import llm
 from llm import CancelToolCall, cli
@@ -725,6 +726,90 @@ def test_tool_function_receives_llm_tool_call():
     assert tool_call.arguments == {"name": "simon"}
     second = chain_response._responses[1]
     assert second.prompt.tool_results[0].output == "result for simon"
+
+
+def test_tool_function_coerces_arguments_using_annotations():
+    captured = {}
+
+    def calculate(quantity: int, price: float, llm_tool_call) -> float:
+        captured.update(quantity=quantity, price=price, llm_tool_call=llm_tool_call)
+        return quantity * price
+
+    supplied_arguments = {"quantity": "34234", "price": "1.25"}
+    model = llm.get_model("echo")
+    chain_response = model.chain(
+        json.dumps(
+            {"tool_calls": [{"name": "calculate", "arguments": supplied_arguments}]}
+        ),
+        tools=[calculate],
+    )
+    chain_response.text()
+
+    assert captured["quantity"] == 34234
+    assert isinstance(captured["quantity"], int)
+    assert captured["price"] == 1.25
+    assert isinstance(captured["price"], float)
+    assert captured["llm_tool_call"].arguments == supplied_arguments
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("async_tool", (False, True))
+async def test_async_model_coerces_tool_arguments(async_tool):
+    captured = {}
+
+    def calculate(quantity: int, price: float) -> float:
+        captured.update(quantity=quantity, price=price)
+        return quantity * price
+
+    async def async_calculate(quantity: int, price: float) -> float:
+        captured.update(quantity=quantity, price=price)
+        return quantity * price
+
+    function = async_calculate if async_tool else calculate
+    model = llm.get_async_model("echo")
+    chain_response = model.chain(
+        json.dumps(
+            {
+                "tool_calls": [
+                    {
+                        "name": function.__name__,
+                        "arguments": {"quantity": "34234", "price": "1.25"},
+                    }
+                ]
+            }
+        ),
+        tools=[function],
+    )
+    await chain_response.text()
+
+    assert captured == {"quantity": 34234, "price": 1.25}
+
+
+def test_invalid_coerced_argument_produces_tool_error():
+    called = False
+
+    def calculate(quantity: int) -> int:
+        nonlocal called
+        called = True
+        return quantity * 2
+
+    model = llm.get_model("echo")
+    chain_response = model.chain(
+        json.dumps(
+            {
+                "tool_calls": [
+                    {"name": "calculate", "arguments": {"quantity": "not-a-number"}}
+                ]
+            }
+        ),
+        tools=[calculate],
+    )
+    chain_response.text()
+
+    result = chain_response._responses[1].prompt.tool_results[0]
+    assert called is False
+    assert isinstance(result.exception, ValidationError)
+    assert "Input should be a valid integer" in result.output
 
 
 def test_async_tool_function_receives_llm_tool_call_with_sync_model():


### PR DESCRIPTION
Closes #1027

## Summary

- retain the Pydantic input model created for function-backed tools
- validate and coerce a copy of model-supplied arguments before invocation
- preserve the original `ToolCall.arguments` payload and `llm_tool_call` injection
- report invalid values through the existing tool-error path

## Tests

- `uv run pytest -q tests/test_tools.py` (38 passed)
- `uv run black . --check`
- `uv run ruff check .`
- `uv run mypy llm`
- repository Cog check

The full suite reached 704 passing tests; its embedding failures reproduce on clean `upstream/main` with the locally resolved `sqlite-utils` transaction behavior (`cannot commit - no transaction is active`).