### PR TITLE
Add --key option to llm embed and llm embed-multi

### DIFF
--- a/docs/embeddings/cli.md
+++ b/docs/embeddings/cli.md
@@ -17,6 +17,8 @@ llm embed -c 'This is some content' -m 3-small
 ```
 `-m 3-small` specifies the OpenAI `text-embedding-3-small` model. You will need to have set an OpenAI API key using `llm keys set openai` for this to work.
 
+You can pass an API key directly using the `--key` option instead of relying on a stored or environment variable key. This option is also available for `llm embed-multi`.
+
 You can install plugins to access other models. The [llm-sentence-transformers](https://github.com/simonw/llm-sentence-transformers) plugin can be used to run models on your own laptop, such as the [MiniLM-L6](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2) model:
 
 ```bash

--- a/docs/help.md
+++ b/docs/help.md
@@ -877,6 +877,7 @@ Usage: llm embed [OPTIONS] [COLLECTION] [ID]
 Options:
   -i, --input PATH                File to embed
   -m, --model TEXT                Embedding model to use
+  --key TEXT                      API key to use
   --store                         Store the text itself in the database
   -d, --database FILE
   -c, --content TEXT              Content to embed
@@ -935,6 +936,7 @@ Options:
   --batch-size INTEGER         Batch size to use when running embeddings
   --prefix TEXT                Prefix to add to the IDs
   -m, --model TEXT             Embedding model to use
+  --key TEXT                   API key to use
   --prepend TEXT               Prepend this string to all content before
                                embedding
   --store                      Store the text itself in the database

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -3261,6 +3261,7 @@ def uninstall(packages, yes):
 @click.option(
     "-m", "--model", help="Embedding model to use", envvar="LLM_EMBEDDING_MODEL"
 )
+@click.option("--key", help="API key to use")
 @click.option("--store", is_flag=True, help="Store the text itself in the database")
 @click.option(
     "-d",
@@ -3287,7 +3288,17 @@ def uninstall(packages, yes):
     help="Output format",
 )
 def embed(
-    collection, id, input, model, store, database, content, binary, metadata, format_
+    collection,
+    id,
+    input,
+    model,
+    key,
+    store,
+    database,
+    content,
+    binary,
+    metadata,
+    format_,
 ):
     """Embed text and store or return the result"""
     if collection and not id:
@@ -3331,6 +3342,9 @@ def embed(
             raise click.ClickException(
                 "You need to specify an embedding model (no default model is set)"
             )
+
+    if key:
+        model_obj.key = key
 
     show_output = True
     if collection and (format_ is None):
@@ -3405,6 +3419,7 @@ def embed(
 @click.option(
     "-m", "--model", help="Embedding model to use", envvar="LLM_EMBEDDING_MODEL"
 )
+@click.option("--key", help="API key to use")
 @click.option(
     "--prepend",
     help="Prepend this string to all content before embedding",
@@ -3428,6 +3443,7 @@ def embed_multi(
     batch_size,
     prefix,
     model,
+    key,
     prepend,
     store,
     database,
@@ -3497,6 +3513,9 @@ def embed_multi(
         raise click.ClickException(
             "You need to specify an embedding model (no default model is set)"
         )
+
+    if key:
+        collection_obj.model().key = key
 
     expected_length = None
     if files:

--- a/tests/test_embed_cli.py
+++ b/tests/test_embed_cli.py
@@ -176,6 +176,48 @@ def test_embed_store_binary(user_path):
     ]
 
 
+def test_embed_key_option(embed_demo):
+    # --key should be passed through to the embedding model
+    assert embed_demo.key is None
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["embed", "-c", "hello world", "-m", "embed-demo", "--key", "sekrit"]
+    )
+    assert result.exit_code == 0
+    assert embed_demo.key == "sekrit"
+
+
+def test_embed_multi_key_option(embed_demo, tmpdir):
+    # --key should be passed through to the embedding model for embed-multi too
+    assert embed_demo.key is None
+    db_path = str(tmpdir / "embeddings.db")
+    db = sqlite_utils.Database(db_path)
+    db["content"].insert_all(
+        [
+            {"id": 1, "name": "cli", "description": "Command line interface"},
+        ],
+        pk="id",
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "embed-multi",
+            "stuff",
+            "-d",
+            db_path,
+            "--sql",
+            "select * from content",
+            "-m",
+            "embed-demo",
+            "--key",
+            "sekrit",
+        ],
+    )
+    assert result.exit_code == 0
+    assert embed_demo.key == "sekrit"
+
+
 def test_collection_delete_errors(user_path):
     db = sqlite_utils.Database(str(user_path / "embeddings.db"))
     collection = Collection("items", db, model_id="embed-demo")


### PR DESCRIPTION
Closes #757.

`llm prompt` already accepts a `--key` option to pass an API key directly. This adds the same option to `llm embed` and `llm embed-multi` so an embedding model's key can be supplied on the command line rather than only via a stored key (`llm keys set ...`) or an environment variable.

When `--key` is given, it is set on the resolved embedding model before embedding, so `EmbeddingModel.get_key()` returns it (mirroring how the key is threaded through for prompts). The default behaviour is unchanged when the option is omitted.

Example:

```bash
llm embed -c 'This is some content' -m 3-small --key sk-...
```

### Changes
- `--key` option on both `embed` and `embed-multi` in `llm/cli.py`
- Docs: mention in `docs/embeddings/cli.md`; regenerated `docs/help.md` via cog
- Tests: `test_embed_key_option` and `test_embed_multi_key_option` verifying the key reaches the model

`pytest tests/test_embed_cli.py tests/test_embed.py` passes (109 passed); `black` and `ruff` are clean.