### PR TITLE
Skip empty toolboxes in text output of `llm tools`

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -2764,8 +2764,11 @@ def tools_list(tool_defs, json_, python_tools):
             if tool.description:
                 click.echo(textwrap.indent(tool.description.strip(), "  ") + "\n")
         for toolbox in toolbox_objects:
+            toolbox_method_tools = list(toolbox.method_tools())
+            if not toolbox_method_tools:
+                continue
             click.echo(toolbox.name + ":\n")
-            for tool in toolbox.method_tools():
+            for tool in toolbox_method_tools:
                 sig = (
                     str(inspect.signature(tool.implementation))
                     .replace("(self, ", "(")

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1038,6 +1038,39 @@ def test_plugins_command():
     ]
 
 
+def test_tools_list_skips_empty_toolboxes():
+    # Toolboxes with no public methods (e.g. dynamic toolboxes that require
+    # constructor arguments to yield tools, like an MCP client) must not
+    # appear in the text output of `llm tools` – showing "MCP:\n" with nothing
+    # beneath it looks broken (issue #1580).
+    class EmptyBox(llm.Toolbox):
+        pass
+
+    class EmptyBoxPlugin:
+        __name__ = "EmptyBoxPlugin"
+
+        @hookimpl
+        def register_tools(self, register):
+            register(EmptyBox)
+
+    try:
+        plugins.pm.register(EmptyBoxPlugin(), name="EmptyBoxPlugin")
+
+        runner = CliRunner()
+        result = runner.invoke(cli.cli, ["tools"])
+        assert result.exit_code == 0
+        assert "EmptyBox" not in result.output
+
+        # JSON output still lists the toolbox (with an empty tools array) so
+        # programmatic consumers can discover it.
+        result_json = runner.invoke(cli.cli, ["tools", "--json"])
+        assert result_json.exit_code == 0
+        data = json.loads(result_json.output)
+        assert any(tb["name"] == "EmptyBox" for tb in data["toolboxes"])
+    finally:
+        plugins.pm.unregister(name="EmptyBoxPlugin")
+
+
 def tool_activity_rows(db):
     """Per-turn tool calls and results from the message store, in the
     shape the old TOOL_RESULTS_SQL produced from the legacy tables."""


### PR DESCRIPTION
When a plugin registers a toolbox class whose `method_tools()` yields no tools — for example an MCP client that only produces tools once a URL is supplied — `llm tools` printed the toolbox name (e.g. `MCP:`) followed by nothing, which looked broken. This change skips such empty toolboxes in the human-readable text output; JSON output still lists them with `"tools": []` for programmatic consumers. Fixes #1580

---
_Generated by [Claude Code](https://claude.ai/code/session_01CfUpdgpMBXSgfj9kUg3KES)_