### PR TITLE
Fix template schema_object overriding --schema command-line argument

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -900,7 +900,7 @@ def prompt(
             fragments = [*template_obj.fragments, *fragments]
         if template_obj.system_fragments:
             system_fragments = [*template_obj.system_fragments, *system_fragments]
-        if template_obj.schema_object:
+        if template_obj.schema_object and not schema:
             schema = template_obj.schema_object
         tools, python_tools = _merge_template_tools(template_obj, tools, python_tools)
         if template_obj.options:

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -561,3 +561,34 @@ def test_tools_in_templates(
     finally:
         after()
         pm.unregister(name="greetings-plugin")
+
+
+def test_cli_schema_takes_precedence_over_template_schema_object(
+    templates_path, mock_model, logs_db
+):
+    # https://github.com/simonw/llm/issues/1583
+    # --schema on the CLI should override a template's schema_object,
+    # consistent with how --system, -o (options), and -m (model) behave.
+    (templates_path / "withschema.yaml").write_text(
+        "schema_object:\n  type: object\n  properties:\n    name:\n      type: string\n",
+        "utf-8",
+    )
+    cli_schema = {"type": "object", "properties": {"city": {"type": "string"}}}
+    mock_model.enqueue(["response"])
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "--no-stream",
+            "-m",
+            "mock",
+            "-t",
+            "withschema",
+            "--schema",
+            '{"type": "object", "properties": {"city": {"type": "string"}}}',
+            "hello",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    assert mock_model.history[0][0].schema == cli_schema


### PR DESCRIPTION
When a template defines `schema_object` and the user also passes `--schema` on the command line, the template's schema was silently winning instead of the command-line value. Every other template setting (model, extract, options) only applies when the command line did not supply a value, so this one-line fix makes `schema_object` consistent with that pattern. Fixes #1583.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T2B2Q3r6MjX2PQXHQAj4ox)_