### PR TITLE
Add service_tier option for OpenAI models

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ See also [the llm tag](https://simonwillison.net/tags/llm/) on my blog.
   * [Configuration](https://llm.datasette.io/en/stable/openai-models.html#configuration)
   * [OpenAI language models](https://llm.datasette.io/en/stable/openai-models.html#openai-language-models)
   * [Model features](https://llm.datasette.io/en/stable/openai-models.html#model-features)
+  * [Fast mode and service tiers](https://llm.datasette.io/en/stable/openai-models.html#fast-mode-and-service-tiers)
   * [OpenAI embedding models](https://llm.datasette.io/en/stable/openai-models.html#openai-embedding-models)
   * [OpenAI completion models](https://llm.datasette.io/en/stable/openai-models.html#openai-completion-models)
   * [Adding more OpenAI models](https://llm.datasette.io/en/stable/openai-models.html#adding-more-openai-models)

--- a/docs/openai-models.md
+++ b/docs/openai-models.md
@@ -83,6 +83,35 @@ The following features work with OpenAI models:
 - {ref}`Schemas <usage-schemas>` can be used to influence the JSON structure of the model output.
 - {ref}`Model options <usage-model-options>` can be used to set parameters like `temperature`. Use `llm models --options` for a full list of supported options.
 
+(openai-models-service-tier)=
+
+## Fast mode and service tiers
+
+Some OpenAI models can process requests at different speeds and prices using the [service tier](https://developers.openai.com/api/docs/guides/fast-mode) API parameter. `gpt-5.6-sol` supports [Fast mode](https://openai.com/api-fast-mode/), which runs up to 2.5x faster than standard processing at a higher per-token price.
+
+Models that support this expose a `service_tier` option. Use `-o service_tier fast` to enable Fast mode for a prompt:
+
+```bash
+llm -m gpt-5.6-sol -o service_tier fast 'Fast facts about pelicans'
+```
+
+The value is passed straight to the API, so other tiers such as `priority` (the older name for `fast`) and `flex` (slower but cheaper processing, on models that support it) work too:
+
+```bash
+llm -m gpt-5.6-sol -o service_tier flex 'No rush: facts about pelicans'
+```
+
+The requested tier is recorded in the logged options for the prompt, visible in `llm logs -c --json`. The API response also reports the service tier that actually processed the request - OpenAI may fall back to standard processing if Fast mode capacity is unavailable. Using the {ref}`Python API <python-api>` you can check that with:
+
+```python
+import llm
+
+model = llm.get_model("gpt-5.6-sol")
+response = model.prompt("Fast facts about pelicans", service_tier="fast")
+print(response.text())
+print(response.json()["service_tier"])
+```
+
 (openai-models-embedding)=
 
 ## OpenAI embedding models
@@ -154,6 +183,8 @@ If the model should use the OpenAI Responses API rather than Chat Completions, a
 If the model supports structured extraction using json_schema, add `supports_schema: true` to the configuration.
 
 For reasoning models like `o1` or `o3-mini` add `reasoning: true`.
+
+If the model supports the `service_tier` parameter - see {ref}`openai-models-service-tier` - add `service_tier: true` to enable the corresponding option.
 
 With this configuration in place, the following command should run a prompt against the new model:
 

--- a/docs/openai-models.md
+++ b/docs/openai-models.md
@@ -87,18 +87,18 @@ The following features work with OpenAI models:
 
 ## Fast mode and service tiers
 
-Some OpenAI models can process requests at different speeds and prices using the [service tier](https://developers.openai.com/api/docs/guides/fast-mode) API parameter. `gpt-5.6-sol` supports [Fast mode](https://openai.com/api-fast-mode/), which runs up to 2.5x faster than standard processing at a higher per-token price.
+OpenAI models can process requests at different speeds and prices using the `service_tier` API parameter. [Fast mode](https://developers.openai.com/api/docs/guides/fast-mode) runs up to 2.5x faster than standard processing at a higher per-token price, with the biggest speed increase on `gpt-5.6-sol`. [Flex processing](https://developers.openai.com/api/docs/guides/flex-processing) is slower but cheaper. Each tier works with a different subset of models - the Fast and Flex tables on [OpenAI's pricing page](https://developers.openai.com/api/docs/pricing) are the definitive list of which models support which tier.
 
-Models that support this expose a `service_tier` option. Use `-o service_tier fast` to enable Fast mode for a prompt:
+All of the OpenAI models supported by LLM expose a `service_tier` option, with the exception of the legacy `gpt-3.5-turbo-instruct` completion model. Use `-o service_tier fast` to enable Fast mode for a prompt:
 
 ```bash
 llm -m gpt-5.6-sol -o service_tier fast 'Fast facts about pelicans'
 ```
 
-The value is passed straight to the API, so other tiers such as `priority` (the older name for `fast`) and `flex` (slower but cheaper processing, on models that support it) work too:
+The value is passed straight to the API, so other tiers such as `priority` (the older name for `fast`) and `flex` work too:
 
 ```bash
-llm -m gpt-5.6-sol -o service_tier flex 'No rush: facts about pelicans'
+llm -m gpt-5.4 -o service_tier flex 'No rush: facts about pelicans'
 ```
 
 The requested tier is recorded in the logged options for the prompt, visible in `llm logs -c --json`. The API response also reports the service tier that actually processed the request - OpenAI may fall back to standard processing if Fast mode capacity is unavailable. Using the {ref}`Python API <python-api>` you can check that with:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1368,6 +1368,7 @@ OpenAI Responses: gpt-5.6-sol
     image_detail: str
     reasoning_effort: str
     verbosity: str
+    service_tier: str
   Attachment types:
     application/pdf, image/gif, image/jpeg, image/png, image/webp
   Features:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -595,6 +595,10 @@ OpenAI Chat: gpt-4o (aliases: 4o)
     image_detail: str
       Controls the detail level for image attachments. Supported values are
       low, high, and auto.
+    service_tier: str
+      The processing tier to use for this request - for example 'fast' for
+      Fast mode (faster responses at a higher price) or 'flex' for slower,
+      cheaper processing on models that support those tiers.
   Attachment types:
     application/pdf, image/gif, image/jpeg, image/png, image/webp
   Features:
@@ -617,6 +621,7 @@ OpenAI Chat: gpt-4o-mini (aliases: 4o-mini)
     seed: int
     json_object: boolean
     image_detail: str
+    service_tier: str
   Attachment types:
     application/pdf, image/gif, image/jpeg, image/png, image/webp
   Features:
@@ -639,6 +644,7 @@ OpenAI Chat: gpt-4.1 (aliases: 4.1)
     seed: int
     json_object: boolean
     image_detail: str
+    service_tier: str
   Attachment types:
     application/pdf, image/gif, image/jpeg, image/png, image/webp
   Features:
@@ -661,6 +667,7 @@ OpenAI Chat: gpt-4.1-mini (aliases: 4.1-mini)
     seed: int
     json_object: boolean
     image_detail: str
+    service_tier: str
   Attachment types:
     application/pdf, image/gif, image/jpeg, image/png, image/webp
   Features:
@@ -683,6 +690,7 @@ OpenAI Chat: gpt-4.1-nano (aliases: 4.1-nano)
     seed: int
     json_object: boolean
     image_detail: str
+    service_tier: str
   Attachment types:
     application/pdf, image/gif, image/jpeg, image/png, image/webp
   Features:
@@ -705,6 +713,7 @@ OpenAI Chat: gpt-3.5-turbo (aliases: 3.5, chatgpt)
     seed: int
     json_object: boolean
     image_detail: str
+    service_tier: str
   Features:
   - streaming
   - async
@@ -723,6 +732,7 @@ OpenAI Chat: gpt-3.5-turbo-16k (aliases: chatgpt-16k, 3.5-16k)
     seed: int
     json_object: boolean
     image_detail: str
+    service_tier: str
   Features:
   - streaming
   - async
@@ -741,6 +751,7 @@ OpenAI Chat: gpt-4 (aliases: 4, gpt4)
     seed: int
     json_object: boolean
     image_detail: str
+    service_tier: str
   Features:
   - streaming
   - async
@@ -759,6 +770,7 @@ OpenAI Chat: gpt-4-turbo-2024-04-09
     seed: int
     json_object: boolean
     image_detail: str
+    service_tier: str
   Features:
   - streaming
   - async
@@ -777,6 +789,7 @@ OpenAI Chat: gpt-4-turbo (aliases: gpt-4-turbo-preview, 4-turbo, 4t)
     seed: int
     json_object: boolean
     image_detail: str
+    service_tier: str
   Features:
   - streaming
   - async
@@ -826,6 +839,10 @@ OpenAI Responses: o1
       supported values are low, medium, and high. Reducing reasoning effort
       can result in faster responses and fewer tokens used on reasoning in a
       response.
+    service_tier: str
+      The processing tier to use for this request - for example 'fast' for
+      Fast mode (faster responses at a higher price) or 'flex' for slower,
+      cheaper processing on models that support those tiers.
   Attachment types:
     application/pdf, image/gif, image/jpeg, image/png, image/webp
   Features:
@@ -849,6 +866,7 @@ OpenAI Responses: o1-2024-12-17
     chat_completions: boolean
     image_detail: str
     reasoning_effort: str
+    service_tier: str
   Attachment types:
     application/pdf, image/gif, image/jpeg, image/png, image/webp
   Features:
@@ -872,6 +890,7 @@ OpenAI Responses: o3-mini
     chat_completions: boolean
     image_detail: str
     reasoning_effort: str
+    service_tier: str
   Features:
   - streaming
   - schemas
@@ -894,6 +913,7 @@ OpenAI Responses: o3
     chat_completions: boolean
     image_detail: str
     reasoning_effort: str
+    service_tier: str
   Attachment types:
     application/pdf, image/gif, image/jpeg, image/png, image/webp
   Features:
@@ -918,6 +938,7 @@ OpenAI Responses: o4-mini
     chat_completions: boolean
     image_detail: str
     reasoning_effort: str
+    service_tier: str
   Attachment types:
     application/pdf, image/gif, image/jpeg, image/png, image/webp
   Features:
@@ -943,6 +964,7 @@ OpenAI Responses: gpt-5
     image_detail: str
     reasoning_effort: str
     verbosity: str
+    service_tier: str
   Attachment types:
     application/pdf, image/gif, image/jpeg, image/png, image/webp
   Features:
@@ -968,6 +990,7 @@ OpenAI Responses: gpt-5-mini
     image_detail: str
     reasoning_effort: str
     verbosity: str
+    service_tier: str
   Attachment types:
     application/pdf, image/gif, image/jpeg, image/png, image/webp
   Features:
@@ -993,6 +1016,7 @@ OpenAI Responses: gpt-5-nano
     image_detail: str
     reasoning_effort: str
     verbosity: str
+    service_tier: str
   Attachment types:
     application/pdf, image/gif, image/jpeg, image/png, image/webp
   Features:
@@ -1018,6 +1042,7 @@ OpenAI Responses: gpt-5-2025-08-07
     image_detail: str
     reasoning_effort: str
     verbosity: str
+    service_tier: str
   Attachment types:
     application/pdf, image/gif, image/jpeg, image/png, image/webp
   Features:
@@ -1043,6 +1068,7 @@ OpenAI Responses: gpt-5-mini-2025-08-07
     image_detail: str
     reasoning_effort: str
     verbosity: str
+    service_tier: str
   Attachment types:
     application/pdf, image/gif, image/jpeg, image/png, image/webp
   Features:
@@ -1068,6 +1094,7 @@ OpenAI Responses: gpt-5-nano-2025-08-07
     image_detail: str
     reasoning_effort: str
     verbosity: str
+    service_tier: str
   Attachment types:
     application/pdf, image/gif, image/jpeg, image/png, image/webp
   Features:
@@ -1093,6 +1120,7 @@ OpenAI Responses: gpt-5.1
     image_detail: str
     reasoning_effort: str
     verbosity: str
+    service_tier: str
   Attachment types:
     application/pdf, image/gif, image/jpeg, image/png, image/webp
   Features:
@@ -1118,6 +1146,7 @@ OpenAI Responses: gpt-5.2
     image_detail: str
     reasoning_effort: str
     verbosity: str
+    service_tier: str
   Attachment types:
     application/pdf, image/gif, image/jpeg, image/png, image/webp
   Features:
@@ -1143,6 +1172,7 @@ OpenAI Responses: gpt-5.2-chat-latest
     image_detail: str
     reasoning_effort: str
     verbosity: str
+    service_tier: str
   Attachment types:
     application/pdf, image/gif, image/jpeg, image/png, image/webp
   Features:
@@ -1168,6 +1198,7 @@ OpenAI Responses: gpt-5.4
     image_detail: str
     reasoning_effort: str
     verbosity: str
+    service_tier: str
   Attachment types:
     application/pdf, image/gif, image/jpeg, image/png, image/webp
   Features:
@@ -1193,6 +1224,7 @@ OpenAI Responses: gpt-5.4-2026-03-05
     image_detail: str
     reasoning_effort: str
     verbosity: str
+    service_tier: str
   Attachment types:
     application/pdf, image/gif, image/jpeg, image/png, image/webp
   Features:
@@ -1218,6 +1250,7 @@ OpenAI Responses: gpt-5.4-mini
     image_detail: str
     reasoning_effort: str
     verbosity: str
+    service_tier: str
   Attachment types:
     application/pdf, image/gif, image/jpeg, image/png, image/webp
   Features:
@@ -1243,6 +1276,7 @@ OpenAI Responses: gpt-5.4-mini-2026-03-17
     image_detail: str
     reasoning_effort: str
     verbosity: str
+    service_tier: str
   Attachment types:
     application/pdf, image/gif, image/jpeg, image/png, image/webp
   Features:
@@ -1268,6 +1302,7 @@ OpenAI Responses: gpt-5.4-nano
     image_detail: str
     reasoning_effort: str
     verbosity: str
+    service_tier: str
   Attachment types:
     application/pdf, image/gif, image/jpeg, image/png, image/webp
   Features:
@@ -1293,6 +1328,7 @@ OpenAI Responses: gpt-5.4-nano-2026-03-17
     image_detail: str
     reasoning_effort: str
     verbosity: str
+    service_tier: str
   Attachment types:
     application/pdf, image/gif, image/jpeg, image/png, image/webp
   Features:
@@ -1318,6 +1354,7 @@ OpenAI Responses: gpt-5.5
     image_detail: str
     reasoning_effort: str
     verbosity: str
+    service_tier: str
   Attachment types:
     application/pdf, image/gif, image/jpeg, image/png, image/webp
   Features:
@@ -1343,6 +1380,7 @@ OpenAI Responses: gpt-5.5-2026-04-23
     image_detail: str
     reasoning_effort: str
     verbosity: str
+    service_tier: str
   Attachment types:
     application/pdf, image/gif, image/jpeg, image/png, image/webp
   Features:
@@ -1394,6 +1432,7 @@ OpenAI Responses: gpt-5.6-terra
     image_detail: str
     reasoning_effort: str
     verbosity: str
+    service_tier: str
   Attachment types:
     application/pdf, image/gif, image/jpeg, image/png, image/webp
   Features:
@@ -1419,6 +1458,7 @@ OpenAI Responses: gpt-5.6-luna
     image_detail: str
     reasoning_effort: str
     verbosity: str
+    service_tier: str
   Attachment types:
     application/pdf, image/gif, image/jpeg, image/png, image/webp
   Features:

--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -38,39 +38,82 @@ from llm.utils import (
 def register_models(register):
     # GPT-4o
     register(
-        Chat("gpt-4o", vision=True, supports_schema=True, supports_tools=True),
-        AsyncChat("gpt-4o", vision=True, supports_schema=True, supports_tools=True),
+        Chat(
+            "gpt-4o",
+            vision=True,
+            service_tier=True,
+            supports_schema=True,
+            supports_tools=True,
+        ),
+        AsyncChat(
+            "gpt-4o",
+            vision=True,
+            service_tier=True,
+            supports_schema=True,
+            supports_tools=True,
+        ),
         aliases=("4o",),
     )
     register(
-        Chat("gpt-4o-mini", vision=True, supports_schema=True, supports_tools=True),
+        Chat(
+            "gpt-4o-mini",
+            vision=True,
+            service_tier=True,
+            supports_schema=True,
+            supports_tools=True,
+        ),
         AsyncChat(
-            "gpt-4o-mini", vision=True, supports_schema=True, supports_tools=True
+            "gpt-4o-mini",
+            vision=True,
+            service_tier=True,
+            supports_schema=True,
+            supports_tools=True,
         ),
         aliases=("4o-mini",),
     )
     # GPT-4.1
     for model_id in ("gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano"):
         register(
-            Chat(model_id, vision=True, supports_schema=True, supports_tools=True),
-            AsyncChat(model_id, vision=True, supports_schema=True, supports_tools=True),
+            Chat(
+                model_id,
+                vision=True,
+                service_tier=True,
+                supports_schema=True,
+                supports_tools=True,
+            ),
+            AsyncChat(
+                model_id,
+                vision=True,
+                service_tier=True,
+                supports_schema=True,
+                supports_tools=True,
+            ),
             aliases=(model_id.replace("gpt-", ""),),
         )
     # 3.5 and 4
     register(
-        Chat("gpt-3.5-turbo"), AsyncChat("gpt-3.5-turbo"), aliases=("3.5", "chatgpt")
+        Chat("gpt-3.5-turbo", service_tier=True),
+        AsyncChat("gpt-3.5-turbo", service_tier=True),
+        aliases=("3.5", "chatgpt"),
     )
     register(
-        Chat("gpt-3.5-turbo-16k"),
-        AsyncChat("gpt-3.5-turbo-16k"),
+        Chat("gpt-3.5-turbo-16k", service_tier=True),
+        AsyncChat("gpt-3.5-turbo-16k", service_tier=True),
         aliases=("chatgpt-16k", "3.5-16k"),
     )
-    register(Chat("gpt-4"), AsyncChat("gpt-4"), aliases=("4", "gpt4"))
-    # GPT-4 Turbo models
-    register(Chat("gpt-4-turbo-2024-04-09"), AsyncChat("gpt-4-turbo-2024-04-09"))
     register(
-        Chat("gpt-4-turbo"),
-        AsyncChat("gpt-4-turbo"),
+        Chat("gpt-4", service_tier=True),
+        AsyncChat("gpt-4", service_tier=True),
+        aliases=("4", "gpt4"),
+    )
+    # GPT-4 Turbo models
+    register(
+        Chat("gpt-4-turbo-2024-04-09", service_tier=True),
+        AsyncChat("gpt-4-turbo-2024-04-09", service_tier=True),
+    )
+    register(
+        Chat("gpt-4-turbo", service_tier=True),
+        AsyncChat("gpt-4-turbo", service_tier=True),
         aliases=("gpt-4-turbo-preview", "4-turbo", "4t"),
     )
     # o1
@@ -81,6 +124,7 @@ def register_models(register):
                 vision=True,
                 can_stream=False,
                 reasoning=True,
+                service_tier=True,
                 supports_schema=True,
                 supports_tools=True,
             ),
@@ -89,23 +133,44 @@ def register_models(register):
                 vision=True,
                 can_stream=False,
                 reasoning=True,
+                service_tier=True,
                 supports_schema=True,
                 supports_tools=True,
             ),
         )
 
     register(
-        Responses("o3-mini", reasoning=True, supports_schema=True, supports_tools=True),
+        Responses(
+            "o3-mini",
+            reasoning=True,
+            service_tier=True,
+            supports_schema=True,
+            supports_tools=True,
+        ),
         AsyncResponses(
-            "o3-mini", reasoning=True, supports_schema=True, supports_tools=True
+            "o3-mini",
+            reasoning=True,
+            service_tier=True,
+            supports_schema=True,
+            supports_tools=True,
         ),
     )
     register(
         Responses(
-            "o3", vision=True, reasoning=True, supports_schema=True, supports_tools=True
+            "o3",
+            vision=True,
+            reasoning=True,
+            service_tier=True,
+            supports_schema=True,
+            supports_tools=True,
         ),
         AsyncResponses(
-            "o3", vision=True, reasoning=True, supports_schema=True, supports_tools=True
+            "o3",
+            vision=True,
+            reasoning=True,
+            service_tier=True,
+            supports_schema=True,
+            supports_tools=True,
         ),
     )
     register(
@@ -113,6 +178,7 @@ def register_models(register):
             "o4-mini",
             vision=True,
             reasoning=True,
+            service_tier=True,
             supports_schema=True,
             supports_tools=True,
         ),
@@ -120,6 +186,7 @@ def register_models(register):
             "o4-mini",
             vision=True,
             reasoning=True,
+            service_tier=True,
             supports_schema=True,
             supports_tools=True,
         ),
@@ -139,6 +206,7 @@ def register_models(register):
                 vision=True,
                 reasoning=True,
                 verbosity=True,
+                service_tier=True,
                 supports_schema=True,
                 supports_tools=True,
             ),
@@ -147,6 +215,7 @@ def register_models(register):
                 vision=True,
                 reasoning=True,
                 verbosity=True,
+                service_tier=True,
                 supports_schema=True,
                 supports_tools=True,
             ),
@@ -158,6 +227,7 @@ def register_models(register):
             vision=True,
             reasoning=True,
             verbosity=True,
+            service_tier=True,
             supports_schema=True,
             supports_tools=True,
         ),
@@ -166,6 +236,7 @@ def register_models(register):
             vision=True,
             reasoning=True,
             verbosity=True,
+            service_tier=True,
             supports_schema=True,
             supports_tools=True,
         ),
@@ -178,6 +249,7 @@ def register_models(register):
                 vision=True,
                 reasoning=True,
                 verbosity=True,
+                service_tier=True,
                 supports_schema=True,
                 supports_tools=True,
             ),
@@ -186,6 +258,7 @@ def register_models(register):
                 vision=True,
                 reasoning=True,
                 verbosity=True,
+                service_tier=True,
                 supports_schema=True,
                 supports_tools=True,
             ),
@@ -208,6 +281,7 @@ def register_models(register):
                 reasoning=True,
                 verbosity=True,
                 image_detail_original=True,
+                service_tier=True,
                 supports_schema=True,
                 supports_tools=True,
             ),
@@ -217,6 +291,7 @@ def register_models(register):
                 reasoning=True,
                 verbosity=True,
                 image_detail_original=True,
+                service_tier=True,
                 supports_schema=True,
                 supports_tools=True,
             ),
@@ -234,6 +309,7 @@ def register_models(register):
                 reasoning=True,
                 verbosity=True,
                 image_detail_original=True,
+                service_tier=True,
                 supports_schema=True,
                 supports_tools=True,
             ),
@@ -243,6 +319,7 @@ def register_models(register):
                 reasoning=True,
                 verbosity=True,
                 image_detail_original=True,
+                service_tier=True,
                 supports_schema=True,
                 supports_tools=True,
             ),
@@ -250,8 +327,6 @@ def register_models(register):
 
     # GPT-5.6
     for model_id in ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"):
-        # gpt-5.6-sol supports service_tier for Fast mode
-        service_tier = model_id == "gpt-5.6-sol"
         register(
             Responses(
                 model_id,
@@ -259,7 +334,7 @@ def register_models(register):
                 reasoning=True,
                 verbosity=True,
                 image_detail_original=True,
-                service_tier=service_tier,
+                service_tier=True,
                 supports_schema=True,
                 supports_tools=True,
             ),
@@ -269,7 +344,7 @@ def register_models(register):
                 reasoning=True,
                 verbosity=True,
                 image_detail_original=True,
-                service_tier=service_tier,
+                service_tier=True,
                 supports_schema=True,
                 supports_tools=True,
             ),

--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -250,6 +250,8 @@ def register_models(register):
 
     # GPT-5.6
     for model_id in ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"):
+        # gpt-5.6-sol supports service_tier for Fast mode
+        service_tier = model_id == "gpt-5.6-sol"
         register(
             Responses(
                 model_id,
@@ -257,6 +259,7 @@ def register_models(register):
                 reasoning=True,
                 verbosity=True,
                 image_detail_original=True,
+                service_tier=service_tier,
                 supports_schema=True,
                 supports_tools=True,
             ),
@@ -266,6 +269,7 @@ def register_models(register):
                 reasoning=True,
                 verbosity=True,
                 image_detail_original=True,
+                service_tier=service_tier,
                 supports_schema=True,
                 supports_tools=True,
             ),
@@ -304,6 +308,8 @@ def register_models(register):
             kwargs["vision"] = True
         if extra_model.get("audio") is True:
             kwargs["audio"] = True
+        if extra_model.get("service_tier") is True:
+            kwargs["service_tier"] = True
         if extra_model.get("completion"):
             klass = Completion
             async_klass = None
@@ -911,6 +917,7 @@ def build_options_class(
     verbosity=False,
     image_detail_original=False,
     chat_completions=False,
+    service_tier=False,
 ):
     fields = {
         "json_object": (
@@ -972,6 +979,19 @@ def build_options_class(
                 default=None,
             ),
         )
+    if service_tier:
+        fields["service_tier"] = (
+            str | None,
+            Field(
+                description=(
+                    "The processing tier to use for this request - for example "
+                    "'fast' for Fast mode (faster responses at a higher price) "
+                    "or 'flex' for slower, cheaper processing on models that "
+                    "support those tiers."
+                ),
+                default=None,
+            ),
+        )
     return create_model("Options", __base__=SharedOptions, **fields)
 
 
@@ -1024,6 +1044,7 @@ class _Shared:
         reasoning=False,
         verbosity=False,
         image_detail_original=False,
+        service_tier=False,
         supports_schema=False,
         supports_tools=False,
         allows_system_prompt=True,
@@ -1044,11 +1065,12 @@ class _Shared:
 
         self.attachment_types = set()
 
-        if reasoning or verbosity or image_detail_original:
+        if reasoning or verbosity or image_detail_original or service_tier:
             self.Options = build_options_class(
                 reasoning=reasoning,
                 verbosity=verbosity,
                 image_detail_original=image_detail_original,
+                service_tier=service_tier,
             )
 
         if vision:
@@ -1516,6 +1538,7 @@ class _SharedResponses(_Shared):
             "reasoning": self._reasoning,
             "verbosity": self._verbosity,
             "image_detail_original": self._image_detail_original,
+            "service_tier": self._service_tier,
             "supports_schema": self.supports_schema,
             "supports_tools": self.supports_tools,
             "allows_system_prompt": self.allows_system_prompt,
@@ -1774,6 +1797,7 @@ class Responses(_SharedResponses, KeyModel):
         reasoning=False,
         verbosity=False,
         image_detail_original=False,
+        service_tier=False,
         supports_schema=False,
         supports_tools=False,
         allows_system_prompt=True,
@@ -1794,6 +1818,7 @@ class Responses(_SharedResponses, KeyModel):
             reasoning=reasoning,
             verbosity=verbosity,
             image_detail_original=image_detail_original,
+            service_tier=service_tier,
             supports_schema=supports_schema,
             supports_tools=supports_tools,
             allows_system_prompt=allows_system_prompt,
@@ -1802,6 +1827,7 @@ class Responses(_SharedResponses, KeyModel):
         self._reasoning_summary = reasoning_summary
         self._verbosity = verbosity
         self._image_detail_original = image_detail_original
+        self._service_tier = service_tier
         # Override the Options class so that ``-o chat_completions 1`` is
         # always available on Responses-routed models.
         self.Options = build_options_class(
@@ -1809,6 +1835,7 @@ class Responses(_SharedResponses, KeyModel):
             verbosity=verbosity,
             image_detail_original=image_detail_original,
             chat_completions=True,
+            service_tier=service_tier,
         )
 
     def execute(
@@ -2007,6 +2034,7 @@ class AsyncResponses(_SharedResponses, AsyncKeyModel):
         reasoning=False,
         verbosity=False,
         image_detail_original=False,
+        service_tier=False,
         supports_schema=False,
         supports_tools=False,
         allows_system_prompt=True,
@@ -2027,6 +2055,7 @@ class AsyncResponses(_SharedResponses, AsyncKeyModel):
             reasoning=reasoning,
             verbosity=verbosity,
             image_detail_original=image_detail_original,
+            service_tier=service_tier,
             supports_schema=supports_schema,
             supports_tools=supports_tools,
             allows_system_prompt=allows_system_prompt,
@@ -2035,11 +2064,13 @@ class AsyncResponses(_SharedResponses, AsyncKeyModel):
         self._reasoning_summary = reasoning_summary
         self._verbosity = verbosity
         self._image_detail_original = image_detail_original
+        self._service_tier = service_tier
         self.Options = build_options_class(
             reasoning=reasoning,
             verbosity=verbosity,
             image_detail_original=image_detail_original,
             chat_completions=True,
+            service_tier=service_tier,
         )
 
     async def execute(

--- a/tests/test_openai_responses.py
+++ b/tests/test_openai_responses.py
@@ -427,12 +427,15 @@ def test_responses_kwargs_omits_empty_reasoning_when_hide_reasoning():
     "model_id,expected",
     [
         ("gpt-5.6-sol", True),
-        ("gpt-5.6-terra", False),
-        ("gpt-5.6-luna", False),
-        ("gpt-5.5", False),
+        ("gpt-5.6-terra", True),
+        ("gpt-5.6-luna", True),
+        ("gpt-5.5", True),
+        ("gpt-4o", True),
+        # The legacy /v1/completions endpoint does not accept service_tier
+        ("gpt-3.5-turbo-instruct", False),
     ],
 )
-def test_service_tier_option_only_on_supported_models(model_id, expected):
+def test_service_tier_option_on_models(model_id, expected):
     model = llm.get_model(model_id)
     assert ("service_tier" in model.Options.model_fields) == expected
 

--- a/tests/test_openai_responses.py
+++ b/tests/test_openai_responses.py
@@ -423,6 +423,106 @@ def test_responses_kwargs_omits_empty_reasoning_when_hide_reasoning():
     assert "reasoning" not in kwargs
 
 
+@pytest.mark.parametrize(
+    "model_id,expected",
+    [
+        ("gpt-5.6-sol", True),
+        ("gpt-5.6-terra", False),
+        ("gpt-5.6-luna", False),
+        ("gpt-5.5", False),
+    ],
+)
+def test_service_tier_option_only_on_supported_models(model_id, expected):
+    model = llm.get_model(model_id)
+    assert ("service_tier" in model.Options.model_fields) == expected
+
+
+def test_responses_kwargs_includes_service_tier():
+    model = llm.get_model("gpt-5.6-sol")
+    options = model.Options(service_tier="fast")
+
+    class FakePrompt:
+        pass
+
+    p = FakePrompt()
+    p.options = options
+    p.tools = []
+    p.schema = None
+    kwargs = model._build_responses_kwargs(p, stream=False)
+    assert kwargs["service_tier"] == "fast"
+
+
+def test_service_tier_sent_to_responses_endpoint(httpx_mock):
+    httpx_mock.add_response(
+        method="POST",
+        url="https://api.openai.com/v1/responses",
+        json={
+            "id": "resp_test_1",
+            "object": "response",
+            "created_at": 1,
+            "model": "gpt-5.6-sol",
+            "output": [
+                {
+                    "type": "message",
+                    "id": "msg_1",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "fast reply",
+                            "annotations": [],
+                        }
+                    ],
+                }
+            ],
+            "usage": {
+                "input_tokens": 5,
+                "output_tokens": 3,
+                "total_tokens": 8,
+            },
+            "status": "completed",
+            "service_tier": "priority",
+        },
+        headers={"Content-Type": "application/json"},
+    )
+    model = llm.get_model("gpt-5.6-sol")
+    response = model.prompt("hello", stream=False, service_tier="fast", key="test")
+    assert response.text() == "fast reply"
+    request_body = json.loads(httpx_mock.get_requests()[-1].content)
+    assert request_body["service_tier"] == "fast"
+    # The response body reports the tier that actually processed the request
+    assert response.json()["service_tier"] == "priority"
+
+
+def test_service_tier_sent_to_chat_completions_fallback(httpx_mock):
+    httpx_mock.add_response(
+        method="POST",
+        url="https://api.openai.com/v1/chat/completions",
+        json={
+            "id": "chatcmpl-x",
+            "object": "chat.completion",
+            "model": "gpt-5.6-sol",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "fast chat"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3},
+        },
+        headers={"Content-Type": "application/json"},
+    )
+    model = llm.get_model("gpt-5.6-sol")
+    response = model.prompt(
+        "hello", stream=False, chat_completions=True, service_tier="fast", key="test"
+    )
+    assert response.text() == "fast chat"
+    request_body = json.loads(httpx_mock.get_requests()[-1].content)
+    assert request_body["service_tier"] == "fast"
+
+
 def test_responses_streams_reasoning_summary_text(httpx_mock):
     httpx_mock.add_response(
         method="POST",


### PR DESCRIPTION
OpenAI [renamed Priority processing to Fast mode](https://openai.com/api-fast-mode/) on July 30th 2026, and `gpt-5.6-sol` supports it for up to 2.5x faster processing at a higher per-token price. It is controlled by the [`service_tier`](https://developers.openai.com/api/docs/guides/fast-mode) API parameter, accepted by both the Responses and Chat Completions endpoints.

This adds a `service_tier` option to OpenAI models registered with a new `service_tier=True`:



```bash
llm -m gpt-5.6-sol -o service_tier fast 'Fast facts about pelicans'
```
This is available for other models too, especially since `service_tier: flex` looks to be supported by many of them (half price in exchange for slower and less reliable.)

<details><summary>Claude Code PR (Fable 5)</summary>

## Design notes

- The option is a **plain string, not an enum** - the value is passed straight through to the API, so `fast`, `priority`, `flex` and any future tier names work on other models/endpoints without code changes.
- The flag is enabled for `gpt-5.6-sol` only (the one model OpenAI documents as supporting Fast mode). Custom models can opt in with `service_tier: true` in `extra-openai-models.yaml`.
- The option flows through both code paths: the Responses API and the `-o chat_completions 1` fallback (the delegate constructor now carries the flag across).
- The requested tier is persisted in the logged options (`turns.options_json`), so `llm logs -c --json` shows it. The tier that *actually* processed the request (echoed by the API, since Fast mode can fall back to standard processing) is available via `response.json()["service_tier"]` in the Python API but is not persisted by the new logging schema - the docs note this.

## Documentation

New "Fast mode and service tiers" section in `docs/openai-models.md` linking to OpenAI's official Fast mode documentation, plus a note in the extra-models section and cog-regenerated options listing in `docs/usage.md`.

## Testing

- 7 new tests: option exposed on `gpt-5.6-sol` but not Terra/Luna/5.5, kwargs building, and request-body assertions for both the `/v1/responses` and `/v1/chat/completions` paths via httpx mocks (including the echoed tier surfacing in `response.json()`).
- Full suite passes: 979 tests. ruff, black and `cog --check` clean.
- Manually tested against the live API: `-o service_tier fast` was accepted, the response echoed `service_tier: priority` (OpenAI's documented echo for GPT-5.6-era models), and timing the same 12-stanza-poem prompt twice per tier showed ~1.37x output tokens/sec over standard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYbKrezWv4ANYuXGFjJGkN

</details>


https://claude.ai/code/session_01CYbKrezWv4ANYuXGFjJGkN