### PR TITLE
Ollama OCR with URLs fails where filepaths succeed

### DIFF
--- a/llm/models.py
+++ b/llm/models.py
@@ -91,7 +91,7 @@ class Attachment:
         if self.path:
             return mimetype_from_path(self.path)
         if self.url:
-            response = httpx.head(self.url)
+            response = httpx.head(self.url, follow_redirects=True)
             response.raise_for_status()
             return response.headers.get("content-type")
         if self.content:
@@ -105,7 +105,7 @@ class Attachment:
             if self.path:
                 content = Path(self.path).read_bytes()
             elif self.url:
-                response = httpx.get(self.url)
+                response = httpx.get(self.url, follow_redirects=True)
                 response.raise_for_status()
                 content = response.content
         return content

--- a/llm/models.py
+++ b/llm/models.py
@@ -91,7 +91,8 @@ class Attachment:
         if self.path:
             return mimetype_from_path(self.path)
         if self.url:
-            response = httpx.head(self.url, follow_redirects=True)
+            with httpx.Client(follow_redirects=True, max_redirects=3) as client:
+                response = client.head(self.url)
             response.raise_for_status()
             return response.headers.get("content-type")
         if self.content:
@@ -105,7 +106,8 @@ class Attachment:
             if self.path:
                 content = Path(self.path).read_bytes()
             elif self.url:
-                response = httpx.get(self.url, follow_redirects=True)
+                with httpx.Client(follow_redirects=True, max_redirects=3) as client:
+                    response = client.get(self.url)
                 response.raise_for_status()
                 content = response.content
         return content

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -2,6 +2,7 @@ import os
 import sys
 from unittest.mock import ANY
 
+import httpx
 import pytest
 from click.testing import CliRunner
 
@@ -113,6 +114,21 @@ def test_attachment_content_bytes_follows_redirects(httpx_mock):
     assert attachment.content_bytes() == TINY_PNG
 
 
+def test_attachment_content_bytes_limits_redirects(httpx_mock):
+    for redirect in range(4):
+        httpx_mock.add_response(
+            url=f"https://example.com/redirect-{redirect}",
+            status_code=301,
+            headers={"Location": f"https://example.com/redirect-{redirect + 1}"},
+        )
+
+    attachment = llm.Attachment(url="https://example.com/redirect-0")
+    with pytest.raises(httpx.TooManyRedirects):
+        attachment.content_bytes()
+
+    assert len(httpx_mock.get_requests()) == 4
+
+
 def test_attachment_resolve_type_follows_redirects(httpx_mock):
     httpx_mock.add_response(
         method="HEAD",
@@ -127,3 +143,19 @@ def test_attachment_resolve_type_follows_redirects(httpx_mock):
     )
     attachment = llm.Attachment(url="https://example.com/redirected.png")
     assert attachment.resolve_type() == "image/png"
+
+
+def test_attachment_resolve_type_limits_redirects(httpx_mock):
+    for redirect in range(4):
+        httpx_mock.add_response(
+            method="HEAD",
+            url=f"https://example.com/redirect-{redirect}",
+            status_code=301,
+            headers={"Location": f"https://example.com/redirect-{redirect + 1}"},
+        )
+
+    attachment = llm.Attachment(url="https://example.com/redirect-0")
+    with pytest.raises(httpx.TooManyRedirects):
+        attachment.resolve_type()
+
+    assert len(httpx_mock.get_requests()) == 4

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -97,3 +97,33 @@ def test_attachment_no_file_descriptor_leak(tmp_path):
 
     # File descriptor count should not have grown significantly
     assert _count_open_fds() <= baseline + 5
+
+
+def test_attachment_content_bytes_follows_redirects(httpx_mock):
+    httpx_mock.add_response(
+        url="https://example.com/redirected.png",
+        status_code=301,
+        headers={"Location": "https://example.com/actual.png"},
+    )
+    httpx_mock.add_response(
+        url="https://example.com/actual.png",
+        content=TINY_PNG,
+    )
+    attachment = llm.Attachment(url="https://example.com/redirected.png")
+    assert attachment.content_bytes() == TINY_PNG
+
+
+def test_attachment_resolve_type_follows_redirects(httpx_mock):
+    httpx_mock.add_response(
+        method="HEAD",
+        url="https://example.com/redirected.png",
+        status_code=301,
+        headers={"Location": "https://example.com/actual.png"},
+    )
+    httpx_mock.add_response(
+        method="HEAD",
+        url="https://example.com/actual.png",
+        headers={"content-type": "image/png"},
+    )
+    attachment = llm.Attachment(url="https://example.com/redirected.png")
+    assert attachment.resolve_type() == "image/png"


### PR DESCRIPTION
Fixes:
- #1046.

## What changed
- `llm/models.py`
- `tests/test_attachments.py`

## Verification
The project's own test suite was run before and after this change; it introduces no new test failures or lint violations.