### PR TITLE
Add llm-tiyuvta to plugin directory

### DIFF
--- a/docs/plugins/directory.md
+++ b/docs/plugins/directory.md
@@ -42,6 +42,7 @@ These plugins can be used to interact with remotely hosted models via their API:
 - **[llm-deepseek](https://github.com/abrasumente233/llm-deepseek)** adds support for the [DeepSeek](https://deepseek.com)'s DeepSeek-Chat and DeepSeek-Coder models.
 - **[llm-lambda-labs](https://github.com/simonw/llm-lambda-labs)** provides access to models hosted by [Lambda Labs](https://docs.lambdalabs.com/public-cloud/lambda-chat-api/), including the Nous Hermes 3 series.
 - **[llm-venice](https://github.com/ar-jan/llm-venice)** provides access to uncensored models hosted by privacy-focused [Venice AI](https://docs.venice.ai/), including Llama 3.1 405B.
+- **[llm-tiyuvta](https://github.com/avifenesh/llm-tiyuvta)** by Avi Fenesh provides access to open-weight models hosted by [tiyuvta](https://inference.tiyuvta.ai/). The plugin reads the live model catalog, so newly launched models appear without a plugin update, and detects per-model capabilities — vision attachments are only enabled for models that support them.
 
 If an API model host provides an OpenAI-compatible API you can also [configure LLM to talk to it](https://llm.datasette.io/en/stable/other-models.html#openai-compatible-models) without needing an extra plugin.
 


### PR DESCRIPTION
Adds [llm-tiyuvta](https://github.com/avifenesh/llm-tiyuvta) to the Remote APIs section.

tiyuvta is a prepaid open-weight-model inference endpoint (OpenAI-compatible: streaming, tools, schemas, vision). Two things the plugin does that might be interesting:

- It reads the endpoint's live model catalog at runtime, so newly launched models show up in `llm models` without a plugin release. The catalog cache is atomic-write with corrupt-cache repair and stale-cache fallback, so a network failure or a proxy interstitial never breaks the CLI.
- It maps per-model capabilities from the catalog: `attachment_types` only includes image types for models that actually have vision, so `-a photo.jpg` against a text-only model fails fast in the CLI instead of round-tripping to a paid 400.

On PyPI as of today: `llm install llm-tiyuvta` (v0.1.0, tests on 3.9–3.13, published via trusted publishing).