### PR TITLE
Validate attachments in conversation prompts

### DIFF
--- a/llm/models.py
+++ b/llm/models.py
@@ -837,6 +837,7 @@ class Conversation(_BaseConversation):
         hide_reasoning: bool = False,
         **kwargs,
     ) -> "Response":
+        self.model._validate_attachments(attachments)
         merged = _merge_options(options, kwargs)
         # Build the authoritative chain so response.prompt.messages
         # equals exactly what the model sees for this turn.
@@ -1023,6 +1024,7 @@ class AsyncConversation(_BaseConversation):
         hide_reasoning: bool = False,
         **kwargs,
     ) -> "AsyncResponse":
+        self.model._validate_attachments(attachments)
         merged = _merge_options(options, kwargs)
         chain = self._build_full_chain(
             prompt=prompt,

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -159,3 +159,108 @@ def test_attachment_resolve_type_limits_redirects(httpx_mock):
         attachment.resolve_type()
 
     assert len(httpx_mock.get_requests()) == 4
+
+
+UNSUPPORTED_ATTACHMENT_CASES = (
+    ((), "This model does not support attachments"),
+    (
+        ("audio/wav",),
+        "This model does not support attachments of type 'image/png', only audio/wav",
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    "attachment_types,expected_message", UNSUPPORTED_ATTACHMENT_CASES
+)
+def test_conversation_prompt_rejects_unsupported_attachment_before_execute(
+    mock_model, attachment_types, expected_message
+):
+    mock_model.attachment_types = frozenset(attachment_types)
+    mock_model.enqueue(["sent"])
+    conversation = mock_model.conversation()
+    attachment = llm.Attachment(type="image/png", content=TINY_PNG)
+
+    with pytest.raises(ValueError) as ex:
+        conversation.prompt("describe", attachments=[attachment]).text()
+
+    assert str(ex.value) == expected_message
+    assert mock_model.history == []
+    assert conversation.responses == []
+
+
+@pytest.mark.parametrize(
+    "attachment_types,expected_message", UNSUPPORTED_ATTACHMENT_CASES
+)
+@pytest.mark.asyncio
+async def test_async_conversation_prompt_rejects_unsupported_attachment_before_execute(
+    async_mock_model, attachment_types, expected_message
+):
+    async_mock_model.attachment_types = frozenset(attachment_types)
+    async_mock_model.enqueue(["sent"])
+    conversation = async_mock_model.conversation()
+    attachment = llm.Attachment(type="image/png", content=TINY_PNG)
+
+    with pytest.raises(ValueError) as ex:
+        await conversation.prompt("describe", attachments=[attachment]).text()
+
+    assert str(ex.value) == expected_message
+    assert async_mock_model.history == []
+    assert conversation.responses == []
+
+
+def test_conversation_prompt_preserves_supported_attachment_in_follow_up_chain(
+    mock_model,
+):
+    mock_model.enqueue(["describe"])
+    mock_model.enqueue(["follow up"])
+    conversation = mock_model.conversation()
+    attachment = llm.Attachment(type="image/png", content=TINY_PNG)
+
+    assert (
+        conversation.prompt("describe", attachments=[attachment]).text() == "describe"
+    )
+    assert conversation.prompt("follow up").text() == "follow up"
+
+    assert mock_model.history[0][0].attachments == [attachment]
+    assert mock_model.history[1][0].messages == [
+        llm.Message(
+            role="user",
+            parts=[
+                llm.parts.TextPart(text="describe"),
+                llm.parts.AttachmentPart(attachment=attachment),
+            ],
+        ),
+        llm.assistant("describe"),
+        llm.user("follow up"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_async_conversation_prompt_preserves_supported_attachment_in_follow_up_chain(
+    async_mock_model,
+):
+    async_mock_model.attachment_types = frozenset({"image/png"})
+    async_mock_model.enqueue(["describe"])
+    async_mock_model.enqueue(["follow up"])
+    conversation = async_mock_model.conversation()
+    attachment = llm.Attachment(type="image/png", content=TINY_PNG)
+
+    assert (
+        await conversation.prompt("describe", attachments=[attachment]).text()
+        == "describe"
+    )
+    assert await conversation.prompt("follow up").text() == "follow up"
+
+    assert async_mock_model.history[0][0].attachments == [attachment]
+    assert async_mock_model.history[1][0].messages == [
+        llm.Message(
+            role="user",
+            parts=[
+                llm.parts.TextPart(text="describe"),
+                llm.parts.AttachmentPart(attachment=attachment),
+            ],
+        ),
+        llm.assistant("describe"),
+        llm.user("follow up"),
+    ]


### PR DESCRIPTION
## Summary

- validate attachments in sync and async `Conversation.prompt()` before a response can execute the provider
- cover both models with no attachment support and models that reject a specific MIME type
- verify supported attachments and the resulting multi-turn conversation history remain unchanged

## Root cause

`Model.prompt()`, `AsyncModel.prompt()`, and both conversation `chain()` paths already call the model attachment validator. The two conversation `prompt()` entry points skipped that same contract, so continued CLI conversations could send an unsupported attachment to the provider.

## Validation

- `pytest -q tests/test_attachments.py` — 13 passed
- `pytest -q` — 1,099 passed with the current `httpx2` / OpenAI 3 dependency set
- `black --check .`
- `ruff check .`
- `mypy llm`
- Cog documentation check
- `python -m build`
- `tests/test-llm-load-plugins.sh` with `llm-cluster` and `llm-mistral`

The branch has been merged normally with current upstream `main` (`7008f55`), which includes the upstream HTTP/OpenAI test-compatibility update. No dependency change is part of this PR's diff.

Fixes #1626
