### PR TITLE
feat: Support chat_template_kwargs for OpenAI-compatible models

### DIFF
--- a/docs/other-models.md
+++ b/docs/other-models.md
@@ -158,6 +158,24 @@ To add the `orca-mini-3b` model hosted by a local installation of [LocalAI](http
 ```
 If the `api_base` is set, the existing configured `openai` API key will not be sent by default.
 
+Some OpenAI-compatible Chat Completions servers support provider-specific chat template arguments. These can be saved in a reusable template using the `chat_template_kwargs` option. For example, a server using `enable_thinking` could use a template like this:
+
+```yaml
+model: orca-openai-compat
+prompt: $input
+options:
+  chat_template_kwargs:
+    enable_thinking: false
+```
+
+The nested keys are defined by the provider, not by LLM. The equivalent command-line option accepts a JSON object:
+
+```bash
+llm -m orca-openai-compat \
+  -o chat_template_kwargs '{"enable_thinking": false}' \
+  "What is the capital of France?"
+```
+
 You can set `api_key_name` to the name of a key stored using the {ref}`api-keys` feature.
 
 Other keys you can use here:

--- a/docs/other-models.md
+++ b/docs/other-models.md
@@ -170,6 +170,24 @@ To add the `orca-mini-3b` model hosted by a local installation of [LocalAI](http
 ```
 If the `api_base` is set, the existing configured `openai` API key will not be sent by default.
 
+Some OpenAI-compatible Chat Completions servers support provider-specific chat template arguments. These can be saved in a reusable template using the `chat_template_kwargs` option. For example, a server using `enable_thinking` could use a template like this:
+
+```yaml
+model: orca-openai-compat
+prompt: $input
+options:
+  chat_template_kwargs:
+    enable_thinking: false
+```
+
+The nested keys are defined by the provider, not by LLM. The equivalent command-line option accepts a JSON object:
+
+```bash
+llm -m orca-openai-compat \
+  -o chat_template_kwargs '{"enable_thinking": false}' \
+  "What is the capital of France?"
+```
+
 You can set `api_key_name` to the name of a key stored using the {ref}`api-keys` feature.
 
 Other keys you can use here:

--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -956,6 +956,32 @@ class SharedOptions(llm.Options):
         return validated_logit_bias
 
 
+class ChatOptions(SharedOptions):
+    chat_template_kwargs: dict | str | None = Field(
+        description=(
+            "Provider-specific arguments for the model's chat template. "
+            "Pass a JSON object string like '{\"enable_thinking\":false}'"
+        ),
+        default=None,
+    )
+
+    @field_validator("chat_template_kwargs")
+    def validate_chat_template_kwargs(cls, chat_template_kwargs):
+        if chat_template_kwargs is None:
+            return None
+
+        if isinstance(chat_template_kwargs, str):
+            try:
+                chat_template_kwargs = json.loads(chat_template_kwargs)
+            except json.JSONDecodeError:
+                raise ValueError("Invalid JSON in chat_template_kwargs string")
+
+        if not isinstance(chat_template_kwargs, dict):
+            raise ValueError("chat_template_kwargs must be a JSON object")
+
+        return chat_template_kwargs
+
+
 class ReasoningEffortEnum(str, Enum):
     none = "none"
     minimal = "minimal"
@@ -1073,7 +1099,7 @@ def build_options_class(
                 default=None,
             ),
         )
-    return create_model("Options", __base__=SharedOptions, **fields)
+    return create_model("Options", __base__=ChatOptions, **fields)
 
 
 def _attachment(attachment, image_detail=None):
@@ -1323,8 +1349,13 @@ class _Shared:
     def build_kwargs(self, prompt, stream):
         kwargs = dict(not_nulls(prompt.options))
         json_object = kwargs.pop("json_object", None)
+        chat_template_kwargs = kwargs.pop("chat_template_kwargs", None)
         kwargs.pop("image_detail", None)
         kwargs.pop("chat_completions", None)
+        if chat_template_kwargs is not None:
+            kwargs["extra_body"] = {
+                "chat_template_kwargs": chat_template_kwargs,
+            }
         if "max_tokens" not in kwargs and self.default_max_tokens is not None:
             kwargs["max_tokens"] = self.default_max_tokens
         if json_object:
@@ -2018,6 +2049,12 @@ class _SharedResponses(_Shared):
         opts.pop("json_object", None)
         opts.pop("chat_completions", None)
         opts.pop("image_detail", None)
+        chat_template_kwargs = opts.pop("chat_template_kwargs", None)
+        if chat_template_kwargs is not None:
+            raise ValueError(
+                "chat_template_kwargs is only supported by Chat Completions; "
+                "use -o chat_completions 1"
+            )
         max_tokens = opts.pop("max_tokens", None)
         reasoning_effort = opts.pop("reasoning_effort", None)
         verbosity = opts.pop("verbosity", None)

--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -956,6 +956,32 @@ class SharedOptions(llm.Options):
         return validated_logit_bias
 
 
+class ChatOptions(SharedOptions):
+    chat_template_kwargs: dict | str | None = Field(
+        description=(
+            "Provider-specific arguments for the model's chat template. "
+            "Pass a JSON object string like '{\"enable_thinking\":false}'"
+        ),
+        default=None,
+    )
+
+    @field_validator("chat_template_kwargs")
+    def validate_chat_template_kwargs(cls, chat_template_kwargs):
+        if chat_template_kwargs is None:
+            return None
+
+        if isinstance(chat_template_kwargs, str):
+            try:
+                chat_template_kwargs = json.loads(chat_template_kwargs)
+            except json.JSONDecodeError:
+                raise ValueError("Invalid JSON in chat_template_kwargs string")
+
+        if not isinstance(chat_template_kwargs, dict):
+            raise ValueError("chat_template_kwargs must be a JSON object")
+
+        return chat_template_kwargs
+
+
 class ReasoningEffortEnum(str, Enum):
     none = "none"
     minimal = "minimal"
@@ -1092,7 +1118,7 @@ def build_options_class(
                 default=None,
             ),
         )
-    return create_model("Options", __base__=SharedOptions, **fields)
+    return create_model("Options", __base__=ChatOptions, **fields)
 
 
 def _attachment(attachment, image_detail=None):
@@ -1342,11 +1368,16 @@ class _Shared:
     def build_kwargs(self, prompt, stream):
         kwargs = dict(not_nulls(prompt.options))
         json_object = kwargs.pop("json_object", None)
+        chat_template_kwargs = kwargs.pop("chat_template_kwargs", None)
         kwargs.pop("image_detail", None)
         kwargs.pop("chat_completions", None)
         # Responses models reuse their Options object when explicitly routed
         # through the Chat Completions compatibility path.
         kwargs.pop("reasoning_summary", None)
+        if chat_template_kwargs is not None:
+            kwargs["extra_body"] = {
+                "chat_template_kwargs": chat_template_kwargs,
+            }
         if "max_tokens" not in kwargs and self.default_max_tokens is not None:
             kwargs["max_tokens"] = self.default_max_tokens
         if json_object:
@@ -2040,6 +2071,12 @@ class _SharedResponses(_Shared):
         opts.pop("json_object", None)
         opts.pop("chat_completions", None)
         opts.pop("image_detail", None)
+        chat_template_kwargs = opts.pop("chat_template_kwargs", None)
+        if chat_template_kwargs is not None:
+            raise ValueError(
+                "chat_template_kwargs is only supported by Chat Completions; "
+                "use -o chat_completions 1"
+            )
         max_tokens = opts.pop("max_tokens", None)
         reasoning_effort = opts.pop("reasoning_effort", None)
         reasoning_summary = opts.pop("reasoning_summary", None)

--- a/tests/test_cli_openai_models.py
+++ b/tests/test_cli_openai_models.py
@@ -64,6 +64,120 @@ def test_openai_options_min_max():
         assert f"less than or equal to {max_val}" in result2.output
 
 
+def test_chat_template_kwargs_option_is_sent_as_json_object(httpx_mock):
+    httpx_mock.add_response(
+        method="POST",
+        url="https://api.openai.com/v1/chat/completions",
+        json={
+            "model": "gpt-4o-mini",
+            "usage": {},
+            "choices": [{"message": {"content": "Thought briefly"}}],
+        },
+        headers={"Content-Type": "application/json"},
+    )
+    result = CliRunner().invoke(
+        cli,
+        [
+            "-m",
+            "gpt-4o-mini",
+            "-o",
+            "chat_template_kwargs",
+            '{"enable_thinking": false}',
+            "-o",
+            "temperature",
+            "0.5",
+            "--no-stream",
+            "--key",
+            "x",
+            "Think briefly",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    request_body = json.loads(httpx_mock.get_requests()[-1].content)
+    assert request_body["chat_template_kwargs"] == {"enable_thinking": False}
+    assert request_body["temperature"] == 0.5
+
+
+@pytest.mark.parametrize(
+    "value,expected_error",
+    (
+        ("{", "Invalid JSON in chat_template_kwargs string"),
+        ('["enable_thinking"]', "chat_template_kwargs must be a JSON object"),
+    ),
+)
+def test_chat_template_kwargs_option_rejects_invalid_json_objects(
+    value, expected_error
+):
+    result = CliRunner().invoke(
+        cli,
+        ["-m", "gpt-4o-mini", "-o", "chat_template_kwargs", value, "Say hi"],
+    )
+
+    assert result.exit_code == 1
+    assert expected_error in result.output
+
+
+def test_responses_model_requires_chat_completions_for_chat_template_kwargs():
+    result = CliRunner().invoke(
+        cli,
+        [
+            "-m",
+            "gpt-5",
+            "--key",
+            "x",
+            "-o",
+            "chat_template_kwargs",
+            '{"enable_thinking": false}',
+            "Say hi",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert (
+        "chat_template_kwargs is only supported by Chat Completions; "
+        "use -o chat_completions 1"
+    ) in result.output
+
+
+def test_responses_model_delegates_chat_template_kwargs_to_chat_completions(
+    httpx_mock,
+):
+    httpx_mock.add_response(
+        method="POST",
+        url="https://api.openai.com/v1/chat/completions",
+        json={
+            "model": "gpt-5",
+            "usage": {},
+            "choices": [{"message": {"content": "Thought briefly"}}],
+        },
+        headers={"Content-Type": "application/json"},
+    )
+    result = CliRunner().invoke(
+        cli,
+        [
+            "-m",
+            "gpt-5",
+            "-o",
+            "chat_completions",
+            "1",
+            "-o",
+            "chat_template_kwargs",
+            '{"enable_thinking": false}',
+            "--no-stream",
+            "--key",
+            "x",
+            "Think briefly",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    request_body = json.loads(httpx_mock.get_requests()[-1].content)
+    assert request_body["chat_template_kwargs"] == {"enable_thinking": False}
+
+
 @pytest.mark.parametrize(
     "model_id",
     (

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -291,6 +291,16 @@ def test_templates_error_on_missing_schema(templates_path):
             None,
             {"temperature": 0.5},
         ),
+        (
+            "prompt: 'Think briefly: $input'\noptions:\n"
+            "  chat_template_kwargs:\n    enable_thinking: false",
+            "Input text",
+            ["-m", "gpt-4o-mini"],
+            "gpt-4o-mini",
+            "Think briefly: Input text",
+            None,
+            {"chat_template_kwargs": {"enable_thinking": False}},
+        ),
         # Should be over-ridden by CLI
         (
             "prompt: 'Summarize this: $input'\noptions:\n  temperature: 0.5",


### PR DESCRIPTION
## Summary

Add `chat_template_kwargs` to the shared Chat Completions option schema as a mapping, with JSON-object normalization for the string form supplied by `-o/--option`, following the existing `logit_bias` validation pattern. In `_Shared.build_kwargs()`, remove that value from the typed OpenAI SDK arguments and place it under the client's custom request-body facility so the serialized request sent to OpenAI-compatible servers contains a top-level `chat_template_kwargs` object; the shared path will cover synchronous and asynchronous `Chat` models as well as configured models and `llm openai endpoint`. Keep the scope explicit to this supported extension instead of changing the base `Options` policy to accept arbitrary keys.

## Validation

- A saved template whose `options.chat_template_kwargs` contains `enable_thinking: false` validates for an OpenAI Chat model and sends that nested object as the top-level `chat_template_kwargs` property in the HTTP request.
- A `-o chat_template_kwargs '{"enable_thinking": false}'` value is normalized to the same mapping, while malformed JSON or a non-object JSON value produces the existing clear option-validation error instead of reaching the provider.
- Existing standard options such as `temperature` continue to be sent directly, and omitting `chat_template_kwargs` does not add an empty custom-body field or otherwise change the request payload.
- The user-facing OpenAI-compatible models documentation shows how to set the option in a reusable template and makes clear that the nested keys are provider-specific.

## Why

Templates currently accept an `options:` mapping, but each selected model validates that mapping against its Pydantic `Options` class, so `chat_template_kwargs` is rejected as an extra input. OpenAI-compatible servers such as llama.cpp accept this request property and use its nested values to control template-specific behavior such as disabling thinking. The OpenAI model implementation needs to expose the option while preserving the project's deliberate validation of model options rather than allowing every unknown key through unchecked.

Fixes #1491
