### PR TITLE
Fix embed and embed_multi not backfilling content when store=True on re-embed

### DIFF
--- a/llm/embeddings.py
+++ b/llm/embeddings.py
@@ -134,9 +134,31 @@ class Collection:
         from llm import encode
 
         content_hash = self.content_hash(value)
-        if self.db["embeddings"].count_where(
-            "content_hash = ? and collection_id = ?", [content_hash, self.id]
-        ):
+        existing = list(
+            self.db["embeddings"].rows_where(
+                "content_hash = ? and collection_id = ?",
+                [content_hash, self.id],
+                limit=1,
+            )
+        )
+        if existing:
+            if store:
+                row = existing[0]
+                needs_update = (isinstance(value, str) and row.get("content") is None) or (
+                    isinstance(value, bytes) and row.get("content_blob") is None
+                )
+                if needs_update:
+                    self.db.execute(
+                        "update embeddings set content = ?, content_blob = ?, updated = ?"
+                        " where collection_id = ? and content_hash = ?",
+                        [
+                            value if isinstance(value, str) else None,
+                            value if isinstance(value, bytes) else None,
+                            int(time.time()),
+                            self.id,
+                            content_hash,
+                        ],
+                    )
             return
         embedding = self.model().embed(value)
         cast(Table, self.db["embeddings"]).insert(
@@ -199,18 +221,40 @@ class Collection:
             # Calculate hashes first
             items_and_hashes = [(item, self.content_hash(item[1])) for item in batch]
             # Any of those hashes already exist?
-            existing_ids = [
-                row["id"]
+            existing_rows = {
+                row["id"]: row
                 for row in self.db.query(
                     """
-                    select id from embeddings
+                    select id, content, content_blob from embeddings
                     where collection_id = ? and content_hash in ({})
                     """.format(",".join("?" for _ in items_and_hashes)),
                     [collection_id]
                     + [item_and_hash[1] for item_and_hash in items_and_hashes],
                 )
-            ]
+            }
+            existing_ids = set(existing_rows.keys())
             filtered_batch = [item for item in batch if item[0] not in existing_ids]
+            # When store=True, update content for existing rows that are missing it
+            if store:
+                for id_, value, _ in batch:
+                    if id_ not in existing_rows:
+                        continue
+                    row = existing_rows[id_]
+                    needs_update = (
+                        isinstance(value, str) and row.get("content") is None
+                    ) or (isinstance(value, bytes) and row.get("content_blob") is None)
+                    if needs_update:
+                        self.db.execute(
+                            "update embeddings set content = ?, content_blob = ?,"
+                            " updated = ? where collection_id = ? and id = ?",
+                            [
+                                value if isinstance(value, str) else None,
+                                value if isinstance(value, bytes) else None,
+                                int(time.time()),
+                                collection_id,
+                                id_,
+                            ],
+                        )
             embeddings = list(
                 self.model().embed_multi(item[1] for item in filtered_batch)
             )

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -148,6 +148,30 @@ def test_embed_multi(with_metadata, batch_size, expected_batches):
     assert collection.model().batch_count == expected_batches
 
 
+def test_embed_store_after_no_store(collection):
+    # collection fixture embeds id=1 "hello world" without store, so content=NULL
+    row = next(collection.db["embeddings"].rows_where("id = ?", ["1"]))
+    assert row["content"] is None
+    # Re-embed the same content with store=True
+    collection.embed("1", "hello world", store=True)
+    row = next(collection.db["embeddings"].rows_where("id = ?", ["1"]))
+    assert row["content"] == "hello world"
+
+
+def test_embed_multi_store_after_no_store():
+    db = sqlite_utils.Database(memory=True)
+    collection = llm.Collection("test", db, model_id="embed-demo")
+    # Embed without store first
+    collection.embed_multi([("1", "hello world"), ("2", "goodbye world")])
+    for row in db["embeddings"].rows:
+        assert row["content"] is None
+    # Re-embed with store=True — existing content should now be populated
+    collection.embed_multi([("1", "hello world"), ("2", "goodbye world")], store=True)
+    rows = {r["id"]: r for r in db["embeddings"].rows}
+    assert rows["1"]["content"] == "hello world"
+    assert rows["2"]["content"] == "goodbye world"
+
+
 def test_collection_delete(collection):
     db = collection.db
     assert db["embeddings"].count == 2


### PR DESCRIPTION
When an item is first embedded without `store=True` and then re-embedded with `store=True`, the deduplication logic detects the matching `content_hash` and skips the row entirely, leaving `content` and `content_blob` as NULL even though the caller explicitly requested storage. This fix retrieves the existing row before skipping, and issues an UPDATE to backfill the content columns when they are missing. Fixes #224

---
_Generated by [Claude Code](https://claude.ai/code/session_01D64sL9zHw5yben2ZRnuar6)_