### PR TITLE
fix: guard empty aliases list in 'llm aliases list'

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 ## Unreleased
 
 - Reasoning-capable Responses API models now support a `reasoning_summary` option with `auto`, `concise`, and `detailed` values. This can be used with {ref}`llm openai endpoint --responses <openai-endpoint>`. [#1600](https://github.com/simonw/llm/issues/1600)
+- Fixed `llm aliases list` raising a `ValueError` when no aliases are defined. Thanks, [Taraka Abhiram](https://github.com/abhi-0203). [#1602](https://github.com/simonw/llm/issues/1602)
 
 (v0_32)=
 ## 0.32 (2026-08-04)

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -2929,6 +2929,8 @@ def aliases_list(json_):
             json.dumps({key: value for key, value, type_ in to_output}, indent=4)
         )
         return
+    if not to_output:
+        return
     max_alias_length = max(len(a) for a, _, _ in to_output)
     fmt = "{alias:<" + str(max_alias_length) + "} : {model_id}{type_}"
     for alias, model_id, type_ in to_output:

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -52,6 +52,15 @@ def test_cli_aliases_list(args):
 
 
 @pytest.mark.parametrize("args", (["aliases", "list"], ["aliases"]))
+def test_cli_aliases_list_empty(monkeypatch, args):
+    monkeypatch.setattr("llm.cli.get_model_aliases", lambda: {})
+    monkeypatch.setattr("llm.cli.get_embedding_model_aliases", lambda: {})
+    result = CliRunner().invoke(cli, args)
+    assert result.exit_code == 0
+    assert result.output == ""
+
+
+@pytest.mark.parametrize("args", (["aliases", "list"], ["aliases"]))
 def test_cli_aliases_list_json(args):
     llm.set_alias("e-demo", "embed-demo")
     runner = CliRunner()


### PR DESCRIPTION
## Summary

Fixes a `ValueError: max() arg is an empty sequence` when running `llm aliases list` on a fresh install or after removing all aliases.

The `--json` variant already handles the empty case correctly (returns `{}`), but the plain text path calls `max()` on an empty sequence before checking whether there is anything to display.

## Fix

Add an early return when no aliases exist, before the `max()` call. This matches the `--json` path's behavior.

## Reproduction

```bash
llm aliases list  # on fresh install with no aliases defined
# ValueError: max() arg is an empty sequence
```

Closes #1602
