### PR TITLE
Fix llm openai endpoint ignoring --schema when template also defines schema_object

### DIFF
--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -584,7 +584,7 @@ def register_commands(cli):
                 raise click.ClickException(str(ex))
             if not model_id and template_obj.model:
                 model_id = template_obj.model
-            if template_obj.schema_object:
+            if template_obj.schema_object and not schema:
                 schema = template_obj.schema_object
             if template_obj.options:
                 options = _merge_template_options(template_obj, options)

--- a/tests/test_openai_endpoint.py
+++ b/tests/test_openai_endpoint.py
@@ -305,19 +305,64 @@ attachment_types:
             },
         ],
         "model": "template-model",
+        # CLI --schema takes precedence over template schema_object
         "response_format": {
             "type": "json_schema",
             "json_schema": {
                 "name": "output",
-                "schema": {
-                    "type": "object",
-                    "properties": {"answer": {"type": "string"}},
-                    "required": ["answer"],
-                },
+                "schema": {"type": "object"},
             },
         },
         "stream": False,
         "temperature": 0.4,
+    }
+
+
+def test_endpoint_template_schema_object_used_when_no_cli_schema(
+    httpx_mock, user_path, templates_path
+):
+    base_url = "https://templates2.example.test/v1"
+    _add_chat_response(httpx_mock, base_url, "Template response 2")
+    (templates_path / "schemaonly.yaml").write_text(
+        """
+model: schema-model
+schema_object:
+  type: object
+  properties:
+    answer:
+      type: string
+  required:
+  - answer
+""".strip(),
+        "utf-8",
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "openai",
+            "endpoint",
+            base_url,
+            "test question",
+            "--template",
+            "schemaonly",
+            "--no-stream",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    request_body = json.loads(httpx_mock.get_requests()[0].content)
+    assert request_body["response_format"] == {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "output",
+            "schema": {
+                "type": "object",
+                "properties": {"answer": {"type": "string"}},
+                "required": ["answer"],
+            },
+        },
     }
 
 


### PR DESCRIPTION
The `llm openai endpoint` command applied `template.schema_object` unconditionally at `openai_models.py:587`, overwriting any `--schema` value the user explicitly passed on the command line. This is inconsistent with how every other template override works: `model` is only applied `if not model_id`, options use `_merge_template_options` (skipping already-specified keys), and attachments are additive. The same bug was fixed for the main `prompt` command in #1584, but the `endpoint` command has its own copy of the template-application block that was not included in that fix.

Fix: add `and not schema` to the guard condition, matching the pattern used everywhere else. The existing `test_endpoint_template` already invoked the command with both `--template` (schema_object set) and `--schema`; its assertion was corrected to expect the CLI value to win. A companion test confirms the template schema_object is still applied when no `--schema` is given.

Fixes #1583