### PR TITLE
Fix schema_dsl() IndexError when a field has no name before the colon

### DIFF
--- a/llm/utils.py
+++ b/llm/utils.py
@@ -392,6 +392,8 @@ def schema_dsl(schema_dsl: str, multi: bool = False) -> Dict[str, Any]:
 
         # Process field name and type
         field_parts = field_info.strip().split()
+        if not field_parts:
+            continue
         field_name = field_parts[0].strip()
 
         # Default type is string

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -218,6 +218,17 @@ def test_extract_fenced_code_block(input, last, expected):
                 "required": ["name", "age"],
             },
         ),
+        # Test case 9: Field with no name before the colon is silently skipped
+        (":just a description", {"type": "object", "properties": {}, "required": []}),
+        # Test case 10: Mix of named and unnamed fields; unnamed field is skipped
+        (
+            "name, :description",
+            {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["name"],
+            },
+        ),
     ],
 )
 def test_schema_dsl(schema, expected):


### PR DESCRIPTION
When `schema_dsl()` receives a field with no name before the colon (e.g. `':description'` or `'name, :description'`), `field_info.strip().split()` returns an empty list and the subsequent `field_parts[0]` indexing raises `IndexError`. The fix adds a `continue` guard when `field_parts` is empty, silently skipping nameless fields; two new parametrize cases in `test_utils.py` cover both the all-nameless and mixed cases. Fixes #1545