### PR TITLE
Fix Windows absolute fragment paths

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -168,7 +168,7 @@ def resolve_fragments(
             resolved.append(Fragment(response.text, fragment))
         elif fragment == "-":
             resolved.append(Fragment(sys.stdin.read(), "-"))
-        elif has_plugin_prefix(fragment):
+        elif has_plugin_prefix(fragment) and not pathlib.Path(fragment).exists():
             prefix, rest = fragment.split(":", 1)
             loaders = get_fragment_loaders()
             if prefix not in loaders:

--- a/tests/test_fragments_cli.py
+++ b/tests/test_fragments_cli.py
@@ -1,3 +1,4 @@
+import json
 import os
 import textwrap
 from importlib.metadata import version
@@ -126,6 +127,24 @@ def test_fragments_list(user_path):
               source: file3.txt
               content: '3'
             """).strip())
+
+
+def test_fragment_absolute_path(user_path, tmp_path):
+    path = tmp_path / "fragment.txt"
+    path.write_text("Hello from an absolute path")
+
+    result = CliRunner().invoke(
+        cli, ["prompt", "-m", "echo", "-f", str(path)], catch_exceptions=False
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "prompt": "Hello from an absolute path",
+        "system": "",
+        "attachments": [],
+        "stream": True,
+        "previous": [],
+    }
 
 
 @mock.patch.dict(os.environ, {"OPENAI_API_KEY": "X"})


### PR DESCRIPTION
Closes #1563 by treating `C:\...` as a filesystem path rather than a fragment prefix if that path exists - same fix as #901 implemented for template loaders.

<details><summary>Codex PR</summary>

## Summary

- Prefer an existing filesystem path over fragment plugin-prefix interpretation.
- Add CLI regression coverage for loading a fragment from an absolute path.

## Why

On Windows, an absolute path such as `C:\path\file.txt` matches the fragment plugin-prefix check as `C:` and fails with an unknown-prefix error. Checking path existence before plugin dispatch resolves the ambiguity while preserving one-character plugin prefixes when no matching path exists. This also matches the existing template-loader behavior introduced for #901.

This fixes all callers of the shared fragment resolver, including `--fragment`, `--system-fragment`, chat fragments, fragment aliases, and fragment-based log filtering.

## Validation

- `uv run pytest -q` — 794 passed
- `uv run pytest tests/test_fragments_cli.py tests/test_plugins.py -q` — 12 passed
- `uv run ruff check llm/cli.py tests/test_fragments_cli.py`
- `uv run black --check llm/cli.py tests/test_fragments_cli.py`

</details>