### PR TITLE
Narrow except ValueError in embed-multi to only handle missing-model case

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -3363,7 +3363,7 @@ def embed_multi(
     effective_model_id = model or get_default_embedding_model()
     try:
         collection_obj = Collection(collection, db=db, model_id=effective_model_id)
-    except ValueError as e:
+    except ValueError:
         if effective_model_id is None:
             raise click.ClickException(
                 "You need to specify an embedding model (no default model is set)"

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -3360,14 +3360,15 @@ def embed_multi(
     for alias, attach_path in attach:
         db.attach(alias, attach_path)
 
+    effective_model_id = model or get_default_embedding_model()
     try:
-        collection_obj = Collection(
-            collection, db=db, model_id=model or get_default_embedding_model()
-        )
-    except ValueError:
-        raise click.ClickException(
-            "You need to specify an embedding model (no default model is set)"
-        )
+        collection_obj = Collection(collection, db=db, model_id=effective_model_id)
+    except ValueError as e:
+        if effective_model_id is None:
+            raise click.ClickException(
+                "You need to specify an embedding model (no default model is set)"
+            )
+        raise
 
     expected_length = None
     if files:

--- a/tests/test_embed_cli.py
+++ b/tests/test_embed_cli.py
@@ -1,7 +1,7 @@
 import json
 import pathlib
 import sys
-from unittest.mock import ANY
+from unittest.mock import ANY, patch
 
 import pytest
 import sqlite_utils
@@ -715,3 +715,25 @@ def test_duplicate_content_embedded_only_once(embed_demo):
     # Should have only embedded one more thing
     assert db["embeddings"].count == 4
     assert len(embed_demo.embedded_content) == 4
+
+
+def test_embed_multi_non_model_valueerror_is_not_masked(user_path):
+    # A ValueError raised by Collection() for a reason other than a missing model
+    # must not be swallowed and replaced with the "no default model" message.
+    runner = CliRunner()
+    sentinel = ValueError("DB migration failed unexpectedly")
+
+    def raise_sentinel(*args, **kwargs):
+        raise sentinel
+
+    with patch("llm.cli.Collection", side_effect=raise_sentinel):
+        result = runner.invoke(
+            cli,
+            ["embed-multi", "test", "-", "-m", "embed-demo"],
+            input="id,text\n1,hello",
+        )
+
+    # The original ValueError must propagate, not be converted to a ClickException
+    # about missing embedding models.
+    assert result.exception is sentinel
+    assert "no default model" not in (result.output or "")


### PR DESCRIPTION
The broad `except ValueError` around `Collection()` in the `embed-multi` command would silently convert any ValueError (e.g. from a database migration failure) into the misleading "You need to specify an embedding model" message. The fix extracts the model ID first, then only shows the user-friendly message when no model was provided; all other ValueErrors are re-raised. A regression test verifies that a non-model ValueError propagates instead of being masked. Fixes #1523

---
_Generated by [Claude Code](https://claude.ai/code/session_01P21wrXuJbMCwW8gNsYoWVM)_