### PR TITLE
Fix chat after log database is deleted

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -137,6 +137,7 @@ def _run_chat(
     prompt_callback,
     *,
     db=None,
+    db_path=None,
     initial_fragments=None,
     initial_attachments=None,
     transform_prompt=None,
@@ -161,8 +162,17 @@ def _run_chat(
     accumulated_attachments = []
     end_token = "!end"
 
+    def ensure_db():
+        nonlocal db
+        if db_path is not None and not db_path.exists():
+            db.close()
+            db = sqlite_utils.Database(db_path)
+            migrate(db)
+        return db
+
     while True:
         prompt = click.prompt("", prompt_suffix="> " if not in_multi else "")
+        db = ensure_db()
         fragments = []
         attachments = []
         if argument_fragments:
@@ -214,7 +224,7 @@ def _run_chat(
             show_reasoning=show_reasoning,
         )
         if after_response is not None:
-            after_response(response)
+            after_response(response, ensure_db())
         print()
 
 
@@ -1348,10 +1358,11 @@ def chat(
         model.model_id,
         execute_chat_prompt,
         db=db,
+        db_path=log_path,
         initial_fragments=argument_fragments,
         initial_attachments=argument_attachments,
         transform_prompt=transform_chat_prompt,
-        after_response=lambda response: response.log_to_db(db),
+        after_response=lambda response, db: response.log_to_db(db),
         show_reasoning=not hide_reasoning,
     )
 

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -273,6 +273,34 @@ def test_llm_chat_creates_log_database(tmpdir, monkeypatch, custom_database_path
     assert sqlite_utils.Database(db_path)["turns"].count == 2
 
 
+def test_chat_recreates_deleted_log_database(user_path, mock_model, monkeypatch):
+    log_path = user_path / "logs.db"
+    mock_model.enqueue(["first response"])
+    mock_model.enqueue(["second response"])
+    original_execute = mock_model.execute
+    calls = 0
+
+    def execute(prompt, stream, response, conversation):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            log_path.remove()
+        yield from original_execute(prompt, stream, response, conversation)
+
+    monkeypatch.setattr(mock_model, "execute", execute)
+    result = CliRunner().invoke(
+        llm.cli.cli,
+        ["chat", "-m", "mock"],
+        input="first\nsecond\nquit\n",
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    rows = logged_rows(sqlite_utils.Database(str(log_path)))
+    assert len(rows) == 1
+    assert rows[0]["prompt"] == "second"
+
+
 @pytest.mark.xfail(sys.platform == "win32", reason="Expected to fail on Windows")
 def test_chat_tools(logs_db):
     runner = CliRunner()


### PR DESCRIPTION
Fixes #1204

Summary:
- Reopen and migrate the chat log database when its path disappears during a session.
- Use the refreshed connection for fragment commands and response logging.
- Add a regression test that deletes logs.db between chat responses.

Tests:
- .venv/bin/pytest -q (976 passed)
- .venv/bin/ruff check llm/cli.py tests/test_chat.py
- .venv/bin/black --check llm/cli.py tests/test_chat.py