### PR TITLE
Ability to override default model using LLM_DEFAULT_MODEL env variable

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 ## Unreleased
 
 - Reasoning-capable Responses API models now support a `reasoning_summary` option with `auto`, `concise`, and `detailed` values. This can be used with {ref}`llm openai endpoint --responses <openai-endpoint>`. [#1600](https://github.com/simonw/llm/issues/1600)
+- The default model can now be overridden using the `LLM_DEFAULT_MODEL` environment variable. This takes precedence over the model saved by `llm models default`.
 
 (v0_32)=
 ## 0.32 (2026-08-04)

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1012,6 +1012,9 @@ llm.set_default_model("claude-5-sonnet")
 
 This returns the currently configured default model, or `gpt-5.6-luna` if no default has been set.
 
+If the `LLM_DEFAULT_MODEL` environment variable is set, its value is returned
+instead of the configured default.
+
 ```python
 import llm
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -180,6 +180,16 @@ llm models default
 ```
 Any of the supported aliases for a model can be passed to this command.
 
+You can override the configured default using the `LLM_DEFAULT_MODEL`
+environment variable:
+
+```bash
+export LLM_DEFAULT_MODEL=gpt-4.1
+```
+
+This takes precedence over the model saved by `llm models default`. An explicit
+`-m/--model` option still takes precedence for an individual command.
+
 ### Setting a custom directory location
 
 This tool stores various files - prompt templates, stored keys, preferences, a database of logs - in a directory on your computer.

--- a/llm/__init__.py
+++ b/llm/__init__.py
@@ -483,6 +483,10 @@ def cosine_similarity(a, b):
 
 
 def get_default_model(filename="default_model.txt", default=DEFAULT_MODEL):
+    if filename == "default_model.txt":
+        environment_default = os.environ.get("LLM_DEFAULT_MODEL")
+        if environment_default is not None:
+            return environment_default
     path = user_dir() / filename
     if path.exists():
         return path.read_text().strip()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,7 @@ def templates_path(user_path):
 @pytest.fixture(autouse=True)
 def env_setup(monkeypatch, user_path):
     monkeypatch.setenv("LLM_USER_PATH", str(user_path))
+    monkeypatch.delenv("LLM_DEFAULT_MODEL", raising=False)
 
 
 class MockModel(llm.Model):

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -615,6 +615,18 @@ def test_model_defaults(tmpdir, monkeypatch):
     assert llm.get_model().model_id == "gpt-4o"
 
 
+def test_default_model_environment_variable_takes_precedence(tmpdir, monkeypatch):
+    user_dir = str(tmpdir / "u")
+    monkeypatch.setenv("LLM_USER_PATH", user_dir)
+    llm.set_default_model("gpt-4o")
+
+    monkeypatch.setenv("LLM_DEFAULT_MODEL", "gpt-4.1")
+
+    assert llm.get_default_model() == "gpt-4.1"
+    assert llm.get_model().model_id == "gpt-4.1"
+    assert llm.get_default_embedding_model() is None
+
+
 def test_get_models():
     models = llm.get_models()
     assert all(isinstance(model, (llm.Model, llm.KeyModel)) for model in models)


### PR DESCRIPTION
This introduces an environment variable `$LLM_DEFAULT_MODEL` that the user can set to override the default model to use. It takes precedence over the `default_model.txt` file (i.e. what was set using "llm models default").

Motivation is that an environment variable is per-shell and thus less "stateful" and much easier to handle than a static config file in many situations. In my case, I want to use a zsh integration that sets different default models for "llm" depending on what the current directory is. Think "employer-provided" vs. "privately used" models. This is much easier to do by setting an env variable rather than defining different aliases for "llm --model xxx" or -- worse -- rewriting the `default_model.txt` file.

It's a simple change, maybe you can merge it. I can change the name of the variable if "LLM_DEFAULT_MODEL" sounds too generic or something.