### PR TITLE
Fix IndexError in schema_dsl() when a field has no name before the colon

### DIFF
--- a/llm/utils.py
+++ b/llm/utils.py
@@ -392,6 +392,10 @@ def schema_dsl(schema_dsl: str, multi: bool = False) -> Dict[str, Any]:
 
         # Process field name and type
         field_parts = field_info.strip().split()
+        if not field_parts:
+            raise ValueError(
+                f"Field definition {field!r} has no field name before the colon"
+            )
         field_name = field_parts[0].strip()
 
         # Default type is string

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -247,6 +247,18 @@ def test_schema_dsl_multi():
 
 
 @pytest.mark.parametrize(
+    "bad_dsl",
+    [
+        ":just a description",
+        "name, :no name before colon",
+    ],
+)
+def test_schema_dsl_no_field_name_raises(bad_dsl):
+    with pytest.raises(ValueError, match="has no field name"):
+        schema_dsl(bad_dsl)
+
+
+@pytest.mark.parametrize(
     "text, max_length, normalize_whitespace, keep_end, expected",
     [
         # Basic truncation tests


### PR DESCRIPTION
When a DSL string like ':description' or 'name, :no-name' is passed to schema_dsl(), field_info is empty, so split() returns [] and indexing [0] raises a bare IndexError. This adds a guard that raises a clear ValueError with the offending field shown, and adds two regression tests covering both the standalone and mixed-field cases. Fixes #1466

---
_Generated by [Claude Code](https://claude.ai/code/session_01NnsjqzUor3v7fYAGYVU6FA)_