### PR TITLE
Add llm-1password to plugin directory

### DIFF
--- a/docs/plugins/directory.md
+++ b/docs/plugins/directory.md
@@ -90,6 +90,7 @@ The following plugins add new {ref}`tools <tools>` that can be used by models:
 - **[llm-python](https://github.com/simonw/llm-python)** adds a `llm python` command for running a Python interpreter in the same virtual environment as LLM. This is useful for debugging, and also provides a convenient way to interact with the LLM {ref}`python-api` if you installed LLM using Homebrew or `pipx`.
 - **[llm-cluster](https://github.com/simonw/llm-cluster)** adds a `llm cluster` command for calculating clusters for a collection of embeddings. Calculated clusters can then be passed to a Large Language Model to generate a summary description.
 - **[llm-jq](https://github.com/simonw/llm-jq)** lets you pipe in JSON data and a prompt describing a `jq` program, then executes the generated program against the JSON.
+- **[llm-1password](https://github.com/dallascrilley/llm-1password)** adds `llm 1password` commands that store `op://` references and resolve model keys from 1Password at call time.
 
 (plugin-directory-fun)=
 ## Just for fun


### PR DESCRIPTION
Adds one Extra commands line for [llm-1password](https://github.com/dallascrilley/llm-1password).

The plugin stores `op://` references and resolves model keys from 1Password at call time. A failed read aborts the prompt.

```bash
llm install llm-1password
```

Published on PyPI: https://pypi.org/project/llm-1password/
