### PR TITLE
docs: add OrcaRouter as an OpenAI-compatible provider example

### DIFF
--- a/docs/other-models.md
+++ b/docs/other-models.md
@@ -205,3 +205,30 @@ Some providers such as [openrouter.ai](https://openrouter.ai/docs) may require t
     HTTP-Referer: "https://llm.datasette.io/"
     X-Title: LLM
 ```
+
+### OrcaRouter
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway that routes requests to models from OpenAI, Anthropic, Google, DeepSeek, Qwen and other providers through a single endpoint. It exposes the same provider/model namespace used by OpenRouter, and the `orcarouter/auto` model name selects an upstream model adaptively based on your routing configuration. The `model_name` must be the full vendor-prefixed model identifier as listed on the OrcaRouter dashboard.
+
+Store an OrcaRouter API key using `llm keys set orcarouter`, then add entries to your `extra-openai-models.yaml`:
+
+```yaml
+- model_id: orcarouter-auto
+  model_name: orcarouter/auto
+  api_base: "https://api.orcarouter.ai/v1"
+  api_key_name: orcarouter
+  supports_tools: true
+
+- model_id: orcarouter-gpt-5
+  model_name: openai/gpt-5.5
+  api_base: "https://api.orcarouter.ai/v1"
+  api_key_name: orcarouter
+  supports_tools: true
+  supports_schema: true
+```
+
+Run prompts against any configured model:
+
+```bash
+llm -m orcarouter-auto 'Explain git rebase in 2 sentences'
+```


### PR DESCRIPTION
## Summary

Adds [OrcaRouter](https://www.orcarouter.ai) as a documented example of an OpenAI-compatible AI gateway, alongside LocalAI and OpenRouter in `docs/other-models.md`.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding it as a documented provider means LLM users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## What changed

This updates `docs/other-models.md` with a new OrcaRouter section showing how to configure OrcaRouter models through `extra-openai-models.yaml`, mirroring the existing OpenRouter / AGIone examples.

The examples use full OrcaRouter model identifiers:

- `orcarouter/auto` — the adaptive router endpoint
- `openai/gpt-5.5` — a vendor-prefixed model identifier

## Why

OrcaRouter provides a single OpenAI-compatible endpoint for routing to frontier models through standard Bearer-token authentication, using the same provider/model namespace style as OpenRouter.

This fits the existing "OpenAI-compatible models" documentation pattern used for providers like LocalAI and OpenRouter.

## Verification

- Live-tested both example models (`orcarouter/auto` and `openai/gpt-5.5`) against `https://api.orcarouter.ai/v1` with a real API key — both return 200 with a normal chat completion.
- Ran the documented user flow end-to-end: `llm keys set orcarouter`, configured `extra-openai-models.yaml`, `llm models` shows both models, and `llm -m orcarouter-auto '...'` / `llm -m orcarouter-gpt-5 '...'` both returned a completion.
- Test suite: `1105 passed`.
- Linters: `black --check`, `ruff check .`, `mypy llm`, and `cog --check` all pass.

## Disclosure

I'm an engineer on the OrcaRouter team.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter
