### PR TITLE
Reject non-ASCII API keys when setting them

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1598,6 +1598,11 @@ def keys_set(name, value):
         $ llm keys set openai
         Enter key: ...
     """
+    if not value.isascii():
+        raise click.ClickException(
+            "The key must contain only ASCII characters. "
+            "Some non-ASCII characters were detected; please re-copy the key and try again."
+        )
     default = {"// Note": "This file stores secret API credentials. Do not share!"}
     path = user_dir() / "keys.json"
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -43,6 +43,18 @@ def test_keys_set(monkeypatch, tmpdir):
 
 
 @pytest.mark.xfail(sys.platform == "win32", reason="Expected to fail on Windows")
+def test_keys_set_rejects_non_ascii(monkeypatch, tmpdir):
+    user_path = tmpdir / "user/keys"
+    monkeypatch.setenv("LLM_USER_PATH", str(user_path))
+    keys_path = user_path / "keys.json"
+    runner = CliRunner()
+    result = runner.invoke(cli, ["keys", "set", "openai"], input="sk-\u00e0bc")
+    assert result.exit_code == 1
+    assert "ASCII" in result.output
+    assert not keys_path.exists()
+
+
+@pytest.mark.xfail(sys.platform == "win32", reason="Expected to fail on Windows")
 def test_keys_get(monkeypatch, tmpdir):
     user_path = tmpdir / "user/keys"
     monkeypatch.setenv("LLM_USER_PATH", str(user_path))


### PR DESCRIPTION
## Summary

Fixes #576 (the API-key aspect).

A key containing non-ASCII characters (for example a zero-width or non-breaking character pasted from a clipboard) is stored fine but later breaks HTTP requests, because HTTP header values must be ASCII and httpx raises a confusing `UnicodeEncodeError: 'ascii' codec can't encode...`.

This adds an upfront check to `llm keys set`: if the pasted value contains any non-ASCII character, the command fails immediately with a clear, actionable message, and no key is written.

## Verification

- `pytest tests/test_keys.py -q`: 8 passed
- `ruff check llm/cli.py tests/test_keys.py`: passed
- `black --check llm/cli.py tests/test_keys.py`: passed

Prepared with OpenAI Codex (GPT-5) assistance.