### PR TITLE
Fix fenced code extraction with CRLF line endings

### DIFF
--- a/llm/utils.py
+++ b/llm/utils.py
@@ -200,13 +200,13 @@ def extract_fenced_code_block(text: str, last: bool = False) -> str | None:
     # - ^ or \n ensures that the fence is at the start of a line
     # - (`{3,}) captures the opening backticks (at least three)
     # - (\w+)? optionally captures the language tag
-    # - \n matches the newline after the opening fence
+    # - \r?\n matches the newline after the opening fence
     # - (.*?) non-greedy match for the code block content
     # - (?P=fence) ensures that the closing fence has the same number of backticks
     # - [ ]* allows for optional spaces between the closing fence and newline
-    # - (?=\n|$) ensures that the closing fence is followed by a newline or end of string
+    # - (?=\r?\n|$) ensures that the closing fence is followed by a newline or end of string
     pattern = re.compile(
-        r"""(?m)^(?P<fence>`{3,})(?P<lang>\w+)?\n(?P<code>.*?)^(?P=fence)[ ]*(?=\n|$)""",
+        r"""(?m)^(?P<fence>`{3,})(?P<lang>\w+)?\r?\n(?P<code>.*?)^(?P=fence)[ ]*(?=\r?\n|$)""",
         re.DOTALL,
     )
     matches = list(pattern.finditer(text))

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -209,6 +209,36 @@ def test_extract_fenced_code(
         assert "```" in output
 
 
+def test_extract_fenced_code_crlf(httpx_mock):
+    """The CLI extracts fenced code when the model response uses CRLF."""
+    httpx_mock.add_response(
+        method="POST",
+        url="https://api.openai.com/v1/chat/completions",
+        json={
+            "model": "gpt-4o-mini",
+            "usage": {},
+            "choices": [
+                {
+                    "message": {
+                        "content": 'Code:\r\n\r\n```python\r\nprint("ok")\r\n```\r\nDone.'
+                    }
+                }
+            ],
+        },
+        headers={"Content-Type": "application/json"},
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["-m", "gpt-4o-mini", "--key", "x", "Write code", "--extract"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    # Click normalizes terminal output to LF; test_utils.py verifies that
+    # extraction itself preserves the response's CRLF bytes.
+    assert result.output == 'print("ok")\n\n'
+
+
 def test_openai_chat_stream(mocked_openai_chat_stream, user_path):
     runner = CliRunner()
     result = runner.invoke(cli, ["-m", "gpt-3.5-turbo", "--key", "x", "Say hi"])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -115,6 +115,27 @@ def test_simplify_usage_dict(input_data, expected_output):
             False,
             "def foo():\n    return `bar`\n",
         ],
+        [
+            "Here is some text.\r\n\r\n```python\r\ndef foo():\r\n    return 'bar'\r\n```\r\n\r\nMore text.",
+            False,
+            "def foo():\r\n    return 'bar'\r\n",
+        ],
+        [
+            (
+                "First code block:\r\n\r\n```python\r\nfirst()\r\n```\r\n\r\n"
+                "Second code block:\n\n```javascript\nsecond();\r\n```\n"
+            ),
+            False,
+            "first()\r\n",
+        ],
+        [
+            (
+                "First code block:\r\n\r\n```python\r\nfirst()\r\n```\r\n\r\n"
+                "Second code block:\n\n```javascript\nsecond();\r\n```\n"
+            ),
+            True,
+            "second();\r\n",
+        ],
     ],
 )
 def test_extract_fenced_code_block(input, last, expected):


### PR DESCRIPTION
Fenced model responses using CRLF line endings were not recognized. `--extract` could therefore print the entire reply or skip to a later LF-only code block.

Accept CRLF at opening and closing fences while preserving the extracted content, language-tag syntax, and fence-length checks. Add utility and mocked-HTTP CLI regressions, including mixed line endings and first/last selection.

Validation on Python 3.14:

- `python -m pytest -q`: 1109 passed.
- `black --check .`, `mypy llm`, and `ruff check .`: passed.
- The new CLI regression fails against the unchanged upstream function and passes with this fix.
