### PR TITLE
Add redirect_stdout_to_stderr() utility for native libraries

### DIFF
--- a/llm/utils.py
+++ b/llm/utils.py
@@ -1,9 +1,11 @@
+import contextlib
 import hashlib
 import itertools
 import json
 import os
 import pathlib
 import re
+import sys
 import textwrap
 import threading
 import time
@@ -18,6 +20,29 @@ from ulid import ULID
 MIME_TYPE_FIXES = {
     "audio/wave": "audio/wav",
 }
+
+
+@contextlib.contextmanager
+def redirect_stdout_to_stderr():
+    """Temporarily redirect OS-level stdout (file descriptor 1) to stderr.
+
+    Some native libraries write log messages straight to file descriptor 1,
+    bypassing both ``sys.stdout`` and ``contextlib.redirect_stdout``. For
+    example, llama.cpp (used by the ``llm-llama-cpp`` plugin) and gpt4all
+    emit diagnostics this way. Wrapping those native calls in this context
+    manager routes that noise to stderr, leaving stdout free for model output.
+    """
+    stdout = sys.__stdout__ or sys.stdout
+    stderr = sys.__stderr__ or sys.stderr
+    stdout_fd = stdout.fileno()
+    stderr_fd = stderr.fileno()
+    saved_stdout_fd = os.dup(stdout_fd)
+    try:
+        os.dup2(stderr_fd, stdout_fd)
+        yield
+    finally:
+        os.dup2(saved_stdout_fd, stdout_fd)
+        os.close(saved_stdout_fd)
 
 
 class Fragment(str):

--- a/llm/utils.py
+++ b/llm/utils.py
@@ -31,18 +31,27 @@ def redirect_stdout_to_stderr():
     example, llama.cpp (used by the ``llm-llama-cpp`` plugin) and gpt4all
     emit diagnostics this way. Wrapping those native calls in this context
     manager routes that noise to stderr, leaving stdout free for model output.
+
+    This changes file descriptor 1 process-wide, so the redirect affects every
+    thread while the context manager is active.
     """
     stdout = sys.__stdout__ or sys.stdout
     stderr = sys.__stderr__ or sys.stderr
     stdout_fd = stdout.fileno()
     stderr_fd = stderr.fileno()
+    stdout.flush()
     saved_stdout_fd = os.dup(stdout_fd)
     try:
         os.dup2(stderr_fd, stdout_fd)
-        yield
+        try:
+            yield
+        finally:
+            stdout.flush()
     finally:
-        os.dup2(saved_stdout_fd, stdout_fd)
-        os.close(saved_stdout_fd)
+        try:
+            os.dup2(saved_stdout_fd, stdout_fd)
+        finally:
+            os.close(saved_stdout_fd)
 
 
 class Fragment(str):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import json
-import os
+import subprocess
+import sys
 import threading
 from types import SimpleNamespace
 
@@ -13,7 +14,6 @@ from llm.utils import (
     instantiate_from_spec,
     maybe_fenced_code,
     monotonic_ulid,
-    redirect_stdout_to_stderr,
     resolve_schema_input,
     schema_dsl,
     simplify_usage_dict,
@@ -635,31 +635,31 @@ def test_toolbox_config_capture():
 
 
 def test_redirect_stdout_to_stderr():
-    # Redirect the real stdout and stderr file descriptors to pipes so we can
-    # observe OS-level writes that bypass Python's sys.stdout/sys.stderr.
-    stdout_read, stdout_write = os.pipe()
-    stderr_read, stderr_write = os.pipe()
-    original_stdout = os.dup(1)
-    original_stderr = os.dup(2)
-    os.dup2(stdout_write, 1)
-    os.dup2(stderr_write, 2)
-    try:
-        with redirect_stdout_to_stderr():
-            os.write(1, b"native-noise")
-        os.write(1, b"clean-output")
-    finally:
-        os.dup2(original_stdout, 1)
-        os.dup2(original_stderr, 2)
-        os.close(original_stdout)
-        os.close(original_stderr)
-        os.close(stdout_write)
-        os.close(stderr_write)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            """
+import os
+import sys
 
-    stdout_data = os.read(stdout_read, 1024)
-    stderr_data = os.read(stderr_read, 1024)
-    os.close(stdout_read)
-    os.close(stderr_read)
+from llm.utils import redirect_stdout_to_stderr
 
-    assert b"native-noise" not in stdout_data
-    assert b"clean-output" in stdout_data
-    assert b"native-noise" in stderr_data
+print("model-output-before")
+with redirect_stdout_to_stderr():
+    sys.stdout.flush()
+    print("python-noise")
+    os.write(1, b"native-noise\\n")
+print("model-output-after")
+""",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout.splitlines() == [
+        "model-output-before",
+        "model-output-after",
+    ]
+    assert result.stderr.splitlines() == ["native-noise", "python-noise"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import json
+import os
 import threading
 from types import SimpleNamespace
 
@@ -12,6 +13,7 @@ from llm.utils import (
     instantiate_from_spec,
     maybe_fenced_code,
     monotonic_ulid,
+    redirect_stdout_to_stderr,
     resolve_schema_input,
     schema_dsl,
     simplify_usage_dict,
@@ -630,3 +632,34 @@ def test_toolbox_config_capture():
         pass
 
     assert Tool6()._config == {}
+
+
+def test_redirect_stdout_to_stderr():
+    # Redirect the real stdout and stderr file descriptors to pipes so we can
+    # observe OS-level writes that bypass Python's sys.stdout/sys.stderr.
+    stdout_read, stdout_write = os.pipe()
+    stderr_read, stderr_write = os.pipe()
+    original_stdout = os.dup(1)
+    original_stderr = os.dup(2)
+    os.dup2(stdout_write, 1)
+    os.dup2(stderr_write, 2)
+    try:
+        with redirect_stdout_to_stderr():
+            os.write(1, b"native-noise")
+        os.write(1, b"clean-output")
+    finally:
+        os.dup2(original_stdout, 1)
+        os.dup2(original_stderr, 2)
+        os.close(original_stdout)
+        os.close(original_stderr)
+        os.close(stdout_write)
+        os.close(stderr_write)
+
+    stdout_data = os.read(stdout_read, 1024)
+    stderr_data = os.read(stderr_read, 1024)
+    os.close(stdout_read)
+    os.close(stderr_read)
+
+    assert b"native-noise" not in stdout_data
+    assert b"clean-output" in stdout_data
+    assert b"native-noise" in stderr_data

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import json
+import os
 import subprocess
 import sys
 import threading
@@ -635,6 +636,8 @@ def test_toolbox_config_capture():
 
 
 def test_redirect_stdout_to_stderr():
+    env = os.environ.copy()
+    env.pop("PYTHONUNBUFFERED", None)
     result = subprocess.run(
         [
             sys.executable,
@@ -655,6 +658,7 @@ print("model-output-after")
         ],
         check=True,
         capture_output=True,
+        env=env,
         text=True,
     )
 


### PR DESCRIPTION
## Summary

Related to #196.

This implements the shared-helper option proposed by @vanshtaneja23 in [their issue comment](https://github.com/simonw/llm/issues/196#issuecomment-4879379424): a file-descriptor-level `redirect_stdout_to_stderr()` context manager in `llm.utils`.

The helper flushes buffered Python stdout before file descriptor 1 is redirected and again before it is restored. This prevents model output buffered outside the context from crossing stream boundaries. The docstring also notes that changing file descriptor 1 is process-wide and affects every thread while the context is active.

The regression test runs the helper in a subprocess with captured streams. It verifies that model output written before and after the context stays on stdout, while buffered Python output and a native `os.write()` inside the context go to stderr. The child process explicitly uses normal buffered output even if the parent test environment sets `PYTHONUNBUFFERED`.

This PR does not change `llm-llama-cpp` or `llm-gpt4all`, so it does not by itself fix #196. Those plugins would still need to wrap their native calls, or use library logging callbacks, before their diagnostics stop leaking to stdout.

## Verification

- `uv run pytest tests/test_utils.py -q`: `92 passed`
- `PYTHONUNBUFFERED=1 uv run pytest tests/test_utils.py::test_redirect_stdout_to_stderr -q`: `1 passed`
- `uv run pytest -q`: `1125 passed`
- `uv run ruff check llm/utils.py tests/test_utils.py`: passed
- `uv run black --check llm/utils.py tests/test_utils.py`: passed
- `git diff --check`: passed

Prepared with OpenAI Codex (GPT-5) assistance.