### PR TITLE
Fix fragment filter SQL broken by SQLite 3.51.0 EXISTS/UNION change

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1780,19 +1780,22 @@ def logs_list(
 
         for i, fragment_hash in enumerate(fragment_hashes):
             exists_clause = f"""
-            exists (
-                select 1 from prompt_fragments
-                where prompt_fragments.response_id = responses.id
-                and prompt_fragments.fragment_id in (
-                    select fragments.id from fragments
-                    where hash = :f{i}
+            (
+                exists (
+                    select 1 from prompt_fragments
+                    where prompt_fragments.response_id = responses.id
+                    and prompt_fragments.fragment_id in (
+                        select fragments.id from fragments
+                        where hash = :f{i}
+                    )
                 )
-                union
-                select 1 from system_fragments
-                where system_fragments.response_id = responses.id
-                and system_fragments.fragment_id in (
-                    select fragments.id from fragments
-                    where hash = :f{i}
+                or exists (
+                    select 1 from system_fragments
+                    where system_fragments.response_id = responses.id
+                    and system_fragments.fragment_id in (
+                        select fragments.id from fragments
+                        where hash = :f{i}
+                    )
                 )
             )
             """


### PR DESCRIPTION
SQLite 3.51.0 broke correlated `EXISTS` subqueries that internally use `UNION`, causing the `--fragment` filter in `llm logs` to return no results when both `prompt_fragments` and `system_fragments` have rows. The fix splits the single `EXISTS (... UNION ...)` into two separate `EXISTS` clauses joined by `OR`, which works correctly on all SQLite versions. Fixes #1511.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LNimtyhwsuZ4aXGDLardEM)_