### PR TITLE
fix: set conversation_id from the conversation in --data-ids

### DIFF
--- a/docs/schemas.md
+++ b/docs/schemas.md
@@ -588,11 +588,11 @@ llm logs --schema-multi 'name, ten_word_bio' --data-key items --data-ids
 ```
 Output:
 ```json
-{"name": "Nebula", "ten_word_bio": "A cosmic puppy with starry fur, loves adventures in space.", "response_id": "01jn4dawj8sq0c6t3emf4k5ryx", "conversation_id": "01jn4dawj8sq0c6t3emf4k5ryx"}
-{"name": "Echo", "ten_word_bio": "A clever hound with extraordinary hearing, master of hide-and-seek.", "response_id": "01jn4dawj8sq0c6t3emf4k5ryx", "conversation_id": "01jn4dawj8sq0c6t3emf4k5ryx"}
-{"name": "Biscuit", "ten_word_bio": "An adorable chef dog, bakes treats that everyone loves.", "response_id": "01jn4dawj8sq0c6t3emf4k5ryx", "conversation_id": "01jn4dawj8sq0c6t3emf4k5ryx"}
-{"name": "Cosmo", "ten_word_bio": "Galactic explorer, loves adventures and chasing shooting stars.", "response_id": "01jn4daycb3svj0x7kvp7zrp4q", "conversation_id": "01jn4daycb3svj0x7kvp7zrp4q"}
-{"name": "Pixel", "ten_word_bio": "Tech-savvy pup, builds gadgets and loves virtual playtime.", "response_id": "01jn4daycb3svj0x7kvp7zrp4q", "conversation_id": "01jn4daycb3svj0x7kvp7zrp4q"}
+{"name": "Nebula", "ten_word_bio": "A cosmic puppy with starry fur, loves adventures in space.", "response_id": "01jn4dawj8sq0c6t3emf4k5ryx", "conversation_id": "01jn4daxk2sq0c6t3emf4k5aaa"}
+{"name": "Echo", "ten_word_bio": "A clever hound with extraordinary hearing, master of hide-and-seek.", "response_id": "01jn4dawj8sq0c6t3emf4k5ryx", "conversation_id": "01jn4daxk2sq0c6t3emf4k5aaa"}
+{"name": "Biscuit", "ten_word_bio": "An adorable chef dog, bakes treats that everyone loves.", "response_id": "01jn4dawj8sq0c6t3emf4k5ryx", "conversation_id": "01jn4daxk2sq0c6t3emf4k5aaa"}
+{"name": "Cosmo", "ten_word_bio": "Galactic explorer, loves adventures and chasing shooting stars.", "response_id": "01jn4daycb3svj0x7kvp7zrp4q", "conversation_id": "01jn4dazk2sq0c6t3emf4k5bbb"}
+{"name": "Pixel", "ten_word_bio": "Tech-savvy pup, builds gadgets and loves virtual playtime.", "response_id": "01jn4daycb3svj0x7kvp7zrp4q", "conversation_id": "01jn4dazk2sq0c6t3emf4k5bbb"}
 ```
 If a row already has a property called `"conversation_id"` or `"response_id"` additional underscores will be appended to the ID key until it no longer overlaps with the existing keys.
 

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1970,7 +1970,9 @@ def logs_list(
                 if data_ids:
                     for item in new_items:
                         item[find_unused_key(item, "response_id")] = row["id"]
-                        item[find_unused_key(item, "conversation_id")] = row["id"]
+                        item[find_unused_key(item, "conversation_id")] = row[
+                            "conversation_id"
+                        ]
                 to_output.extend(new_items)
             except ValueError:
                 pass

--- a/tests/test_llm_logs.py
+++ b/tests/test_llm_logs.py
@@ -612,8 +612,12 @@ def test_logs_schema_data_ids(schema_log_path):
         "name",
         "conversation_id__",
     }
+    assert last_row["response_id_"] == str(ulid).lower()
+    assert last_row["conversation_id__"] == "abc123"
     for row in rows:
         assert set(row.keys()) == {"conversation_id", "response_id", "name"}
+        assert row["conversation_id"] in {"abc123", "abc456"}
+        assert row["conversation_id"] != row["response_id"]
 
 
 _expected_yaml_re = r"""- id: [a-f0-9]{32}


### PR DESCRIPTION
## Summary

- `llm logs --data-ids` attached `row["id"]` (the response ULID) to both `response_id` and `conversation_id`.
- `conversation_id` now uses `row["conversation_id"]` so consumers can group rows by thread.
- Docs example updated so the two IDs are no longer identical.

Fixes:
- #1598

## What I changed

- Files: `llm/cli.py`, `tests/test_llm_logs.py`, `docs/schemas.md`
- Behavior before → after: `--data-ids` wrote the same ULID twice; it now writes the conversation/thread id on `conversation_id`.

## Test plan

- [x] Reproduced: both keys were set from `row["id"]`
- [x] `uv run pytest tests/test_llm_logs.py::test_logs_schema_data_ids tests/test_llm_logs.py::test_logs_schema` (5 passed)
- [x] Collision case still uses `conversation_id__` when the payload already has `conversation_id` / `conversation_id_`, and that value is `abc123`

## Notes for maintainers

- I can iterate on review comments
