### PR TITLE
Declare httpx as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 dependencies = [
     "click",
     "condense-json>=1.1",
+    "httpx",
     "openai>=2.32.0",
     "click-default-group>=1.2.3",
     "sqlite-utils>=4.0",


### PR DESCRIPTION
Refs #1608.

`httpx` is imported in `llm/models.py`, `llm/cli.py`, `llm/utils.py` and `llm/default_plugins/openai_models.py`, but it was never declared in `dependencies` — it arrived transitively through `openai`. `openai` 3.0.0 (released 2026-08-12) migrated to HTTPX2, so a fresh install no longer gets `httpx` and every command dies at import time with `ModuleNotFoundError: No module named 'httpx'`.

Verified both directions with a clean install, without the dev group (which would mask the problem, since `pytest-httpx` brings `httpx` in):

```
uv venv v1 && VIRTUAL_ENV=v1 uv pip install .
v1/bin/llm models
```

| tree | result |
| --- | --- |
| `main` (c410af0) | `ModuleNotFoundError: No module named 'httpx'` |
| this branch | works — resolves `openai==3.0.0`, `httpx2==2.10.0`, `httpx==0.28.1` |

No httpx2 migration seems necessary in `llm` itself: the only place an httpx object reaches the OpenAI client is `openai_models.py:1336` (`LLM_OPENAI_SHOW_RESPONSES` → `http_client=logging_client()`), and openai 3.0.0's legacy escape hatch still accepts a plain `httpx.Client` — #1608 has a runnable check confirming the custom transport is really used, not silently ignored.

This only covers the broken install. The second half of #1608 — `pytest-httpx` no longer intercepting openai's traffic under httpx2, so tests reach `api.openai.com` for real — is untouched here, since pinning versus migrating to `pytest-httpx2` is your call.
