### PR TITLE
Fix Anthropic API key alias in Python API docs

### DIFF
--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -543,7 +543,7 @@ Then in your Python code:
 import llm
 
 model = llm.get_model("claude-3.5-sonnet")
-# Use this if you have not set the key using 'llm keys set claude':
+# Use this if you have not set the key using 'llm keys set anthropic':
 model.key = 'YOUR_API_KEY_HERE'
 response = model.prompt("Five surprising names for a pet pelican")
 print(response.text())


### PR DESCRIPTION
## Summary
- Update the llm-anthropic Python API example to reference `llm keys set anthropic` instead of the legacy `claude` key alias.
- Aligns with `docs/index.md` and the llm-anthropic plugin (`needs_key = "anthropic"`).

## Test plan
- [x] Docs-only change in `docs/python-api.md`