### PR TITLE
Fix logs -f fragment filter returning no results on SQLite 3.51.0 and 3.51.1

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1978,19 +1978,22 @@ def logs_list(
 
         for i, fragment_hash in enumerate(fragment_hashes):
             exists_clause = f"""
-            exists (
-                select 1 from prompt_fragments
-                where prompt_fragments.response_id = responses.id
-                and prompt_fragments.fragment_id in (
-                    select fragments.id from fragments
-                    where hash = :f{i}
+            (
+                exists (
+                    select 1 from prompt_fragments
+                    where prompt_fragments.response_id = responses.id
+                    and prompt_fragments.fragment_id in (
+                        select fragments.id from fragments
+                        where hash = :f{i}
+                    )
                 )
-                union
-                select 1 from system_fragments
-                where system_fragments.response_id = responses.id
-                and system_fragments.fragment_id in (
-                    select fragments.id from fragments
-                    where hash = :f{i}
+                or exists (
+                    select 1 from system_fragments
+                    where system_fragments.response_id = responses.id
+                    and system_fragments.fragment_id in (
+                        select fragments.id from fragments
+                        where hash = :f{i}
+                    )
                 )
             )
             """


### PR DESCRIPTION
SQLite 3.51 changed how correlated subqueries inside EXISTS behave when the subquery body is a UNION: the outer correlation (`responses.id`) is silently dropped, causing the filter to return no rows even when matches exist. The fix rewrites `EXISTS (A UNION B)` as `(EXISTS (A) OR EXISTS (B))`, which is semantically identical but works correctly on all SQLite versions. Fixes #1511

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFKMM42St23t57HSmS61Et)_