### PR TITLE
Upgrade OpenAI tests to HTTPX2

### DIFF
--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -1333,7 +1333,7 @@ class _Shared:
         if self.headers:
             kwargs["default_headers"] = self.headers
         if os.environ.get("LLM_OPENAI_SHOW_RESPONSES"):
-            kwargs["http_client"] = logging_client()
+            kwargs["http_client"] = logging_client(async_=async_)
         if async_:
             return openai.AsyncOpenAI(**kwargs)
         else:

--- a/llm/utils.py
+++ b/llm/utils.py
@@ -7,10 +7,10 @@ import re
 import textwrap
 import threading
 import time
-from typing import Any, Final
+from typing import Any, Final, Literal, overload
 
 import click
-import httpx
+import httpx2
 import puremagic
 import sqlite_utils
 from ulid import ULID
@@ -93,18 +93,18 @@ def remove_dict_none_values(d):
     return new_dict
 
 
-class _LogResponse(httpx.Response):
+class _LogResponse(httpx2.Response):
     def iter_bytes(self, *args, **kwargs):
         for chunk in super().iter_bytes(*args, **kwargs):
             click.echo(chunk.decode(), err=True)
             yield chunk
 
 
-class _LogTransport(httpx.BaseTransport):
-    def __init__(self, transport: httpx.BaseTransport):
+class _LogTransport(httpx2.BaseTransport):
+    def __init__(self, transport: httpx2.BaseTransport):
         self.transport = transport
 
-    def handle_request(self, request: httpx.Request) -> httpx.Response:
+    def handle_request(self, request: httpx2.Request) -> httpx2.Response:
         response = self.transport.handle_request(request)
         return _LogResponse(
             status_code=response.status_code,
@@ -114,11 +114,36 @@ class _LogTransport(httpx.BaseTransport):
         )
 
 
-def _no_accept_encoding(request: httpx.Request):
+class _AsyncLogResponse(httpx2.Response):
+    async def aiter_bytes(self, *args, **kwargs):
+        async for chunk in super().aiter_bytes(*args, **kwargs):
+            click.echo(chunk.decode(), err=True)
+            yield chunk
+
+
+class _AsyncLogTransport(httpx2.AsyncBaseTransport):
+    def __init__(self, transport: httpx2.AsyncBaseTransport):
+        self.transport = transport
+
+    async def handle_async_request(self, request: httpx2.Request) -> httpx2.Response:
+        response = await self.transport.handle_async_request(request)
+        return _AsyncLogResponse(
+            status_code=response.status_code,
+            headers=response.headers,
+            stream=response.stream,
+            extensions=response.extensions,
+        )
+
+
+def _no_accept_encoding(request: httpx2.Request):
     request.headers.pop("accept-encoding", None)
 
 
-def _log_response(response: httpx.Response):
+async def _async_no_accept_encoding(request: httpx2.Request):
+    _no_accept_encoding(request)
+
+
+def _log_response(response: httpx2.Response):
     request = response.request
     click.echo(f"Request: {request.method} {request.url}", err=True)
     click.echo("  Headers:", err=True)
@@ -145,9 +170,33 @@ def _log_response(response: httpx.Response):
     click.echo("  Body:", err=True)
 
 
-def logging_client() -> httpx.Client:
-    return httpx.Client(
-        transport=_LogTransport(httpx.HTTPTransport()),
+async def _async_log_response(response: httpx2.Response):
+    _log_response(response)
+
+
+@overload
+def logging_client(*, async_: Literal[False] = False) -> httpx2.Client: ...
+
+
+@overload
+def logging_client(*, async_: Literal[True]) -> httpx2.AsyncClient: ...
+
+
+@overload
+def logging_client(*, async_: bool) -> httpx2.Client | httpx2.AsyncClient: ...
+
+
+def logging_client(*, async_=False):
+    if async_:
+        return httpx2.AsyncClient(
+            transport=_AsyncLogTransport(httpx2.AsyncHTTPTransport()),
+            event_hooks={
+                "request": [_async_no_accept_encoding],
+                "response": [_async_log_response],
+            },
+        )
+    return httpx2.Client(
+        transport=_LogTransport(httpx2.HTTPTransport()),
         event_hooks={"request": [_no_accept_encoding], "response": [_log_response]},
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ classifiers = [
 dependencies = [
     "click",
     "condense-json>=1.1",
-    "openai>=2.32.0",
+    "httpx2",
+    "openai>=3",
     "click-default-group>=1.2.3",
     "sqlite-utils>=4.0",
     "pydantic>=2.0.0",
@@ -47,6 +48,7 @@ dev = [
     "pytest",
     "numpy",
     "pytest-httpx>=0.33.0",
+    "pytest-httpx2>=1.0.0",
     "pytest-asyncio",
     "cogapp",
     "mypy>=1.10.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import importlib.metadata
 import json
 import sqlite3
 
+import httpx
 import llm_echo
 import pytest
 import sqlite_utils
@@ -12,10 +13,51 @@ import llm
 from llm.plugins import pm
 
 
+class OpenAIHTTPX2Mock:
+    """Small pytest-httpx-compatible facade over pytest-httpx2's router."""
+
+    def __init__(self, router):
+        self.router = router
+        self._responses = {}
+
+    def add_response(
+        self,
+        *,
+        method="GET",
+        url,
+        status_code=200,
+        is_reusable=False,
+        **kwargs,
+    ):
+        response = httpx.Response(status_code, **kwargs)
+        key = (method, url)
+        route = self.router.request(method, url)
+        responses = self._responses.setdefault(key, [])
+        responses.append(response)
+        if is_reusable:
+            route.mock(return_value=response)
+        else:
+            route.mock(side_effect=list(responses))
+
+    def get_requests(self):
+        return [call.request for call in self.router.calls]
+
+    def reuse_response(self, *, method, url):
+        response = self._responses[(method, url)][-1]
+        self.router.request(method, url).mock(return_value=response)
+
+    def reset(self):
+        self.router.reset()
+
+
 def pytest_configure(config):
     import sys
 
     sys._called_from_test = True
+    config.addinivalue_line(
+        "markers",
+        "httpx2(*, assert_all_called=False): configure the HTTPX2 mock router",
+    )
 
 
 def pytest_report_header(config):
@@ -27,6 +69,11 @@ def pytest_report_header(config):
         f"SQLite: {version}",
         f"sqlite-utils: {sqlite_utils_version}",
     ]
+
+
+@pytest.fixture
+def openai_httpx2_mock(httpx2_mock):
+    return OpenAIHTTPX2Mock(httpx2_mock)
 
 
 @pytest.fixture
@@ -248,8 +295,8 @@ def register_echo_model():
 
 
 @pytest.fixture
-def mocked_openai_chat(httpx_mock):
-    httpx_mock.add_response(
+def mocked_openai_chat(openai_httpx2_mock):
+    openai_httpx2_mock.add_response(
         method="POST",
         url="https://api.openai.com/v1/chat/completions",
         json={
@@ -259,18 +306,18 @@ def mocked_openai_chat(httpx_mock):
         },
         headers={"Content-Type": "application/json"},
     )
-    return httpx_mock
+    return openai_httpx2_mock
 
 
 @pytest.fixture
-def mock_openai_responses(httpx_mock):
+def mock_openai_responses(openai_httpx2_mock):
     def add_response(
         text="Bob, Alice, Eve",
         model="gpt-5.6-luna",
         response_id="resp_test",
         message_id="msg_test",
     ):
-        httpx_mock.add_response(
+        openai_httpx2_mock.add_response(
             method="POST",
             url="https://api.openai.com/v1/responses",
             json={
@@ -307,14 +354,14 @@ def mock_openai_responses(httpx_mock):
 
 
 @pytest.fixture
-def mocked_openai_responses(httpx_mock, mock_openai_responses):
+def mocked_openai_responses(openai_httpx2_mock, mock_openai_responses):
     mock_openai_responses()
-    return httpx_mock
+    return openai_httpx2_mock
 
 
 @pytest.fixture
-def mocked_openai_chat_returning_fenced_code(httpx_mock):
-    httpx_mock.add_response(
+def mocked_openai_chat_returning_fenced_code(openai_httpx2_mock):
+    openai_httpx2_mock.add_response(
         method="POST",
         url="https://api.openai.com/v1/chat/completions",
         json={
@@ -330,7 +377,7 @@ def mocked_openai_chat_returning_fenced_code(httpx_mock):
         },
         headers={"Content-Type": "application/json"},
     )
-    return httpx_mock
+    return openai_httpx2_mock
 
 
 def stream_events():
@@ -357,8 +404,8 @@ def stream_events():
 
 
 @pytest.fixture
-def mocked_openai_chat_stream(httpx_mock):
-    httpx_mock.add_response(
+def mocked_openai_chat_stream(openai_httpx2_mock):
+    openai_httpx2_mock.add_response(
         method="POST",
         url="https://api.openai.com/v1/chat/completions",
         stream=IteratorStream(stream_events()),
@@ -367,8 +414,8 @@ def mocked_openai_chat_stream(httpx_mock):
 
 
 @pytest.fixture
-def mocked_openai_completion(httpx_mock):
-    httpx_mock.add_response(
+def mocked_openai_completion(openai_httpx2_mock):
+    openai_httpx2_mock.add_response(
         method="POST",
         url="https://api.openai.com/v1/completions",
         json={
@@ -389,7 +436,7 @@ def mocked_openai_completion(httpx_mock):
         headers={"Content-Type": "application/json"},
         is_reusable=True,
     )
-    return httpx_mock
+    return openai_httpx2_mock
 
 
 def stream_completion_events():
@@ -464,19 +511,19 @@ def stream_completion_events():
 
 
 @pytest.fixture
-def mocked_openai_completion_logprobs_stream(httpx_mock):
-    httpx_mock.add_response(
+def mocked_openai_completion_logprobs_stream(openai_httpx2_mock):
+    openai_httpx2_mock.add_response(
         method="POST",
         url="https://api.openai.com/v1/completions",
         stream=IteratorStream(stream_completion_events()),
         headers={"Content-Type": "text/event-stream"},
     )
-    return httpx_mock
+    return openai_httpx2_mock
 
 
 @pytest.fixture
-def mocked_openai_completion_logprobs(httpx_mock):
-    httpx_mock.add_response(
+def mocked_openai_completion_logprobs(openai_httpx2_mock):
+    openai_httpx2_mock.add_response(
         method="POST",
         url="https://api.openai.com/v1/completions",
         json={
@@ -505,12 +552,12 @@ def mocked_openai_completion_logprobs(httpx_mock):
         },
         headers={"Content-Type": "application/json"},
     )
-    return httpx_mock
+    return openai_httpx2_mock
 
 
 @pytest.fixture
-def mocked_localai(httpx_mock):
-    httpx_mock.add_response(
+def mocked_localai(openai_httpx2_mock):
+    openai_httpx2_mock.add_response(
         method="POST",
         url="http://localai.localhost/chat/completions",
         json={
@@ -520,7 +567,7 @@ def mocked_localai(httpx_mock):
         },
         headers={"Content-Type": "application/json"},
     )
-    httpx_mock.add_response(
+    openai_httpx2_mock.add_response(
         method="POST",
         url="http://localai.localhost/completions",
         json={
@@ -530,7 +577,7 @@ def mocked_localai(httpx_mock):
         },
         headers={"Content-Type": "application/json"},
     )
-    return httpx_mock
+    return openai_httpx2_mock
 
 
 @pytest.fixture

--- a/tests/test_cli_openai_models.py
+++ b/tests/test_cli_openai_models.py
@@ -112,8 +112,8 @@ def test_deprecated_models_are_not_registered(model_id):
         llm.get_async_model(model_id)
 
 
-def test_gpt5_verbosity_option_is_sent_to_openai_chat_completions(httpx_mock):
-    httpx_mock.add_response(
+def test_gpt5_verbosity_option_is_sent_to_openai_chat_completions(openai_httpx2_mock):
+    openai_httpx2_mock.add_response(
         method="POST",
         url="https://api.openai.com/v1/chat/completions",
         json={
@@ -143,13 +143,15 @@ def test_gpt5_verbosity_option_is_sent_to_openai_chat_completions(httpx_mock):
         catch_exceptions=False,
     )
     assert result.exit_code == 0
-    request_body = json.loads(httpx_mock.get_requests()[-1].content)
+    request_body = json.loads(openai_httpx2_mock.get_requests()[-1].content)
     assert request_body["verbosity"] == "high"
     assert "text" not in request_body
 
 
-def test_gpt5_verbosity_option_is_sent_to_openai_responses_by_default(httpx_mock):
-    httpx_mock.add_response(
+def test_gpt5_verbosity_option_is_sent_to_openai_responses_by_default(
+    openai_httpx2_mock,
+):
+    openai_httpx2_mock.add_response(
         method="POST",
         url="https://api.openai.com/v1/responses",
         json={
@@ -198,7 +200,7 @@ def test_gpt5_verbosity_option_is_sent_to_openai_responses_by_default(httpx_mock
         catch_exceptions=False,
     )
     assert result.exit_code == 0
-    request_body = json.loads(httpx_mock.get_requests()[-1].content)
+    request_body = json.loads(openai_httpx2_mock.get_requests()[-1].content)
     assert request_body["text"]["verbosity"] == "high"
     assert request_body["include"] == ["reasoning.encrypted_content"]
     assert "verbosity" not in request_body
@@ -214,8 +216,8 @@ def test_gpt5_verbosity_option_validates_allowed_values():
     assert "Input should be 'low', 'medium' or 'high'" in result.output
 
 
-def test_code_interpreter_cli_tool_is_resolved_from_model(httpx_mock):
-    httpx_mock.add_response(
+def test_code_interpreter_cli_tool_is_resolved_from_model(openai_httpx2_mock):
+    openai_httpx2_mock.add_response(
         method="POST",
         url="https://api.openai.com/v1/responses",
         json={
@@ -261,7 +263,7 @@ def test_code_interpreter_cli_tool_is_resolved_from_model(httpx_mock):
 
     assert result.exit_code == 0
     assert result.stdout == "Calculated\n"
-    request_body = json.loads(httpx_mock.get_requests()[-1].content)
+    request_body = json.loads(openai_httpx2_mock.get_requests()[-1].content)
     assert request_body["tools"] == [
         {
             "type": "code_interpreter",
@@ -271,7 +273,7 @@ def test_code_interpreter_cli_tool_is_resolved_from_model(httpx_mock):
     assert "code_interpreter_call.outputs" in request_body["include"]
 
 
-def test_code_interpreter_cli_tool_is_reused_on_continue(httpx_mock, user_path):
+def test_code_interpreter_cli_tool_is_reused_on_continue(openai_httpx2_mock, user_path):
     def response_payload(response_id, text):
         return {
             "id": response_id,
@@ -338,7 +340,7 @@ def test_code_interpreter_cli_tool_is_reused_on_continue(httpx_mock, user_path):
         first_payload,
         response_payload("resp_code_interpreter_second", "Continued"),
     ):
-        httpx_mock.add_response(
+        openai_httpx2_mock.add_response(
             method="POST",
             url="https://api.openai.com/v1/responses",
             json=payload,
@@ -370,7 +372,7 @@ def test_code_interpreter_cli_tool_is_reused_on_continue(httpx_mock, user_path):
     assert second.exit_code == 0
     assert second.output == "Continued\n"
     request_bodies = [
-        json.loads(request.content) for request in httpx_mock.get_requests()
+        json.loads(request.content) for request in openai_httpx2_mock.get_requests()
     ]
     expected_tool = {
         "type": "code_interpreter",
@@ -392,8 +394,8 @@ def test_code_interpreter_cli_tool_is_reused_on_continue(httpx_mock, user_path):
     assert {row["instance_id"] for row in db["turn_tools"].rows} == {instance["id"]}
 
 
-def test_web_search_cli_tool_is_resolved_from_model(httpx_mock):
-    httpx_mock.add_response(
+def test_web_search_cli_tool_is_resolved_from_model(openai_httpx2_mock):
+    openai_httpx2_mock.add_response(
         method="POST",
         url="https://api.openai.com/v1/responses",
         json={
@@ -439,7 +441,7 @@ def test_web_search_cli_tool_is_resolved_from_model(httpx_mock):
 
     assert result.exit_code == 0
     assert result.stdout == "Search complete\n"
-    request_body = json.loads(httpx_mock.get_requests()[-1].content)
+    request_body = json.loads(openai_httpx2_mock.get_requests()[-1].content)
     assert request_body["tools"] == [
         {
             "type": "web_search",
@@ -522,8 +524,8 @@ def test_openai_image_detail_option_description(model_id, expected_description):
     assert field.description == expected_description
 
 
-def test_openai_image_detail_option_is_sent_on_image_attachments(httpx_mock):
-    httpx_mock.add_response(
+def test_openai_image_detail_option_is_sent_on_image_attachments(openai_httpx2_mock):
+    openai_httpx2_mock.add_response(
         method="POST",
         url="https://api.openai.com/v1/chat/completions",
         json={
@@ -553,7 +555,7 @@ def test_openai_image_detail_option_is_sent_on_image_attachments(httpx_mock):
         catch_exceptions=False,
     )
     assert result.exit_code == 0
-    request_body = json.loads(httpx_mock.get_requests()[-1].content)
+    request_body = json.loads(openai_httpx2_mock.get_requests()[-1].content)
     image_part = request_body["messages"][0]["content"][1]
     assert image_part == {
         "type": "image_url",
@@ -565,8 +567,8 @@ def test_openai_image_detail_option_is_sent_on_image_attachments(httpx_mock):
     assert "image_detail" not in request_body
 
 
-def test_openai_image_detail_original_is_sent_for_gpt54(httpx_mock):
-    httpx_mock.add_response(
+def test_openai_image_detail_original_is_sent_for_gpt54(openai_httpx2_mock):
+    openai_httpx2_mock.add_response(
         method="POST",
         url="https://api.openai.com/v1/chat/completions",
         json={
@@ -599,15 +601,15 @@ def test_openai_image_detail_original_is_sent_for_gpt54(httpx_mock):
         catch_exceptions=False,
     )
     assert result.exit_code == 0
-    request_body = json.loads(httpx_mock.get_requests()[-1].content)
+    request_body = json.loads(openai_httpx2_mock.get_requests()[-1].content)
     image_part = request_body["messages"][0]["content"][1]
     assert image_part["image_url"]["detail"] == "original"
 
 
 def test_openai_image_detail_original_is_sent_for_gpt54_responses_by_default(
-    httpx_mock,
+    openai_httpx2_mock,
 ):
-    httpx_mock.add_response(
+    openai_httpx2_mock.add_response(
         method="POST",
         url="https://api.openai.com/v1/responses",
         json={
@@ -659,7 +661,7 @@ def test_openai_image_detail_original_is_sent_for_gpt54_responses_by_default(
         catch_exceptions=False,
     )
     assert result.exit_code == 0
-    request_body = json.loads(httpx_mock.get_requests()[-1].content)
+    request_body = json.loads(openai_httpx2_mock.get_requests()[-1].content)
     image_part = request_body["input"][0]["content"][1]
     assert image_part == {
         "type": "input_image",
@@ -681,12 +683,14 @@ def test_openai_image_detail_original_is_rejected_for_other_models():
 
 @pytest.mark.parametrize("async_", (False, True))
 @pytest.mark.parametrize("usage", (None, "-u", "--usage"))
-def test_gpt4o_mini_sync_and_async(monkeypatch, tmpdir, httpx_mock, async_, usage):
+def test_gpt4o_mini_sync_and_async(
+    monkeypatch, tmpdir, openai_httpx2_mock, async_, usage
+):
     user_path = tmpdir / "user_dir"
     log_db = user_path / "logs.db"
     monkeypatch.setenv("LLM_USER_PATH", str(user_path))
     assert not log_db.exists()
-    httpx_mock.add_response(
+    openai_httpx2_mock.add_response(
         method="POST",
         # chat completion request
         url="https://api.openai.com/v1/chat/completions",

--- a/tests/test_fragments_cli.py
+++ b/tests/test_fragments_cli.py
@@ -148,8 +148,8 @@ def test_fragment_absolute_path(user_path, tmp_path):
 
 
 @mock.patch.dict(os.environ, {"OPENAI_API_KEY": "X"})
-def test_fragment_url_user_agent(mocked_openai_chat, user_path):
-    mocked_openai_chat.add_response(
+def test_fragment_url_user_agent(mocked_openai_chat, httpx_mock, user_path):
+    httpx_mock.add_response(
         url="https://example.com/fragment.txt",
         text="Hello from URL",
     )
@@ -167,7 +167,7 @@ def test_fragment_url_user_agent(mocked_openai_chat, user_path):
     assert result.exit_code == 0
 
     # Verify the User-Agent header was sent for the fragment URL request
-    requests = mocked_openai_chat.get_requests()
+    requests = httpx_mock.get_requests()
     fragment_request = next(r for r in requests if "example.com" in str(r.url))
     llm_version = version("llm")
     expected_user_agent = f"llm/{llm_version} (https://llm.datasette.io/)"

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -66,10 +66,10 @@ def test_keys_list(monkeypatch, tmpdir, args):
     assert result2.output.strip() == "openai"
 
 
-@pytest.mark.httpx_mock(
-    assert_all_requests_were_expected=False, can_send_already_matched_responses=True
-)
 def test_uses_correct_key(mocked_openai_chat, monkeypatch, tmpdir):
+    mocked_openai_chat.reuse_response(
+        method="POST", url="https://api.openai.com/v1/chat/completions"
+    )
     user_dir = tmpdir / "user-dir"
     pathlib.Path(user_dir).mkdir()
     keys_path = user_dir / "keys.json"

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -141,7 +141,9 @@ def test_llm_default_prompt(
 
 @mock.patch.dict(os.environ, {"OPENAI_API_KEY": "X"})
 @pytest.mark.parametrize("async_", (False, True))
-def test_llm_prompt_continue(httpx_mock, mock_openai_responses, user_path, async_):
+def test_llm_prompt_continue(
+    openai_httpx2_mock, mock_openai_responses, user_path, async_
+):
     mock_openai_responses(
         text="Bob, Alice, Eve",
         response_id="resp_first",
@@ -859,7 +861,7 @@ def test_schemas_dsl():
 def test_llm_prompt_continue_with_database(
     tmpdir,
     monkeypatch,
-    httpx_mock,
+    openai_httpx2_mock,
     mock_openai_responses,
     user_path,
     custom_database_path,

--- a/tests/test_openai_endpoint.py
+++ b/tests/test_openai_endpoint.py
@@ -10,8 +10,8 @@ from llm.cli import cli
 from llm.migrations import migrate
 
 
-def _add_chat_response(httpx_mock, url, text):
-    httpx_mock.add_response(
+def _add_chat_response(openai_httpx2_mock, url, text):
+    openai_httpx2_mock.add_response(
         method="POST",
         url=f"{url}/chat/completions",
         json={
@@ -36,8 +36,8 @@ def _add_chat_response(httpx_mock, url, text):
     )
 
 
-def _add_chat_tool_call_response(httpx_mock, url, name, arguments):
-    httpx_mock.add_response(
+def _add_chat_tool_call_response(openai_httpx2_mock, url, name, arguments):
+    openai_httpx2_mock.add_response(
         method="POST",
         url=f"{url}/chat/completions",
         json={
@@ -158,10 +158,10 @@ def _chat_stream_events():
 
 
 def test_endpoint_chat_completions_does_not_log_or_leak_default_key(
-    httpx_mock, user_path, monkeypatch
+    openai_httpx2_mock, user_path, monkeypatch
 ):
     base_url = "https://example.test/v1"
-    _add_chat_response(httpx_mock, base_url, "Hello from the endpoint")
+    _add_chat_response(openai_httpx2_mock, base_url, "Hello from the endpoint")
     monkeypatch.setenv("OPENAI_API_KEY", "real-default-openai-key")
 
     result = CliRunner().invoke(
@@ -188,7 +188,7 @@ def test_endpoint_chat_completions_does_not_log_or_leak_default_key(
     assert result.output == "Hello from the endpoint\n"
     assert not (user_path / "logs.db").exists()
 
-    request = httpx_mock.get_requests()[0]
+    request = openai_httpx2_mock.get_requests()[0]
     assert request.headers["Authorization"] == "Bearer DUMMY_KEY"
     assert request.headers["X-Test"] == "one"
     assert json.loads(request.content) == {
@@ -199,9 +199,9 @@ def test_endpoint_chat_completions_does_not_log_or_leak_default_key(
     }
 
 
-def test_endpoint_chat_completions_attachment(httpx_mock, user_path, tmp_path):
+def test_endpoint_chat_completions_attachment(openai_httpx2_mock, user_path, tmp_path):
     base_url = "https://attachments.example.test/v1"
-    _add_chat_response(httpx_mock, base_url, "A test image")
+    _add_chat_response(openai_httpx2_mock, base_url, "A test image")
     image_bytes = b"\x89PNG\r\n\x1a\nendpoint attachment"
     image_path = tmp_path / "image.png"
     image_path.write_bytes(image_bytes)
@@ -225,7 +225,7 @@ def test_endpoint_chat_completions_attachment(httpx_mock, user_path, tmp_path):
     assert result.exit_code == 0
     assert result.output == "A test image\n"
     assert not (user_path / "logs.db").exists()
-    assert json.loads(httpx_mock.get_requests()[0].content)["messages"] == [
+    assert json.loads(openai_httpx2_mock.get_requests()[0].content)["messages"] == [
         {
             "role": "user",
             "content": [
@@ -243,9 +243,9 @@ def test_endpoint_chat_completions_attachment(httpx_mock, user_path, tmp_path):
     ]
 
 
-def test_endpoint_template(httpx_mock, user_path, templates_path):
+def test_endpoint_template(openai_httpx2_mock, user_path, templates_path):
     base_url = "https://templates.example.test/v1"
-    _add_chat_response(httpx_mock, base_url, "Template response")
+    _add_chat_response(openai_httpx2_mock, base_url, "Template response")
     (templates_path / "endpoint.yaml").write_text(
         """
 model: template-model
@@ -289,7 +289,7 @@ attachment_types:
     assert result.exit_code == 0
     assert result.output == "Template response\n"
     assert not (user_path / "logs.db").exists()
-    assert json.loads(httpx_mock.get_requests()[0].content) == {
+    assert json.loads(openai_httpx2_mock.get_requests()[0].content) == {
         "messages": [
             {"role": "system", "content": "You are concise"},
             {
@@ -320,10 +320,10 @@ attachment_types:
 
 
 def test_endpoint_template_schema_object_used_when_no_cli_schema(
-    httpx_mock, user_path, templates_path
+    openai_httpx2_mock, user_path, templates_path
 ):
     base_url = "https://templates2.example.test/v1"
-    _add_chat_response(httpx_mock, base_url, "Template response 2")
+    _add_chat_response(openai_httpx2_mock, base_url, "Template response 2")
     (templates_path / "schemaonly.yaml").write_text(
         """
 model: schema-model
@@ -353,7 +353,7 @@ schema_object:
     )
 
     assert result.exit_code == 0
-    request_body = json.loads(httpx_mock.get_requests()[0].content)
+    request_body = json.loads(openai_httpx2_mock.get_requests()[0].content)
     assert request_body["response_format"] == {
         "type": "json_schema",
         "json_schema": {
@@ -367,9 +367,9 @@ schema_object:
     }
 
 
-def test_endpoint_schema(httpx_mock, user_path):
+def test_endpoint_schema(openai_httpx2_mock, user_path):
     base_url = "https://schema.example.test/v1"
-    _add_chat_response(httpx_mock, base_url, '{"name": "Cleo", "age": 10}')
+    _add_chat_response(openai_httpx2_mock, base_url, '{"name": "Cleo", "age": 10}')
 
     result = CliRunner().invoke(
         cli,
@@ -389,7 +389,7 @@ def test_endpoint_schema(httpx_mock, user_path):
 
     assert result.exit_code == 0
     assert not (user_path / "logs.db").exists()
-    request_body = json.loads(httpx_mock.get_requests()[0].content)
+    request_body = json.loads(openai_httpx2_mock.get_requests()[0].content)
     assert request_body["response_format"] == {
         "type": "json_schema",
         "json_schema": {
@@ -406,9 +406,11 @@ def test_endpoint_schema(httpx_mock, user_path):
     }
 
 
-def test_endpoint_schema_by_id_from_existing_logs_database(httpx_mock, user_path):
+def test_endpoint_schema_by_id_from_existing_logs_database(
+    openai_httpx2_mock, user_path
+):
     base_url = "https://schema-id.example.test/v1"
-    _add_chat_response(httpx_mock, base_url, '{"name": "Cleo"}')
+    _add_chat_response(openai_httpx2_mock, base_url, '{"name": "Cleo"}')
     schema = {
         "type": "object",
         "properties": {"name": {"type": "string"}},
@@ -436,7 +438,7 @@ def test_endpoint_schema_by_id_from_existing_logs_database(httpx_mock, user_path
     )
 
     assert result.exit_code == 0
-    request_body = json.loads(httpx_mock.get_requests()[0].content)
+    request_body = json.loads(openai_httpx2_mock.get_requests()[0].content)
     assert request_body["response_format"]["json_schema"]["schema"] == schema
     assert db["responses"].count == 0
 
@@ -464,10 +466,10 @@ def test_endpoint_invalid_schema_id_does_not_create_logs_database(user_path):
 
 
 def test_endpoint_static_template_runs_once_on_terminal(
-    httpx_mock, user_path, templates_path, monkeypatch
+    openai_httpx2_mock, user_path, templates_path, monkeypatch
 ):
     base_url = "https://terminal-template.example.test/v1"
-    _add_chat_response(httpx_mock, base_url, "Five pelicans")
+    _add_chat_response(openai_httpx2_mock, base_url, "Five pelicans")
     (templates_path / "pelican.yaml").write_text(
         "prompt: List five pelican names\n", "utf-8"
     )
@@ -491,15 +493,17 @@ def test_endpoint_static_template_runs_once_on_terminal(
     assert result.exit_code == 0
     assert result.output == "Five pelicans\n"
     assert not (user_path / "logs.db").exists()
-    assert json.loads(httpx_mock.get_requests()[0].content)["messages"] == [
+    assert json.loads(openai_httpx2_mock.get_requests()[0].content)["messages"] == [
         {"role": "user", "content": "List five pelican names"}
     ]
 
 
-def test_endpoint_tools_and_functions(httpx_mock, user_path):
+def test_endpoint_tools_and_functions(openai_httpx2_mock, user_path):
     base_url = "https://tools.example.test/v1"
-    _add_chat_tool_call_response(httpx_mock, base_url, "multiply", {"a": 6, "b": 7})
-    _add_chat_response(httpx_mock, base_url, "The answer is 42")
+    _add_chat_tool_call_response(
+        openai_httpx2_mock, base_url, "multiply", {"a": 6, "b": 7}
+    )
+    _add_chat_response(openai_httpx2_mock, base_url, "The answer is 42")
 
     result = CliRunner().invoke(
         cli,
@@ -527,7 +531,9 @@ def test_endpoint_tools_and_functions(httpx_mock, user_path):
     assert result.output == "The answer is 42\n"
     assert not (user_path / "logs.db").exists()
 
-    requests = [json.loads(request.content) for request in httpx_mock.get_requests()]
+    requests = [
+        json.loads(request.content) for request in openai_httpx2_mock.get_requests()
+    ]
     assert len(requests) == 2
     assert {tool["function"]["name"] for tool in requests[0]["tools"]} == {
         "llm_version",
@@ -557,9 +563,9 @@ def test_endpoint_tools_and_functions(httpx_mock, user_path):
     ]
 
 
-def test_endpoint_streams_by_default(httpx_mock, user_path):
+def test_endpoint_streams_by_default(openai_httpx2_mock, user_path):
     base_url = "https://stream.example.test/v1"
-    httpx_mock.add_response(
+    openai_httpx2_mock.add_response(
         method="POST",
         url=f"{base_url}/chat/completions",
         stream=IteratorStream(_chat_stream_events()),
@@ -582,14 +588,14 @@ def test_endpoint_streams_by_default(httpx_mock, user_path):
     assert result.exit_code == 0
     assert result.output == "Hello streamed\n"
     assert not (user_path / "logs.db").exists()
-    request_body = json.loads(httpx_mock.get_requests()[0].content)
+    request_body = json.loads(openai_httpx2_mock.get_requests()[0].content)
     assert request_body["stream"] is True
     assert request_body["stream_options"] == {"include_usage": True}
 
 
-def test_endpoint_uses_explicit_key(httpx_mock, user_path):
+def test_endpoint_uses_explicit_key(openai_httpx2_mock, user_path):
     base_url = "https://example.test/v1"
-    _add_chat_response(httpx_mock, base_url, "Authenticated")
+    _add_chat_response(openai_httpx2_mock, base_url, "Authenticated")
 
     result = CliRunner().invoke(
         cli,
@@ -608,18 +614,18 @@ def test_endpoint_uses_explicit_key(httpx_mock, user_path):
     )
 
     assert result.exit_code == 0
-    assert httpx_mock.get_requests()[0].headers["Authorization"] == (
+    assert openai_httpx2_mock.get_requests()[0].headers["Authorization"] == (
         "Bearer endpoint-key"
     )
     assert not (user_path / "logs.db").exists()
 
 
 def test_endpoint_lists_models_without_model_or_logging(
-    httpx_mock, user_path, monkeypatch
+    openai_httpx2_mock, user_path, monkeypatch
 ):
     base_url = "https://models.example.test/v1"
     monkeypatch.setenv("OPENAI_API_KEY", "real-default-openai-key")
-    httpx_mock.add_response(
+    openai_httpx2_mock.add_response(
         method="GET",
         url=f"{base_url}/models",
         json={
@@ -659,14 +665,16 @@ def test_endpoint_lists_models_without_model_or_logging(
     assert result.exit_code == 0
     assert result.output == "first-model\nsecond-model\n"
     assert not (user_path / "logs.db").exists()
-    request = httpx_mock.get_requests()[0]
+    request = openai_httpx2_mock.get_requests()[0]
     assert request.headers["Authorization"] == "Bearer DUMMY_KEY"
     assert request.headers["X-Test"] == "one"
 
 
-def test_endpoint_models_surfaces_error_from_successful_response(httpx_mock, user_path):
+def test_endpoint_models_surfaces_error_from_successful_response(
+    openai_httpx2_mock, user_path
+):
     base_url = "https://models-error.example.test"
-    httpx_mock.add_response(
+    openai_httpx2_mock.add_response(
         method="GET",
         url=f"{base_url}/models",
         json={"error": "Unexpected endpoint or method. (GET /models)"},
@@ -684,9 +692,9 @@ def test_endpoint_models_surfaces_error_from_successful_response(httpx_mock, use
     assert not (user_path / "logs.db").exists()
 
 
-def test_endpoint_responses_api(httpx_mock, user_path):
+def test_endpoint_responses_api(openai_httpx2_mock, user_path):
     base_url = "https://responses.example.test/v1"
-    httpx_mock.add_response(
+    openai_httpx2_mock.add_response(
         method="POST",
         url=f"{base_url}/responses",
         json=_responses_payload("Hello from Responses"),
@@ -717,7 +725,7 @@ def test_endpoint_responses_api(httpx_mock, user_path):
     assert result.exit_code == 0
     assert result.output == "Hello from Responses\n"
     assert not (user_path / "logs.db").exists()
-    assert json.loads(httpx_mock.get_requests()[0].content) == {
+    assert json.loads(openai_httpx2_mock.get_requests()[0].content) == {
         "input": [{"role": "user", "content": "Hello"}],
         "include": ["reasoning.encrypted_content"],
         "model": "test-model",
@@ -730,10 +738,10 @@ def test_endpoint_responses_api(httpx_mock, user_path):
 
 @pytest.mark.parametrize("reasoning_summary", ("auto", "concise", "detailed"))
 def test_endpoint_responses_reasoning_summary_option(
-    httpx_mock, user_path, reasoning_summary
+    openai_httpx2_mock, user_path, reasoning_summary
 ):
     base_url = "https://responses-summary.example.test/v1"
-    httpx_mock.add_response(
+    openai_httpx2_mock.add_response(
         method="POST",
         url=f"{base_url}/responses",
         json=_responses_payload("Hello from Responses"),
@@ -761,7 +769,7 @@ def test_endpoint_responses_reasoning_summary_option(
     assert result.exit_code == 0
     assert result.output == "Hello from Responses\n"
     assert not (user_path / "logs.db").exists()
-    assert json.loads(httpx_mock.get_requests()[0].content) == {
+    assert json.loads(openai_httpx2_mock.get_requests()[0].content) == {
         "input": [{"role": "user", "content": "Hello"}],
         "include": ["reasoning.encrypted_content"],
         "model": "test-model",
@@ -772,7 +780,7 @@ def test_endpoint_responses_reasoning_summary_option(
 
 
 def test_endpoint_responses_reasoning_summary_option_rejects_invalid_value(
-    httpx_mock, user_path
+    openai_httpx2_mock, user_path
 ):
     result = CliRunner().invoke(
         cli,
@@ -797,13 +805,13 @@ def test_endpoint_responses_reasoning_summary_option_rejects_invalid_value(
         "Error: reasoning_summary\n"
         "  Input should be 'auto', 'concise' or 'detailed'\n"
     )
-    assert not httpx_mock.get_requests()
+    assert not openai_httpx2_mock.get_requests()
     assert not (user_path / "logs.db").exists()
 
 
-def test_endpoint_responses_api_attachment(httpx_mock, user_path):
+def test_endpoint_responses_api_attachment(openai_httpx2_mock, user_path):
     base_url = "https://responses-attachments.example.test/v1"
-    httpx_mock.add_response(
+    openai_httpx2_mock.add_response(
         method="POST",
         url=f"{base_url}/responses",
         json=_responses_payload("A remote image"),
@@ -834,7 +842,7 @@ def test_endpoint_responses_api_attachment(httpx_mock, user_path):
     assert result.exit_code == 0
     assert result.output == "A remote image\n"
     assert not (user_path / "logs.db").exists()
-    request_body = json.loads(httpx_mock.get_requests()[0].content)
+    request_body = json.loads(openai_httpx2_mock.get_requests()[0].content)
     assert "include" not in request_body
     assert "reasoning" not in request_body
     assert request_body["input"] == [
@@ -852,9 +860,9 @@ def test_endpoint_responses_api_attachment(httpx_mock, user_path):
     ]
 
 
-def test_endpoint_responses_api_schema_multi(httpx_mock, user_path):
+def test_endpoint_responses_api_schema_multi(openai_httpx2_mock, user_path):
     base_url = "https://responses-schema.example.test/v1"
-    httpx_mock.add_response(
+    openai_httpx2_mock.add_response(
         method="POST",
         url=f"{base_url}/responses",
         json=_responses_payload('{"items": [{"name": "Cleo", "age": 10}]}'),
@@ -880,7 +888,7 @@ def test_endpoint_responses_api_schema_multi(httpx_mock, user_path):
 
     assert result.exit_code == 0
     assert not (user_path / "logs.db").exists()
-    request_body = json.loads(httpx_mock.get_requests()[0].content)
+    request_body = json.loads(openai_httpx2_mock.get_requests()[0].content)
     assert request_body["text"]["format"] == {
         "type": "json_schema",
         "name": "output",
@@ -905,15 +913,15 @@ def test_endpoint_responses_api_schema_multi(httpx_mock, user_path):
     }
 
 
-def test_endpoint_responses_api_tools(httpx_mock, user_path):
+def test_endpoint_responses_api_tools(openai_httpx2_mock, user_path):
     base_url = "https://responses-tools.example.test/v1"
-    httpx_mock.add_response(
+    openai_httpx2_mock.add_response(
         method="POST",
         url=f"{base_url}/responses",
         json=_responses_tool_call_payload("multiply", {"a": 6, "b": 7}),
         headers={"Content-Type": "application/json"},
     )
-    httpx_mock.add_response(
+    openai_httpx2_mock.add_response(
         method="POST",
         url=f"{base_url}/responses",
         json=_responses_payload("The answer is 42"),
@@ -945,7 +953,9 @@ def test_endpoint_responses_api_tools(httpx_mock, user_path):
     assert result.output == "The answer is 42\n"
     assert not (user_path / "logs.db").exists()
 
-    requests = [json.loads(request.content) for request in httpx_mock.get_requests()]
+    requests = [
+        json.loads(request.content) for request in openai_httpx2_mock.get_requests()
+    ]
     assert requests[0]["tools"][0]["name"] == "multiply"
     assert requests[1]["input"] == [
         {"role": "user", "content": "What is 6 * 7?"},
@@ -963,7 +973,7 @@ def test_endpoint_responses_api_tools(httpx_mock, user_path):
     ]
 
 
-def test_endpoint_responses_api_raw_server_side_tool(httpx_mock, user_path):
+def test_endpoint_responses_api_raw_server_side_tool(openai_httpx2_mock, user_path):
     base_url = "https://raw-tools.example.test/v1"
     response_payload = _responses_payload("Search complete")
     response_payload["output"].insert(
@@ -979,7 +989,7 @@ def test_endpoint_responses_api_raw_server_side_tool(httpx_mock, user_path):
             },
         },
     )
-    httpx_mock.add_response(
+    openai_httpx2_mock.add_response(
         method="POST",
         url=f"{base_url}/responses",
         json=response_payload,
@@ -1010,13 +1020,13 @@ def test_endpoint_responses_api_raw_server_side_tool(httpx_mock, user_path):
     assert result.exit_code == 0
     assert result.output == "Search complete\n"
     assert not (user_path / "logs.db").exists()
-    request_body = json.loads(httpx_mock.get_requests()[0].content)
+    request_body = json.loads(openai_httpx2_mock.get_requests()[0].content)
     assert request_body["tools"] == [tool_spec]
 
 
-def test_endpoint_reads_one_off_prompt_from_stdin(httpx_mock, user_path):
+def test_endpoint_reads_one_off_prompt_from_stdin(openai_httpx2_mock, user_path):
     base_url = "https://stdin.example.test/v1"
-    _add_chat_response(httpx_mock, base_url, "From stdin")
+    _add_chat_response(openai_httpx2_mock, base_url, "From stdin")
 
     result = CliRunner().invoke(
         cli,
@@ -1033,14 +1043,16 @@ def test_endpoint_reads_one_off_prompt_from_stdin(httpx_mock, user_path):
     )
 
     assert result.exit_code == 0
-    request_body = json.loads(httpx_mock.get_requests()[0].content)
+    request_body = json.loads(openai_httpx2_mock.get_requests()[0].content)
     assert request_body["messages"] == [{"role": "user", "content": "Hello from stdin"}]
     assert not (user_path / "logs.db").exists()
 
 
-def test_endpoint_without_prompt_waits_for_stdin(httpx_mock, user_path, monkeypatch):
+def test_endpoint_without_prompt_waits_for_stdin(
+    openai_httpx2_mock, user_path, monkeypatch
+):
     base_url = "https://terminal-stdin.example.test/v1"
-    _add_chat_response(httpx_mock, base_url, "From awaited stdin")
+    _add_chat_response(openai_httpx2_mock, base_url, "From awaited stdin")
     monkeypatch.setattr("click.testing._NamedTextIOWrapper.isatty", lambda self: True)
 
     result = CliRunner().invoke(
@@ -1059,7 +1071,7 @@ def test_endpoint_without_prompt_waits_for_stdin(httpx_mock, user_path, monkeypa
 
     assert result.exit_code == 0
     assert result.output == "From awaited stdin\n"
-    request_body = json.loads(httpx_mock.get_requests()[0].content)
+    request_body = json.loads(openai_httpx2_mock.get_requests()[0].content)
     assert request_body["messages"] == [
         {"role": "user", "content": "Hello after waiting for stdin"}
     ]
@@ -1067,11 +1079,11 @@ def test_endpoint_without_prompt_waits_for_stdin(httpx_mock, user_path, monkeypa
 
 
 def test_endpoint_interactive_chat_preserves_history(
-    httpx_mock, user_path, templates_path
+    openai_httpx2_mock, user_path, templates_path
 ):
     base_url = "https://chat.example.test/v1"
-    _add_chat_response(httpx_mock, base_url, "First answer")
-    _add_chat_response(httpx_mock, base_url, "Second answer")
+    _add_chat_response(openai_httpx2_mock, base_url, "First answer")
+    _add_chat_response(openai_httpx2_mock, base_url, "Second answer")
     (templates_path / "endpoint-chat.yaml").write_text(
         'prompt: "Question: $input"\n', "utf-8"
     )
@@ -1109,7 +1121,7 @@ def test_endpoint_interactive_chat_preserves_history(
     assert "Second answer" in result.output
     assert not (user_path / "logs.db").exists()
 
-    requests = httpx_mock.get_requests()
+    requests = openai_httpx2_mock.get_requests()
     assert len(requests) == 2
     request_bodies = [json.loads(request.content) for request in requests]
     assert all(

--- a/tests/test_openai_messages.py
+++ b/tests/test_openai_messages.py
@@ -323,10 +323,10 @@ class TestBuildMessagesConversationHistory:
         ]
 
     def test_no_double_emission_from_conversation_prompt_flow(
-        self, chat_model, httpx_mock
+        self, chat_model, openai_httpx2_mock
     ):
         # Two staged responses so conv.prompt twice can complete.
-        httpx_mock.add_response(
+        openai_httpx2_mock.add_response(
             method="POST",
             url="https://api.openai.com/v1/chat/completions",
             json={
@@ -345,7 +345,7 @@ class TestBuildMessagesConversationHistory:
             },
             headers={"Content-Type": "application/json"},
         )
-        httpx_mock.add_response(
+        openai_httpx2_mock.add_response(
             method="POST",
             url="https://api.openai.com/v1/chat/completions",
             json={
@@ -373,7 +373,7 @@ class TestBuildMessagesConversationHistory:
         r2.text()
 
         # Inspect what was sent on the SECOND turn.
-        sent_body = json.loads(httpx_mock.get_requests()[-1].content)
+        sent_body = json.loads(openai_httpx2_mock.get_requests()[-1].content)
         sent_messages = sent_body["messages"]
         # Exactly three: user(Q1), assistant(A1), user(Q2).
         assert sent_messages == [
@@ -384,8 +384,8 @@ class TestBuildMessagesConversationHistory:
 
 
 class TestStreamingExecuteYieldsStreamEvents:
-    def test_text_stream_yields_text_events(self, httpx_mock):
-        httpx_mock.add_response(
+    def test_text_stream_yields_text_events(self, openai_httpx2_mock):
+        openai_httpx2_mock.add_response(
             method="POST",
             url="https://api.openai.com/v1/chat/completions",
             stream=IteratorStream(_text_stream()),
@@ -402,8 +402,10 @@ class TestStreamingExecuteYieldsStreamEvents:
         # Text chunks concatenate to the expected full text.
         assert "".join(e.chunk for e in events) == "Hello"
 
-    def test_text_stream_plain_iteration_still_returns_strings(self, httpx_mock):
-        httpx_mock.add_response(
+    def test_text_stream_plain_iteration_still_returns_strings(
+        self, openai_httpx2_mock
+    ):
+        openai_httpx2_mock.add_response(
             method="POST",
             url="https://api.openai.com/v1/chat/completions",
             stream=IteratorStream(_text_stream()),
@@ -415,8 +417,8 @@ class TestStreamingExecuteYieldsStreamEvents:
         assert all(isinstance(c, str) for c in chunks)
         assert "".join(chunks) == "Hello"
 
-    def test_text_stream_messages_assembled(self, httpx_mock):
-        httpx_mock.add_response(
+    def test_text_stream_messages_assembled(self, openai_httpx2_mock):
+        openai_httpx2_mock.add_response(
             method="POST",
             url="https://api.openai.com/v1/chat/completions",
             stream=IteratorStream(_text_stream()),
@@ -429,8 +431,8 @@ class TestStreamingExecuteYieldsStreamEvents:
             llm.Message(role="assistant", parts=[llm.parts.TextPart(text="Hello")])
         ]
 
-    def test_tool_call_stream_yields_name_and_args_events(self, httpx_mock):
-        httpx_mock.add_response(
+    def test_tool_call_stream_yields_name_and_args_events(self, openai_httpx2_mock):
+        openai_httpx2_mock.add_response(
             method="POST",
             url="https://api.openai.com/v1/chat/completions",
             stream=IteratorStream(_tool_call_stream()),
@@ -457,9 +459,9 @@ class TestStreamingExecuteYieldsStreamEvents:
         assert all(e.part_index == name_ev.part_index for e in args_events)
         assert json.loads("".join(e.chunk for e in args_events)) == {"city": "Paris"}
 
-    def test_tool_call_registered_via_add_tool_call(self, httpx_mock):
+    def test_tool_call_registered_via_add_tool_call(self, openai_httpx2_mock):
         """response.tool_calls() still works — chain/execute relies on it."""
-        httpx_mock.add_response(
+        openai_httpx2_mock.add_response(
             method="POST",
             url="https://api.openai.com/v1/chat/completions",
             stream=IteratorStream(_tool_call_stream()),
@@ -479,8 +481,8 @@ class TestStreamingExecuteYieldsStreamEvents:
         assert tcs[0].arguments == {"city": "Paris"}
         assert tcs[0].tool_call_id == "call_1"
 
-    def test_text_then_tool_call_part_index_advances(self, httpx_mock):
-        httpx_mock.add_response(
+    def test_text_then_tool_call_part_index_advances(self, openai_httpx2_mock):
+        openai_httpx2_mock.add_response(
             method="POST",
             url="https://api.openai.com/v1/chat/completions",
             stream=IteratorStream(_text_then_tool_call_stream()),
@@ -507,8 +509,8 @@ class TestStreamingExecuteYieldsStreamEvents:
 
 class TestAsyncStreamingExecuteYieldsStreamEvents:
     @pytest.mark.asyncio
-    async def test_text_stream_yields_text_events(self, httpx_mock):
-        httpx_mock.add_response(
+    async def test_text_stream_yields_text_events(self, openai_httpx2_mock):
+        openai_httpx2_mock.add_response(
             method="POST",
             url="https://api.openai.com/v1/chat/completions",
             stream=IteratorStream(_text_stream()),
@@ -545,8 +547,10 @@ def _text_stream_with_reasoning_usage(reasoning_tokens):
 
 
 class TestReasoningTokenCount:
-    def test_redacted_reasoning_part_emitted_when_count_present(self, httpx_mock):
-        httpx_mock.add_response(
+    def test_redacted_reasoning_part_emitted_when_count_present(
+        self, openai_httpx2_mock
+    ):
+        openai_httpx2_mock.add_response(
             method="POST",
             url="https://api.openai.com/v1/chat/completions",
             stream=IteratorStream(_text_stream_with_reasoning_usage(150)),
@@ -565,8 +569,8 @@ class TestReasoningTokenCount:
             )
         ]
 
-    def test_no_reasoning_part_when_zero_or_absent(self, httpx_mock):
-        httpx_mock.add_response(
+    def test_no_reasoning_part_when_zero_or_absent(self, openai_httpx2_mock):
+        openai_httpx2_mock.add_response(
             method="POST",
             url="https://api.openai.com/v1/chat/completions",
             stream=IteratorStream(_text_stream_with_reasoning_usage(0)),
@@ -582,8 +586,8 @@ class TestReasoningTokenCount:
 
 
 class TestNonStreamingExecuteYieldsStreamEvents:
-    def test_non_streaming_text_yields_single_event(self, httpx_mock):
-        httpx_mock.add_response(
+    def test_non_streaming_text_yields_single_event(self, openai_httpx2_mock):
+        openai_httpx2_mock.add_response(
             method="POST",
             url="https://api.openai.com/v1/chat/completions",
             json={

--- a/tests/test_openai_responses.py
+++ b/tests/test_openai_responses.py
@@ -32,6 +32,71 @@ def _text_response_json(model="gpt-5.6-luna", text="ok"):
     }
 
 
+def test_openai_requests_do_not_escape_http_mock(openai_httpx2_mock, monkeypatch):
+    openai_httpx2_mock.add_response(
+        method="POST",
+        url="https://api.openai.com/v1/responses",
+        json=_text_response_json(text="intercepted"),
+        headers={"Content-Type": "application/json"},
+    )
+
+    for name in (
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "ALL_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "all_proxy",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    def fail_if_network_is_reached(*args, **kwargs):
+        raise AssertionError("OpenAI request escaped the test HTTP mock")
+
+    monkeypatch.setattr(
+        "httpcore2._backends.sync.SyncBackend.connect_tcp",
+        fail_if_network_is_reached,
+    )
+
+    response = llm.get_model("gpt-5.6-luna").prompt(
+        "Say intercepted", stream=False, key="test"
+    )
+
+    assert response.text() == "intercepted"
+
+
+@pytest.mark.parametrize("async_", (False, True))
+@pytest.mark.asyncio
+async def test_openai_response_logging_uses_httpx2_client(
+    openai_httpx2_mock, monkeypatch, capsys, async_
+):
+    openai_httpx2_mock.add_response(
+        method="POST",
+        url="https://api.openai.com/v1/responses",
+        json=_text_response_json(text="logged"),
+        headers={"Content-Type": "application/json"},
+    )
+    monkeypatch.setenv("LLM_OPENAI_SHOW_RESPONSES", "1")
+
+    if async_:
+        response = llm.get_async_model("gpt-5.6-luna").prompt(
+            "Say logged", stream=False, key="test-secret"
+        )
+        assert await response.text() == "logged"
+    else:
+        response = llm.get_model("gpt-5.6-luna").prompt(
+            "Say logged", stream=False, key="test-secret"
+        )
+        assert response.text() == "logged"
+
+    captured = capsys.readouterr()
+    assert "Request: POST https://api.openai.com/v1/responses" in captured.err
+    assert "authorization: [...]" in captured.err
+    assert "test-secret" not in captured.err
+    assert "Response: status_code=200" in captured.err
+    assert '"text":"logged"' in captured.err
+
+
 @pytest.mark.parametrize(
     ("tool", "expected"),
     (
@@ -163,7 +228,7 @@ def test_web_search_prepare_request_is_additive_and_idempotent():
     assert default_kwargs == {}
 
 
-def test_responses_web_search_request_and_result_capture(httpx_mock):
+def test_responses_web_search_request_and_result_capture(openai_httpx2_mock):
     sources = [
         {"type": "url", "url": "https://openai.com/news/"},
         {"type": "url", "url": "https://example.com/report"},
@@ -193,7 +258,7 @@ def test_responses_web_search_request_and_result_capture(httpx_mock):
             "results": results,
         },
     )
-    httpx_mock.add_response(
+    openai_httpx2_mock.add_response(
         method="POST",
         url="https://api.openai.com/v1/responses",
         json=response_json,
@@ -214,7 +279,7 @@ def test_responses_web_search_request_and_result_capture(httpx_mock):
     )
 
     assert response.text() == "A cited answer"
-    request_body = json.loads(httpx_mock.get_requests()[-1].content)
+    request_body = json.loads(openai_httpx2_mock.get_requests()[-1].content)
     assert request_body["tools"] == [
         {
             "type": "web_search",
@@ -274,8 +339,8 @@ def test_server_side_prepare_request_runs_in_list_order_after_baseline():
     ]
 
 
-def test_responses_mixes_function_and_code_interpreter_tools(httpx_mock):
-    httpx_mock.add_response(
+def test_responses_mixes_function_and_code_interpreter_tools(openai_httpx2_mock):
+    openai_httpx2_mock.add_response(
         method="POST",
         url="https://api.openai.com/v1/responses",
         json=_text_response_json(),
@@ -294,7 +359,7 @@ def test_responses_mixes_function_and_code_interpreter_tools(httpx_mock):
     )
     assert response.text() == "ok"
 
-    request_body = json.loads(httpx_mock.get_requests()[-1].content)
+    request_body = json.loads(openai_httpx2_mock.get_requests()[-1].content)
     assert request_body["tools"][0]["type"] == "function"
     assert request_body["tools"][0]["name"] == "multiply"
     assert request_body["tools"][1] == {
@@ -307,8 +372,8 @@ def test_responses_mixes_function_and_code_interpreter_tools(httpx_mock):
     ]
 
 
-def test_responses_raw_server_tool_passthrough_on_custom_endpoint(httpx_mock):
-    httpx_mock.add_response(
+def test_responses_raw_server_tool_passthrough_on_custom_endpoint(openai_httpx2_mock):
+    openai_httpx2_mock.add_response(
         method="POST",
         url="https://example.test/v1/responses",
         json=_text_response_json(model="custom-model"),
@@ -325,7 +390,7 @@ def test_responses_raw_server_tool_passthrough_on_custom_endpoint(httpx_mock):
     )
 
     assert response.text() == "ok"
-    request_body = json.loads(httpx_mock.get_requests()[-1].content)
+    request_body = json.loads(openai_httpx2_mock.get_requests()[-1].content)
     assert request_body["tools"] == [raw_spec]
 
 
@@ -349,8 +414,8 @@ def test_server_side_tool_rejected_by_chat_and_chat_fallback(tool):
 
 
 @pytest.mark.asyncio
-async def test_async_responses_code_interpreter_request(httpx_mock):
-    httpx_mock.add_response(
+async def test_async_responses_code_interpreter_request(openai_httpx2_mock):
+    openai_httpx2_mock.add_response(
         method="POST",
         url="https://api.openai.com/v1/responses",
         json=_text_response_json(),
@@ -365,7 +430,7 @@ async def test_async_responses_code_interpreter_request(httpx_mock):
     )
 
     assert await response.text() == "ok"
-    request_body = json.loads(httpx_mock.get_requests()[-1].content)
+    request_body = json.loads(openai_httpx2_mock.get_requests()[-1].content)
     assert request_body["tools"] == [
         {
             "type": "code_interpreter",
@@ -379,8 +444,8 @@ async def test_async_responses_code_interpreter_request(httpx_mock):
 
 
 @pytest.mark.asyncio
-async def test_async_responses_web_search_request(httpx_mock):
-    httpx_mock.add_response(
+async def test_async_responses_web_search_request(openai_httpx2_mock):
+    openai_httpx2_mock.add_response(
         method="POST",
         url="https://api.openai.com/v1/responses",
         json=_text_response_json(),
@@ -394,7 +459,7 @@ async def test_async_responses_web_search_request(httpx_mock):
     )
 
     assert await response.text() == "ok"
-    request_body = json.loads(httpx_mock.get_requests()[-1].content)
+    request_body = json.loads(openai_httpx2_mock.get_requests()[-1].content)
     assert request_body["tools"] == [
         {"type": "web_search", "external_web_access": False}
     ]
@@ -579,10 +644,10 @@ def test_responses_model_is_registered():
     )
 
 
-def test_chat_completions_opt_out_dispatches_to_chat(httpx_mock):
+def test_chat_completions_opt_out_dispatches_to_chat(openai_httpx2_mock):
     """When chat_completions=1 is passed, the request must hit
     /v1/chat/completions, not /v1/responses."""
-    httpx_mock.add_response(
+    openai_httpx2_mock.add_response(
         method="POST",
         url="https://api.openai.com/v1/chat/completions",
         json={
@@ -609,12 +674,12 @@ def test_chat_completions_opt_out_dispatches_to_chat(httpx_mock):
         key="test",
     )
     assert response.text() == "hi from chat"
-    request_body = json.loads(httpx_mock.get_requests()[-1].content)
+    request_body = json.loads(openai_httpx2_mock.get_requests()[-1].content)
     assert "reasoning_summary" not in request_body
 
 
-def test_default_routes_to_responses_endpoint(httpx_mock):
-    httpx_mock.add_response(
+def test_default_routes_to_responses_endpoint(openai_httpx2_mock):
+    openai_httpx2_mock.add_response(
         method="POST",
         url="https://api.openai.com/v1/responses",
         json={
@@ -650,15 +715,17 @@ def test_default_routes_to_responses_endpoint(httpx_mock):
     response = model.prompt("hello", stream=False, key="test")
     assert response.text() == "hi from responses"
     # Ensure we sent to the right endpoint
-    requests = [r for r in httpx_mock.get_requests()]
+    requests = [r for r in openai_httpx2_mock.get_requests()]
     assert any("/v1/responses" in str(r.url) for r in requests)
     request_body = json.loads(requests[-1].content)
     assert request_body["include"] == ["reasoning.encrypted_content"]
     assert request_body["reasoning"] == {"summary": "auto"}
 
 
-def test_hide_reasoning_omits_reasoning_summary_from_responses_request(httpx_mock):
-    httpx_mock.add_response(
+def test_hide_reasoning_omits_reasoning_summary_from_responses_request(
+    openai_httpx2_mock,
+):
+    openai_httpx2_mock.add_response(
         method="POST",
         url="https://api.openai.com/v1/responses",
         json={
@@ -693,15 +760,17 @@ def test_hide_reasoning_omits_reasoning_summary_from_responses_request(httpx_moc
     model = llm.get_model("gpt-5.5")
     response = model.prompt("hello", stream=False, key="test", hide_reasoning=True)
     assert response.text() == "hidden"
-    request_body = json.loads(httpx_mock.get_requests()[-1].content)
+    request_body = json.loads(openai_httpx2_mock.get_requests()[-1].content)
     assert request_body["include"] == ["reasoning.encrypted_content"]
     assert "reasoning" not in request_body
 
 
-def test_non_reasoning_responses_model_omits_encrypted_reasoning_include(httpx_mock):
+def test_non_reasoning_responses_model_omits_encrypted_reasoning_include(
+    openai_httpx2_mock,
+):
     from llm.default_plugins.openai_models import Responses
 
-    httpx_mock.add_response(
+    openai_httpx2_mock.add_response(
         method="POST",
         url="https://api.openai.com/v1/responses",
         json={
@@ -738,7 +807,7 @@ def test_non_reasoning_responses_model_omits_encrypted_reasoning_include(httpx_m
     response = model.prompt("hello", stream=False, key="test")
 
     assert response.text() == "hi from gpt-4.1"
-    request_body = json.loads(httpx_mock.get_requests()[-1].content)
+    request_body = json.loads(openai_httpx2_mock.get_requests()[-1].content)
     assert request_body["model"] == "gpt-4.1"
     assert "include" not in request_body
     assert "reasoning" not in request_body
@@ -815,7 +884,7 @@ def test_responses_input_translation_assistant_text_uses_easy_input_message():
     ]
 
 
-def test_responses_reply_sends_prior_assistant_text_as_string(httpx_mock):
+def test_responses_reply_sends_prior_assistant_text_as_string(openai_httpx2_mock):
     """response.reply() should send the same simple history shape a direct
     openai-python Responses call would use for a text-only assistant turn."""
 
@@ -848,13 +917,13 @@ def test_responses_reply_sends_prior_assistant_text_as_string(httpx_mock):
             "status": "completed",
         }
 
-    httpx_mock.add_response(
+    openai_httpx2_mock.add_response(
         method="POST",
         url="https://api.openai.com/v1/responses",
         json=response_json("resp_1", "msg_1", "first-ok"),
         headers={"Content-Type": "application/json"},
     )
-    httpx_mock.add_response(
+    openai_httpx2_mock.add_response(
         method="POST",
         url="https://api.openai.com/v1/responses",
         json=response_json("resp_2", "msg_2", "followup-ok"),
@@ -867,7 +936,7 @@ def test_responses_reply_sends_prior_assistant_text_as_string(httpx_mock):
 
     assert first.text() == "first-ok"
     assert second.text() == "followup-ok"
-    requests = httpx_mock.get_requests()
+    requests = openai_httpx2_mock.get_requests()
     second_body = json.loads(requests[-1].content)
     assert second_body["input"] == [
         {"role": "user", "content": "Say exactly: first-ok"},
@@ -1019,8 +1088,8 @@ def test_responses_kwargs_includes_service_tier():
     assert kwargs["service_tier"] == "fast"
 
 
-def test_service_tier_sent_to_responses_endpoint(httpx_mock):
-    httpx_mock.add_response(
+def test_service_tier_sent_to_responses_endpoint(openai_httpx2_mock):
+    openai_httpx2_mock.add_response(
         method="POST",
         url="https://api.openai.com/v1/responses",
         json={
@@ -1056,14 +1125,14 @@ def test_service_tier_sent_to_responses_endpoint(httpx_mock):
     model = llm.get_model("gpt-5.6-sol")
     response = model.prompt("hello", stream=False, service_tier="fast", key="test")
     assert response.text() == "fast reply"
-    request_body = json.loads(httpx_mock.get_requests()[-1].content)
+    request_body = json.loads(openai_httpx2_mock.get_requests()[-1].content)
     assert request_body["service_tier"] == "fast"
     # The response body reports the tier that actually processed the request
     assert response.json()["service_tier"] == "priority"
 
 
-def test_service_tier_sent_to_chat_completions_fallback(httpx_mock):
-    httpx_mock.add_response(
+def test_service_tier_sent_to_chat_completions_fallback(openai_httpx2_mock):
+    openai_httpx2_mock.add_response(
         method="POST",
         url="https://api.openai.com/v1/chat/completions",
         json={
@@ -1086,12 +1155,12 @@ def test_service_tier_sent_to_chat_completions_fallback(httpx_mock):
         "hello", stream=False, chat_completions=True, service_tier="fast", key="test"
     )
     assert response.text() == "fast chat"
-    request_body = json.loads(httpx_mock.get_requests()[-1].content)
+    request_body = json.loads(openai_httpx2_mock.get_requests()[-1].content)
     assert request_body["service_tier"] == "fast"
 
 
-def test_responses_streams_reasoning_summary_text(httpx_mock):
-    httpx_mock.add_response(
+def test_responses_streams_reasoning_summary_text(openai_httpx2_mock):
+    openai_httpx2_mock.add_response(
         method="POST",
         url="https://api.openai.com/v1/responses",
         stream=IteratorStream(_responses_reasoning_summary_stream()),
@@ -1395,8 +1464,8 @@ def _responses_reasoning_refresh_stream():
     )
 
 
-def test_responses_reasoning_metadata_refreshed_from_final_payload(httpx_mock):
-    httpx_mock.add_response(
+def test_responses_reasoning_metadata_refreshed_from_final_payload(openai_httpx2_mock):
+    openai_httpx2_mock.add_response(
         method="POST",
         url="https://api.openai.com/v1/responses",
         stream=IteratorStream(_responses_reasoning_refresh_stream()),
@@ -1424,10 +1493,10 @@ def test_responses_reasoning_metadata_refreshed_from_final_payload(httpx_mock):
     assert reasoning_parts[0].text == "Thinking aloud"
 
 
-def test_code_interpreter_multi_message_response(httpx_mock):
+def test_code_interpreter_multi_message_response(openai_httpx2_mock):
     """Server-side tool execution interleaving multiple message output
     items must assemble into multiple assistant Messages."""
-    httpx_mock.add_response(
+    openai_httpx2_mock.add_response(
         method="POST",
         url="https://api.openai.com/v1/responses",
         json={
@@ -1493,8 +1562,8 @@ def test_code_interpreter_multi_message_response(httpx_mock):
     assert response.tool_calls() == []
 
 
-def test_code_interpreter_streaming_output_and_request(httpx_mock):
-    httpx_mock.add_response(
+def test_code_interpreter_streaming_output_and_request(openai_httpx2_mock):
+    openai_httpx2_mock.add_response(
         method="POST",
         url="https://api.openai.com/v1/responses",
         stream=IteratorStream(_code_interpreter_stream()),
@@ -1513,7 +1582,7 @@ def test_code_interpreter_streaming_output_and_request(httpx_mock):
     assert all(event.server_executed for event in events[:3])
     assert response.tool_calls() == []
 
-    request_body = json.loads(httpx_mock.get_requests()[-1].content)
+    request_body = json.loads(openai_httpx2_mock.get_requests()[-1].content)
     assert "code_interpreter_call.outputs" in request_body["include"]
 
 
@@ -1540,8 +1609,8 @@ def _assert_web_search_streaming_uses_final_payload(response, messages):
     assert json.loads(tool_result.output) == final_item["results"]
 
 
-def test_web_search_streaming_refreshes_from_final_payload(httpx_mock):
-    httpx_mock.add_response(
+def test_web_search_streaming_refreshes_from_final_payload(openai_httpx2_mock):
+    openai_httpx2_mock.add_response(
         method="POST",
         url="https://api.openai.com/v1/responses",
         stream=IteratorStream(_web_search_refresh_stream()),
@@ -1558,8 +1627,10 @@ def test_web_search_streaming_refreshes_from_final_payload(httpx_mock):
 
 
 @pytest.mark.asyncio
-async def test_async_web_search_streaming_refreshes_from_final_payload(httpx_mock):
-    httpx_mock.add_response(
+async def test_async_web_search_streaming_refreshes_from_final_payload(
+    openai_httpx2_mock,
+):
+    openai_httpx2_mock.add_response(
         method="POST",
         url="https://api.openai.com/v1/responses",
         stream=IteratorStream(_web_search_refresh_stream()),

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -237,7 +237,7 @@ def test_templates_error_on_missing_schema(templates_path):
             ],
             None,
             None,
-            marks=pytest.mark.httpx_mock(),
+            marks=pytest.mark.httpx2(assert_all_called=False),
         ),
         pytest.param(
             "prompt: 'Say $hello'",
@@ -247,7 +247,7 @@ def test_templates_error_on_missing_schema(templates_path):
             None,
             "Error: Missing variables: hello",
             None,
-            marks=pytest.mark.httpx_mock(),
+            marks=pytest.mark.httpx2(assert_all_called=False),
         ),
         # Template generated prompt should combine with CLI prompt
         (


### PR DESCRIPTION
## Summary

- require OpenAI 3 and use HTTPX2 for the custom response-logging client,
  including the async path
- move OpenAI request mocks to `pytest-httpx2` while retaining
  `pytest-httpx` for LLM's own legacy HTTPX requests
- add a network-forbidden isolation regression plus sync/async logging and
  authorization-redaction coverage

OpenAI 3 uses HTTPX2 by default, so the existing pytest-httpx fixtures no
longer intercepted SDK traffic. The new test adapter keeps the existing
ordered-response and request-inspection test style while routing OpenAI calls
through pytest-httpx2. Streaming and non-streaming tests now exercise both
sync and async clients offline.

This deliberately does not add the separate legacy `httpx` runtime dependency
covered by #1609. It keeps pytest-httpx and the direct legacy-HTTPX tests in
place because LLM still uses that client family outside the OpenAI SDK.

## Validation

- `python -m pytest -q` — 1,087 passed on Python 3.12 / macOS arm64
- `black --check .`
- `ruff check .`
- `mypy llm`
- `cog --check -p "import sys, os; sys._called_from_test=True; os.environ['LLM_USER_PATH'] = '/tmp'" docs/**/*.md docs/*.md`
- `python -m build`
- installed `llm-cluster` and `llm-mistral`, then ran
  `tests/test-llm-load-plugins.sh`

The other supported Python versions and operating systems were not run
locally; the GitHub Actions matrix will cover them.

Fixes #1614
