### PR TITLE
Fix parsing failure when prompt text starts with -- and contains a space

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1,6 +1,22 @@
 import asyncio
 import click
 from click_default_group import DefaultGroup
+
+
+class _LLMDefaultGroup(DefaultGroup):
+    """DefaultGroup that treats arg0 values containing a space as positional arguments.
+
+    When the user runs `llm "--find me"`, click-default-group dispatches "--find me"
+    to the default subcommand as arg0.  If arg0 contains a space it cannot be a valid
+    option name, so we insert '--' before it so the subcommand parser treats it as a
+    positional argument rather than an unknown option.
+    """
+
+    def resolve_command(self, ctx, args):
+        cmd_name, cmd, remaining = super().resolve_command(ctx, args)
+        if hasattr(ctx, "arg0") and ctx.arg0 and " " in ctx.arg0:
+            remaining.insert(0, "--")
+        return cmd_name, cmd, remaining
 from dataclasses import asdict
 from importlib.metadata import version
 import io
@@ -342,7 +358,7 @@ def schema_option(fn):
 
 
 @click.group(
-    cls=DefaultGroup,
+    cls=_LLMDefaultGroup,
     default="prompt",
     default_if_no_args=True,
     context_settings={"help_option_names": ["-h", "--help"]},

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -19,6 +19,17 @@ def test_version():
         assert result.output.startswith("cli, version ")
 
 
+def test_prompt_with_option_like_text():
+    # llm "--find me" should not fail with a parse error ("No such option").
+    # The value gets dispatched to the prompt subcommand as a positional arg.
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--find me"])
+    # Exit code 2 means a Click UsageError (parse failure). Any other code is fine —
+    # the parse succeeded; it may still fail for other reasons (no API key, etc.).
+    assert result.exit_code != 2, result.output
+    assert "No such option" not in result.output
+
+
 @pytest.mark.parametrize("custom_database_path", (False, True))
 def test_llm_prompt_creates_log_database(
     mocked_openai_chat, tmpdir, monkeypatch, custom_database_path


### PR DESCRIPTION
Running `llm "--find me"` failed with "No such option: --find me" because click-default-group dispatches the quoted string as arg0 to the prompt subcommand, which then tries to parse it as an option flag. Option names cannot contain spaces, so a custom DefaultGroup subclass now inserts '--' before arg0 when it contains a space, telling the subcommand parser to treat it as a positional argument. Fixes #245

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y8kHj1xMWAbPswh2BnzPUf)_