### PR TITLE
Include server-side tool call output in llm logs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@
 
 - Reasoning-capable Responses API models now support a `reasoning_summary` option with `auto`, `concise`, and `detailed` values. This can be used with {ref}`llm openai endpoint --responses <openai-endpoint>`. [#1600](https://github.com/simonw/llm/issues/1600)
 - `llm prompt -t/--template` can now be repeated to combine templates in order. This allows model configuration and options from one template to be used with a prompt from another.
+- `llm logs` now includes the output of server-side tool calls, shown in a **Tool results** section within the response. These results are also included in `llm logs --json` and `llm logs --short` output, with a new `server_executed` key distinguishing them from locally executed tool results. [#1629](https://github.com/simonw/llm/issues/1629)
 
 (v0_32)=
 ## 0.32 (2026-08-04)

--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1709,6 +1709,7 @@ def annotate_log_rows(db, rows, expand=False, truncate=False):
             "_output_parts",
             "_parent_message_hash",
             "_input_message_hashes",
+            "_output_message_hashes",
             "_tip_message_hash",
             "_legacy",
             "_search_rank",
@@ -2081,6 +2082,34 @@ def logs_list(
                 return details
             return usage
 
+        def _display_tool_results(tool_results):
+            for tool_result in tool_results:
+                attachments = ""
+                for attachment in tool_result["attachments"]:
+                    desc = ""
+                    if attachment.get("type"):
+                        desc += attachment["type"] + ": "
+                    if attachment.get("path"):
+                        desc += attachment["path"]
+                    elif attachment.get("url"):
+                        desc += attachment["url"]
+                    elif attachment.get("content"):
+                        desc += f"<{attachment['content_length']:,} bytes>"
+                    attachments += f"\n    - {desc}"
+                click.echo(
+                    "- **{}**: `{}`  \n{}{}{}".format(
+                        tool_result["name"],
+                        tool_result["tool_call_id"],
+                        _fenced_block(tool_result["output"]),
+                        (
+                            "  \n    **Error**: {}\n".format(tool_result["exception"])
+                            if tool_result["exception"]
+                            else ""
+                        ),
+                        attachments,
+                    )
+                )
+
         def _display_fragments(fragments, title):
             if not fragments:
                 return
@@ -2251,36 +2280,22 @@ def logs_list(
                     )
                     for tool in instance_tools:
                         echo_tool(tool, "    ")
-            if row["tool_results"]:
+            # Results the model was given arrived with the prompt;
+            # server-executed results happened during the response and
+            # render there instead.
+            local_tool_results = [
+                tool_result
+                for tool_result in row["tool_results"]
+                if not tool_result.get("server_executed")
+            ]
+            server_tool_results = [
+                tool_result
+                for tool_result in row["tool_results"]
+                if tool_result.get("server_executed")
+            ]
+            if local_tool_results:
                 click.echo("\n### Tool results\n")
-                for tool_result in row["tool_results"]:
-                    attachments = ""
-                    for attachment in tool_result["attachments"]:
-                        desc = ""
-                        if attachment.get("type"):
-                            desc += attachment["type"] + ": "
-                        if attachment.get("path"):
-                            desc += attachment["path"]
-                        elif attachment.get("url"):
-                            desc += attachment["url"]
-                        elif attachment.get("content"):
-                            desc += f"<{attachment['content_length']:,} bytes>"
-                        attachments += f"\n    - {desc}"
-                    click.echo(
-                        "- **{}**: `{}`  \n{}{}{}".format(
-                            tool_result["name"],
-                            tool_result["tool_call_id"],
-                            _fenced_block(tool_result["output"]),
-                            (
-                                "  \n    **Error**: {}\n".format(
-                                    tool_result["exception"]
-                                )
-                                if tool_result["exception"]
-                                else ""
-                            ),
-                            attachments,
-                        )
-                    )
+                _display_tool_results(local_tool_results)
             attachments = attachments_by_id.get(row["id"])
             if attachments:
                 click.echo("\n### Attachments\n")
@@ -2326,6 +2341,10 @@ def logs_list(
                             _format_tool_call_arguments(tool_call["arguments"]),
                         )
                     )
+                click.echo("")
+            if server_tool_results:
+                click.echo("### Tool results\n")
+                _display_tool_results(server_tool_results)
                 click.echo("")
             if response:
                 click.echo(f"{response}\n")

--- a/llm/logs.py
+++ b/llm/logs.py
@@ -1232,6 +1232,9 @@ class _LogRowBuilder:
                 "_input_message_hashes": self._input_segment_hashes(
                     row["parent_message_hash"]
                 ),
+                "_output_message_hashes": self._output_segment_hashes(
+                    row["tip_message_hash"], row["parent_message_hash"]
+                ),
                 "_tip_message_hash": row["tip_message_hash"],
             }
         )
@@ -1270,6 +1273,30 @@ class _LogRowBuilder:
                 None,
             )
             if message_row is None or message_row["role"] not in ("user", "tool"):
+                break
+            hashes.append(hash_)
+            hash_ = message_row["parent_hash"]
+        hashes.reverse()
+        return hashes
+
+    def _output_segment_hashes(
+        self, tip_hash: str | None, parent_hash: str | None
+    ) -> list[str]:
+        """Hashes of the turn's own output messages - the segment
+        between the parent and the tip, walked directly in the table."""
+        hashes: list[str] = []
+        hash_ = tip_hash
+        while hash_ and hash_ != parent_hash:
+            message_row = next(
+                iter(
+                    self.store.db.query(
+                        "select parent_hash from messages where hash = ?",
+                        [hash_],
+                    )
+                ),
+                None,
+            )
+            if message_row is None:
                 break
             hashes.append(hash_)
             hash_ = message_row["parent_hash"]
@@ -1402,8 +1429,14 @@ def log_row_extras(store: "LogStore", row: dict) -> dict:
     # parts.id and tools.id stand in for the row ids the old
     # tool_calls / tool_results tables exposed, so the JSON shape of
     # `llm logs` is unchanged.
-    call_ids = _part_ids(store, [row.get("_tip_message_hash")], "tool_call")
+    output_message_hashes = row.get("_output_message_hashes") or [
+        row.get("_tip_message_hash")
+    ]
+    call_ids = _part_ids(store, output_message_hashes, "tool_call")
     result_ids = _part_ids(store, row.get("_input_message_hashes") or [], "tool_result")
+    # Server-executed tools produce their results inside the response
+    # itself, so those parts sit in the output messages.
+    server_result_ids = _part_ids(store, output_message_hashes, "tool_result")
 
     # input_schema is rendered as a dict, so decode it here rather than
     # handing the caller the raw JSON text out of the column.
@@ -1448,30 +1481,43 @@ def log_row_extras(store: "LogStore", row: dict) -> dict:
             "name": part.name,
             "arguments": part.arguments,
             "tool_call_id": part.tool_call_id,
+            "server_executed": part.server_executed,
         }
         for part in row.get("_output_parts", [])
         if isinstance(part, ToolCallPart)
     ]
+    # Results among the inputs were executed locally and fed back to
+    # the model; results among the outputs were executed server-side
+    # during the response.
     result_parts = [
-        part for part in row.get("_input_parts", []) if isinstance(part, ToolResultPart)
+        (part, False)
+        for part in row.get("_input_parts", [])
+        if isinstance(part, ToolResultPart)
+    ] + [
+        (part, True)
+        for part in row.get("_output_parts", [])
+        if isinstance(part, ToolResultPart)
     ]
     instances = _instances_by_tool_call_id(
         store,
         row["id"],
-        [part.tool_call_id for part in result_parts if part.tool_call_id],
+        [part.tool_call_id for part, _ in result_parts if part.tool_call_id],
     )
     tool_results = [
         {
-            "id": result_ids.get(part.tool_call_id),
+            "id": (server_result_ids if server_executed else result_ids).get(
+                part.tool_call_id
+            ),
             "tool_id": tool_ids.get(part.name),
             "name": part.name,
             "output": part.output,
             "tool_call_id": part.tool_call_id,
             "exception": part.exception,
+            "server_executed": server_executed,
             "instance": instances.get(part.tool_call_id),
             "attachments": [_attachment_summary(a) for a in part.attachments],
         }
-        for part in result_parts
+        for part, server_executed in result_parts
     ]
 
     fragments: dict[str, list[dict]] = {

--- a/tests/test_llm_logs.py
+++ b/tests/test_llm_logs.py
@@ -1182,6 +1182,79 @@ def test_logs_tool_call_argument_formatting(logs_db):
     ) in normalized_output
 
 
+def test_logs_server_side_tool_results(logs_db, mock_model):
+    """Server-executed tool calls carry their results inside the
+    response itself, so they render in a Tool results section under
+    ## Response - https://github.com/simonw/llm/issues/1629"""
+    import llm
+
+    mock_model.enqueue(
+        [
+            llm.parts.StreamEvent(
+                type="tool_call_name",
+                chunk="shell",
+                tool_call_id="tc_server_1",
+                server_executed=True,
+            ),
+            llm.parts.StreamEvent(
+                type="tool_call_args",
+                chunk='{"commands": ["python fib.py"]}',
+                tool_call_id="tc_server_1",
+                server_executed=True,
+            ),
+            llm.parts.StreamEvent(
+                type="tool_result",
+                chunk="17711",
+                tool_name="shell",
+                tool_call_id="tc_server_1",
+                server_executed=True,
+            ),
+            llm.parts.StreamEvent(type="text", chunk="Fibonacci(22) = 17711"),
+        ]
+    )
+    response = mock_model.prompt("calculate fibonacci 22")
+    response.text()
+    response.log_to_db(logs_db)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["logs", "-c"], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert (
+        "## Response\n"
+        "\n"
+        "### Tool calls\n"
+        "\n"
+        "- **shell**: `tc_server_1`  \n"
+        '    commands: `["python fib.py"]`\n'
+        "\n"
+        "### Tool results\n"
+        "\n"
+        "- **shell**: `tc_server_1`  \n"
+        "    ```\n"
+        "    17711\n"
+        "    ```\n"
+        "\n"
+        "Fibonacci(22) = 17711\n"
+    ) in result.output
+
+    # --json output records the result and marks it server-executed
+    json_result = runner.invoke(cli, ["logs", "--json"], catch_exceptions=False)
+    assert json_result.exit_code == 0
+    row = json.loads(json_result.output)[0]
+    assert row["tool_calls"][0]["server_executed"] is True
+    (tool_result,) = row["tool_results"]
+    assert tool_result["name"] == "shell"
+    assert tool_result["output"] == "17711"
+    assert tool_result["tool_call_id"] == "tc_server_1"
+    assert tool_result["server_executed"] is True
+    assert tool_result["id"] is not None
+
+    # --short mode includes the server-side result too
+    short_result = runner.invoke(cli, ["logs", "--short"], catch_exceptions=False)
+    assert short_result.exit_code == 0
+    assert "shell: 17711" in short_result.output
+
+
 def test_logs_backup(logs_db):
     assert not logs_db.tables
     runner = CliRunner()

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -476,12 +476,12 @@ def test_register_tools(tmpdir, logs_db):
             ('{"tool_calls": [{"name": "upper", "arguments": {"text": "one"}}]}', "[]"),
             (
                 "",
-                '[{"id": ID, "tool_id": 1, "name": "upper", "output": "ONE", "tool_call_id": "tc_TCID", "exception": null, "instance": null, "attachments": []}]',
+                '[{"id": ID, "tool_id": 1, "name": "upper", "output": "ONE", "tool_call_id": "tc_TCID", "exception": null, "server_executed": false, "instance": null, "attachments": []}]',
             ),
             ('{"tool_calls": [{"name": "upper", "arguments": {"text": "two"}}]}', "[]"),
             (
                 "",
-                '[{"id": ID, "tool_id": 1, "name": "upper", "output": "TWO", "tool_call_id": "tc_TCID", "exception": null, "instance": null, "attachments": []}]',
+                '[{"id": ID, "tool_id": 1, "name": "upper", "output": "TWO", "tool_call_id": "tc_TCID", "exception": null, "server_executed": false, "instance": null, "attachments": []}]',
             ),
             (
                 '{"tool_calls": [{"name": "upper", "arguments": {"text": "three"}}]}',
@@ -489,7 +489,7 @@ def test_register_tools(tmpdir, logs_db):
             ),
             (
                 "",
-                '[{"id": ID, "tool_id": 1, "name": "upper", "output": "THREE", "tool_call_id": "tc_TCID", "exception": null, "instance": null, "attachments": []}]',
+                '[{"id": ID, "tool_id": 1, "name": "upper", "output": "THREE", "tool_call_id": "tc_TCID", "exception": null, "server_executed": false, "instance": null, "attachments": []}]',
             ),
         )
         # Test the --td option


### PR DESCRIPTION
Closes:
-  #1629

<details><summary>Claude Code PR</summary>

Server-executed tool calls carry their results inside the response
itself, but log_row_extras only collected ToolResultParts from the
turn's input messages - so those results never appeared in llm logs
output.

Tool results found among the output parts are now included, marked
with a server_executed flag, and rendered in a Tool results section
under the Response heading in Markdown logs. They also appear in
--json and --short output, and their parts row ids resolve via the
turn's output message hashes (which fixes tool call ids for
multi-message outputs too).

</details>

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PzhPhB5akxfAQkBug7i332