### PR TITLE
fix: accept JSON Schema type names in schema_dsl

### DIFF
--- a/docs/schemas.md
+++ b/docs/schemas.md
@@ -472,7 +472,7 @@ You can include type information by adding a type indicator after the property n
 
     name, bio, age int
 
-Supported types are `int` for integers, `float` for floating point numbers, `str` for strings (the default) and `bool` for true/false booleans.
+Supported types are `int` or `integer` for integers, `float` or `number` for floating point numbers, `str` or `string` for strings (the default) and `bool` or `boolean` for true/false booleans.
 
 To include a description of the field to act as a hint to the model, add one after a colon:
 

--- a/llm/utils.py
+++ b/llm/utils.py
@@ -365,9 +365,13 @@ def schema_dsl(schema_dsl: str, multi: bool = False) -> dict[str, Any]:
     # Type mapping dictionary
     type_mapping = {
         "int": "integer",
+        "integer": "integer",
         "float": "number",
+        "number": "number",
         "bool": "boolean",
+        "boolean": "boolean",
         "str": "string",
+        "string": "string",
     }
 
     # Initialize the schema dictionary with required elements

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -226,6 +226,20 @@ def test_extract_fenced_code_block(input, last, expected):
                 "required": ["name", "age"],
             },
         ),
+        # Test case 9: Full JSON Schema type names
+        (
+            "count integer, score number, active boolean, name string",
+            {
+                "type": "object",
+                "properties": {
+                    "count": {"type": "integer"},
+                    "score": {"type": "number"},
+                    "active": {"type": "boolean"},
+                    "name": {"type": "string"},
+                },
+                "required": ["count", "score", "active", "name"],
+            },
+        ),
     ],
 )
 def test_schema_dsl(schema, expected):


### PR DESCRIPTION
## Summary

- `schema_dsl()` only mapped Python-style abbreviations (`int`, `float`, `bool`, `str`). Full JSON Schema names (`integer`, `number`, `boolean`, `string`) fell through to the default `"string"`.
- Map those four names through to the matching JSON Schema types. Short forms are unchanged.
- Document the aliases next to the existing type list.

Fixes #1607

## What I changed

- Files: `llm/utils.py`, `tests/test_utils.py`, `docs/schemas.md`
- Behavior before → after: `schema_dsl('count integer')` produced `{"type": "string"}`; it now produces `{"type": "integer"}`. Same for `number` / `boolean` / `string`.

## Test plan

- [x] Reproduced the issue: `schema_dsl('count integer')` returned string before the mapping change
- [x] Project test command: `uv run pytest tests/test_utils.py` (82 passed)
- [x] Manual check: `schema_dsl('count integer')`, `'score number'`, `'active boolean'`, `'name string'`, and `'age int'` all return the expected types

## Notes for maintainers

- I can iterate on review comments
