### PR TITLE
Enable WAL mode and fix TOCTOU race in migrations to prevent database locking errors

### DIFF
--- a/llm/migrations.py
+++ b/llm/migrations.py
@@ -6,6 +6,8 @@ migration = MIGRATIONS.append
 
 
 def migrate(db):
+    if not db.memory:
+        db.enable_wal()
     ensure_migrations_table(db)
     already_applied = {r["name"] for r in db["_llm_migrations"].rows}
     for fn in MIGRATIONS:
@@ -22,14 +24,14 @@ def migrate(db):
 
 
 def ensure_migrations_table(db):
-    if not db["_llm_migrations"].exists():
-        db["_llm_migrations"].create(
-            {
-                "name": str,
-                "applied_at": str,
-            },
-            pk="name",
-        )
+    db["_llm_migrations"].create(
+        {
+            "name": str,
+            "applied_at": str,
+        },
+        pk="name",
+        if_not_exists=True,
+    )
 
 
 @migration

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -93,6 +93,24 @@ def test_migrate_from_original_schema(has_record):
     }
 
 
+def test_migrate_enables_wal_mode(tmp_path):
+    # https://github.com/simonw/llm/issues/789
+    db_path = tmp_path / "test.db"
+    db = sqlite_utils.Database(db_path)
+    migrate(db)
+    assert db.journal_mode == "wal"
+
+
+def test_ensure_migrations_table_idempotent():
+    # ensure_migrations_table must be safe to call twice (no TOCTOU race)
+    from llm.migrations import ensure_migrations_table
+
+    db = sqlite_utils.Database(memory=True)
+    ensure_migrations_table(db)
+    ensure_migrations_table(db)
+    assert "_llm_migrations" in db.table_names()
+
+
 def test_migrations_with_legacy_alter_table():
     # https://github.com/simonw/llm/issues/162
     db = sqlite_utils.Database(memory=True)


### PR DESCRIPTION
When multiple `llm` processes start at the same time (e.g. via `xargs -P`), they each call `migrate()`, which left the database in the default rollback-journal mode where any exclusive write lock blocks all readers, and used a check-then-create pattern for `_llm_migrations` that creates a TOCTOU race. The fix enables WAL mode for file-backed databases so concurrent reads are never blocked by a writer, and uses `CREATE TABLE IF NOT EXISTS` (via `if_not_exists=True`) to atomically create the migrations table, eliminating the race. Regression tests confirm WAL mode is set after migration and that calling `ensure_migrations_table` twice is safe. Fixes #789

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCZioCenouc9rSivEL5kUS)_