### PR TITLE
Deduplicate required in schema_dsl()

### DIFF
--- a/llm/utils.py
+++ b/llm/utils.py
@@ -413,8 +413,9 @@ def schema_dsl(schema_dsl: str, multi: bool = False) -> dict[str, Any]:
         if description:
             json_schema["properties"][field_name]["description"] = description
 
-        # Add field to required list
-        json_schema["required"].append(field_name)
+        # Add field to required list, which repeating a name must not duplicate
+        if field_name not in json_schema["required"]:
+            json_schema["required"].append(field_name)
 
     if multi:
         return multi_schema(json_schema)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -226,6 +226,32 @@ def test_extract_fenced_code_block(input, last, expected):
                 "required": ["name", "age"],
             },
         ),
+        # Test case 9: Repeated property name is listed once in required
+        (
+            "name, age int, name",
+            {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "age": {"type": "integer"},
+                },
+                "required": ["name", "age"],
+            },
+        ),
+        # Test case 10: Repeated name keeps the last description
+        (
+            """
+        name: first name
+        name: last name
+        """,
+            {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "last name"},
+                },
+                "required": ["name"],
+            },
+        ),
     ],
 )
 def test_schema_dsl(schema, expected):


### PR DESCRIPTION

Closes #1616

`schema_dsl()` writes each field into `properties` (a dict, so a repeated name overwrites) but appends every field to `required` (a list, so a repeated name accumulates):

```python
json_schema["properties"][field_name] = {"type": field_type}
...
json_schema["required"].append(field_name)
```

So a repeated property name produces a schema that is invalid against the JSON Schema meta-schema:

```
llm schemas dsl 'name, age int, name'
```

```json
{
  "type": "object",
  "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
  "required": ["name", "age", "name"]
}
```

`required` is a `stringArray` in 2020-12, which carries `uniqueItems: true`:

```python
>>> from jsonschema import Draft202012Validator
>>> Draft202012Validator.check_schema(schema_dsl("name, age int, name"))
jsonschema.exceptions.SchemaError: ['name', 'age', 'name'] has non-unique elements
```

The newline form is the easier one to hit by accident, since a long schema can reuse a name without it being obvious:

```
name: first name
name: last name
```

which yields one property and `"required": ["name", "name"]`.

### Change

A name already in `required` is not appended again. Both examples above now pass `check_schema()`.

### On the dropped field

The issue also notes that the earlier definition is silently discarded when a name repeats. That is left as is — last-one-wins is what assigning into `properties` already does, and rejecting duplicate names outright would be a behaviour change for anyone whose schema currently relies on it. Test case 10 pins the current behaviour explicitly so it is a decision rather than an accident; happy to make it raise instead if you would prefer that.

### Tests

Two cases added to the existing `test_schema_dsl` parametrize list:

- a repeated name in the comma form is listed once in `required`
- a repeated name in the newline form keeps the last description and is listed once

Both fail before this change and pass after. `tests/test_utils.py` passes (83 tests), and `ruff check` and `black --check` are clean on both files.
