### PR TITLE
Fix pending_tool_calls to exclude server-executed tool calls

### DIFF
--- a/llm/logs.py
+++ b/llm/logs.py
@@ -641,7 +641,11 @@ class LogStore:
         chain = self.load_chain(tip)
         if not chain:
             return []
-        return [part for part in chain[-1].parts if isinstance(part, ToolCallPart)]
+        return [
+            part
+            for part in chain[-1].parts
+            if isinstance(part, ToolCallPart) and not part.server_executed
+        ]
 
 
 def ensure_attachment(db, attachment) -> str:

--- a/tests/test_logs_store.py
+++ b/tests/test_logs_store.py
@@ -475,6 +475,22 @@ class TestPendingToolCalls:
         tip = store.ensure_chain([llm.user("Hi"), llm.assistant("Hello")])
         assert store.pending_tool_calls(tip) == []
 
+    def test_server_executed_tool_calls_are_not_pending(self, store):
+        tip = store.ensure_chain(
+            [
+                llm.user("Search"),
+                llm.assistant(
+                    ToolCallPart(
+                        name="web_search",
+                        arguments={"q": "pelicans"},
+                        tool_call_id="tc1",
+                        server_executed=True,
+                    )
+                ),
+            ]
+        )
+        assert store.pending_tool_calls(tip) == []
+
 
 # ---- logging a response ----------------------------------------------
 


### PR DESCRIPTION
LogStore.pending_tool_calls was returning ToolCallParts with server_executed=True as pending work for the client, even though the provider has already handled them. The fix adds the same `not part.server_executed` guard that _trailing_pending_tool_calls in models.py already applies, along with a regression test covering this case. Fixes #1574

---
_Generated by [Claude Code](https://claude.ai/code/session_01522mwpRNpQJ9XSwTRhCr7F)_