### PR TITLE
Fix --continue to resume most recently active conversation

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1373,19 +1373,20 @@ def load_conversation(
     db = sqlite_utils.Database(log_path)
     migrate(db)
     if conversation_id is None:
-        # Most recent conversation from either generation of tables -
-        # thread ids are conversation ids, so the union dedupes rows
-        # from the dual-write era.
-        matches = list(db.query("""
-                select id from (
-                    select id from threads
-                    union
-                    select id from conversations
+        # Find the thread/conversation whose most recent turn or response has
+        # the highest ID. Ordering by the thread's own creation ID would return
+        # the most recently *created* thread, not the most recently *used* one —
+        # which is wrong after `llm --continue --cid <old-id>` adds a new turn
+        # to an older thread while a newer thread exists.
+        try:
+            conversation_id = next(db.query("""
+                select conversation_id from (
+                    select thread_id as conversation_id, id from turns
+                    union all
+                    select conversation_id, id from responses
                 ) order by id desc limit 1
-                """))
-        if matches:
-            conversation_id = matches[0]["id"]
-        else:
+            """))["conversation_id"]
+        except StopIteration:
             return None
     try:
         row = cast(sqlite_utils.db.Table, db["conversations"]).get(conversation_id)

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -182,6 +182,52 @@ def test_llm_prompt_continue(httpx_mock, mock_openai_responses, user_path, async
     assert len(rows) == 2
 
 
+def test_continue_resumes_most_recently_active_conversation(user_path, mock_model):
+    """llm --continue must resume the conversation with the most recent turn,
+    not the most recently created thread (issue #1140)."""
+    from llm.cli import load_conversation
+
+    runner = CliRunner()
+    log_path = str(user_path / "logs.db")
+
+    # First conversation – thread A is created first (lower ULID).
+    mock_model.enqueue(["response-A"])
+    result = runner.invoke(
+        cli, ["-m", "mock", "prompt A", "--no-stream"], catch_exceptions=False
+    )
+    assert result.exit_code == 0
+
+    db = sqlite_utils.Database(log_path)
+    thread_A_id = list(db["threads"].rows_where(order_by="id"))[0]["id"]
+
+    # Second conversation – thread B is created later (higher ULID).
+    mock_model.enqueue(["response-B"])
+    result = runner.invoke(
+        cli, ["-m", "mock", "prompt B", "--no-stream"], catch_exceptions=False
+    )
+    assert result.exit_code == 0
+
+    threads = list(db["threads"].rows_where(order_by="id"))
+    assert len(threads) == 2
+    thread_B_id = threads[1]["id"]
+    assert thread_B_id > thread_A_id  # B was created after A
+
+    # Explicitly continue thread A – this adds a new turn whose ULID exceeds B's.
+    mock_model.enqueue(["response-A2"])
+    result = runner.invoke(
+        cli,
+        ["-m", "mock", "continue A", "--cid", thread_A_id, "--no-stream"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+    # load_conversation(None) must return thread A (most recent activity),
+    # not thread B (most recently created).
+    conv = load_conversation(None, database=log_path)
+    assert conv is not None
+    assert conv.id == thread_A_id
+
+
 @pytest.mark.parametrize(
     "args,expect_just_code",
     (


### PR DESCRIPTION
When `load_conversation(None)` is called it selects the thread whose creation-time ULID is highest, which means the most recently *created* thread — not the most recently *used* one. After `llm --continue --cid <old-id>` appends a new turn to an older thread, a subsequent bare `llm --continue` skips that older thread and picks a newer but idle thread instead.

The fix replaces the `threads`/`conversations` creation-ID ordering with the same turn/response activity query that `llm logs -c` already uses correctly, so `--continue` always resumes the conversation whose most recent turn has the highest ID. A regression test covering the exact scenario from the bug report is included.

Fixes #1140

---
_Generated by [Claude Code](https://claude.ai/code/session_01ADAmECXvv1Hq8dZucifmAT)_