### PR TITLE
Declare typing-extensions, and a test that catches undeclared imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "click-default-group>=1.2.3",
     "sqlite-utils>=4.0",
     "pydantic>=2.0.0",
+    "typing-extensions",
     "PyYAML",
     "pluggy",
     "python-ulid",

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,6 +1,10 @@
+import ast
 import json
 import os
 import pathlib
+import re
+import sys
+from importlib import metadata
 from importlib.metadata import version
 from unittest import mock
 
@@ -985,3 +989,55 @@ def test_default_exports():
     "Check key exports in the llm __all__ list"
     for name in ("Model", "AsyncModel", "get_model", "get_async_model", "schema_dsl"):
         assert name in llm.__all__, f"{name} not in llm.__all__"
+
+
+def test_all_third_party_imports_are_declared():
+    """Every third-party module imported by llm/ must be a declared dependency.
+
+    httpx was imported by four modules but only arrived transitively via openai,
+    so it vanished when openai 3.0 moved to httpx2 and every fresh install broke.
+    This catches the next one in CI instead of on a user's machine.
+    """
+    llm_dir = pathlib.Path(llm.__file__).parent
+
+    imported = set()
+    for path in sorted(llm_dir.rglob("*.py")):
+        # Source under llm/ contains non-ASCII, so don't trust the platform
+        # default encoding - that would fail on the Windows CI runners.
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    imported.add(alias.name.split(".")[0])
+            # level > 0 is a relative import, so it's internal to llm
+            elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+                imported.add(node.module.split(".")[0])
+
+    third_party = imported - sys.stdlib_module_names - {"llm"}
+
+    def normalize(name):
+        return re.sub(r"[-_.]+", "-", name).lower()
+
+    declared = set()
+    for requirement in metadata.requires("llm") or []:
+        # Skip anything gated behind an extra - those aren't guaranteed installed
+        if "extra ==" in requirement:
+            continue
+        declared.add(normalize(re.split(r"[<>=!~;\s\[]", requirement, 1)[0]))
+
+    module_to_distributions = metadata.packages_distributions()
+
+    undeclared = set()
+    for module in third_party:
+        distributions = module_to_distributions.get(module)
+        if not distributions:
+            # Not installed in this environment, so we can't map it to a
+            # distribution to check. Don't guess.
+            continue
+        if not any(normalize(dist) in declared for dist in distributions):
+            undeclared.add(module)
+
+    assert not undeclared, (
+        "these modules are imported by llm/ but are not declared in "
+        "pyproject.toml dependencies: " + ", ".join(sorted(undeclared))
+    )


### PR DESCRIPTION
Refs #1608. Follow-on to e9a4382 — that fixed `httpx`; this covers the same
class of bug that is still latent, and adds a test so there isn't a third one.

`llm/serialization.py` imports `typing_extensions` directly, and the comment
above the import says out loud that it is leaning on a transitive:

```python
# NotRequired moved to typing in 3.11; use typing_extensions for 3.10
# support. typing_extensions is a transitive dep via pydantic.
from typing_extensions import NotRequired, TypedDict
```

That is exactly the arrangement `httpx` had via `openai` until openai 3.0
switched to httpx2 and every fresh install started dying at import time. It
works today because pydantic pulls it in, and it keeps working right up until
pydantic stops — at which point it breaks the same way, on users' machines
rather than in CI. The import is unconditional, so it is needed on every
supported Python, not just 3.10.

### Changes

**`pyproject.toml`** — add `typing-extensions` to `dependencies`.

**`tests/test_llm.py`** — new `test_all_third_party_imports_are_declared`:
walks the AST of every module under `llm/`, collects top-level non-stdlib
imports, maps each to its providing distribution via
`importlib.metadata.packages_distributions()`, and asserts it appears in the
package's own declared requirements.

On current `main` it fails with:

```
AssertionError: these modules are imported by llm/ but are not declared in
pyproject.toml dependencies: typing_extensions
```

and passes with the `pyproject.toml` change. It generalises, so the next
undeclared import gets caught in CI instead of by a user on a fresh install.

### Verification

- Verified failing before the `pyproject.toml` change, passing after.
- `typing_extensions` is the only thing it flags — no false positives across
  the rest of `llm/`.
- `black --check .`, `ruff check .` and `mypy llm` are clean.

### Notes on the test

- Reads sources with an explicit `encoding="utf-8"` rather than the platform
  default, since files under `llm/` contain non-ASCII — otherwise it would
  fail on the Windows CI matrix.
- Skips relative imports, and skips modules it cannot resolve to an installed
  distribution rather than guessing, so an optional/platform-gated import can't
  produce a spurious failure.
- Ignores requirements gated behind an `extra ==` marker, so only genuinely
  guaranteed dependencies count as declared.

I have deliberately left the second half of #1608 (the suite escaping to the
live API under openai 3) alone — #1621 is taking that on properly, and this
does not touch it. Note that `Test` on `main` is currently red for that reason,
so CI on this PR will likely be red too; it is pre-existing and unrelated to
this change.
