### PR TITLE
Fix crash when the same file is passed as --attachment twice

### DIFF
--- a/llm/models.py
+++ b/llm/models.py
@@ -1525,6 +1525,7 @@ class _BaseResponse:
                     "attachment_id": attachment_id,
                     "order": index,
                 },
+                ignore=True,
             )
 
         # Persist any tools, tool calls and tool results

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -72,6 +72,21 @@ def _count_open_fds():
     return len(os.listdir(fd_dir))
 
 
+def test_duplicate_attachment_logs_once(mock_model, logs_db, tmp_path):
+    """Passing the same file twice must not crash with UNIQUE constraint failed."""
+    runner = CliRunner()
+    mock_model.enqueue(["ok"])
+    png_file = tmp_path / "img.png"
+    png_file.write_bytes(TINY_PNG)
+    result = runner.invoke(
+        cli.cli,
+        ["prompt", "-m", "mock", "describe", "-a", str(png_file), "-a", str(png_file)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert len(list(logs_db["prompt_attachments"].rows)) == 1
+
+
 @pytest.mark.skipif(
     sys.platform not in ("darwin", "linux"),
     reason="File descriptor counting only supported on macOS and Linux",


### PR DESCRIPTION
When the same file path is given to `--attachment` more than once, every occurrence produces the same `attachment_id` (SHA-256 of file bytes). The second `INSERT` into `prompt_attachments` — whose primary key is `(response_id, attachment_id)` — then fails with `sqlite3.IntegrityError: UNIQUE constraint failed`, crashing after the model has already replied. Adding `ignore=True` to that insert silently drops the duplicate row and lets logging complete normally. Fixes #1354

---
_Generated by [Claude Code](https://claude.ai/code/session_011kdzKxTWbPwfDUeXu3oiP1)_