### PR TITLE
Add llm-perplexity-agent to the plugin directory

### DIFF
--- a/docs/plugins/directory.md
+++ b/docs/plugins/directory.md
@@ -27,6 +27,7 @@ These plugins can be used to interact with remotely hosted models via their API:
 - **[llm-command-r](https://github.com/simonw/llm-command-r)** supports Cohere's Command R and [Command R Plus](https://txt.cohere.com/command-r-plus-microsoft-azure/) API models.
 - **[llm-reka](https://github.com/simonw/llm-reka)** supports the [Reka](https://www.reka.ai/) family of models via their API.
 - **[llm-perplexity](https://github.com/hex/llm-perplexity)** by Alexandru Geana supports the [Perplexity Labs](https://docs.perplexity.ai/) API models, including `llama-3-sonar-large-32k-online` which can search for things online and `llama-3-70b-instruct`.
+- **[llm-perplexity-agent](https://github.com/zalez/perplexity-agent-mcp)** by Constantin Gonzalez provides `perplexity-agent`, using Perplexity's [Agent API](https://docs.perplexity.ai/docs/agent-api/quickstart) for multi-step web research with citations — a different endpoint from the Sonar chat models above, with options for research depth, recency and domain filtering.
 - **[llm-groq](https://github.com/angerman/llm-groq)** by Moritz Angermann provides access to fast models hosted by [Groq](https://console.groq.com/docs/models).
 - **[llm-grok](https://github.com/Hiepler/llm-grok)** by Benedikt Hiepler providing access to Grok model using the xAI API [Grok](https://x.ai/api).
 - **[llm-anyscale-endpoints](https://github.com/simonw/llm-anyscale-endpoints)** supports models hosted on the [Anyscale Endpoints](https://app.endpoints.anyscale.com/) platform, including Llama 2 70B.


### PR DESCRIPTION
Adds one line to `docs/plugins/directory.md` for [llm-perplexity-agent](https://github.com/zalez/perplexity-agent-mcp), which provides a `perplexity-agent` model.

```bash
llm install llm-perplexity-agent
llm -m perplexity-agent 'What changed in MCP 2026-07-28?'
```

## Why a second Perplexity plugin

It is complementary to `llm-perplexity`, not a replacement, and I placed it directly after that entry so the distinction is visible from adjacency.

`llm-perplexity` wraps Perplexity's Sonar **chat models** — `sonar`, `sonar-pro`, `sonar-deep-research`, `sonar-reasoning-pro`. This wraps their [Agent API](https://docs.perplexity.ai/docs/agent-api/quickstart) (`POST /v1/agent`), a different endpoint: a multi-step agent that runs its own searches, fetches pages and synthesises one cited answer.

There is no model-name overlap, and both use the same `perplexity` key alias, so having both installed works with no extra configuration — which is how I run them.

## Options

```bash
llm -m perplexity-agent -o preset xhigh -o recency week 'Latest on X'
llm -m perplexity-agent -o domains 'nasa.gov,-reddit.com' 'Artemis status'
```

`preset` selects research depth and is passed through unvalidated, since Perplexity's schema declares no enum for it. Poll progress goes to stderr so the answer still pipes cleanly.

Published on PyPI as [`llm-perplexity-agent`](https://pypi.org/project/llm-perplexity-agent/). BSD-3-Clause. Tested against Python 3.10–3.14.