### PR TITLE
docs: clarify hosted extra-openai model setup

### DIFF
--- a/docs/openai-models.md
+++ b/docs/openai-models.md
@@ -260,6 +260,10 @@ Let's say OpenAI have just released the `gpt-3.5-turbo-0613` model and you want 
 ```
 The `model_id` is the identifier that will be recorded in the LLM logs. You can use this to specify the model, or you can optionally include a list of aliases for that model. The `model_name` is the actual model identifier that will be passed to the API, which must match exactly what the API expects.
 
+For a hosted OpenAI-compatible endpoint, see the configuration example in
+{ref}`openai-compatible-models`; set `api_key_name` when using `api_base`, and
+leave `responses` unset unless the endpoint supports the Responses API.
+
 If the model is a completion model (such as `gpt-3.5-turbo-instruct`) add `completion: true` to the configuration.
 
 If the model should use the OpenAI Responses API rather than Chat Completions, add `responses: true` to the configuration. This is useful for models such as `o1`, `o3-mini` and `gpt-5`-style models that are accessed through `/v1/responses`.

--- a/docs/other-models.md
+++ b/docs/other-models.md
@@ -192,6 +192,23 @@ And confirm they were logged correctly with:
 llm logs -n 1
 ```
 
+The same configuration works with hosted OpenAI-compatible APIs. For example,
+this config registers a hosted model called `pzero`:
+
+```yaml
+- model_id: pzero
+  model_name: deepseek-v4-flash
+  api_base: "https://api.pzero.studio/v1"
+  api_key_name: pzero
+```
+
+In this example, `model_name` is required and is the model identifier sent to
+the API; `model_id` is only LLM's local identifier. Because `api_base` is set,
+the default `openai` key is not used, so `api_key_name` must name a key stored
+with `llm keys set pzero`. Chat Completions is used by default; only add
+`responses: true` when the endpoint supports the Responses API at
+`/v1/responses`.
+
 ### Extra HTTP headers
 
 Some providers such as [openrouter.ai](https://openrouter.ai/docs) may require the setting of additional HTTP headers. You can set those using the `headers:` key like this:


### PR DESCRIPTION
## Description

Closes #1645.

Clarify the three easy-to-miss settings when configuring a hosted OpenAI-compatible model through `extra-openai-models.yaml`: `model_name` is the upstream API identifier, `api_key_name` is required when `api_base` is set, and Chat Completions remains the default unless `responses: true` is intentional. Add a concrete hosted endpoint example and cross-reference it from the OpenAI model documentation.

## Testing

- `git diff --check` — passed
- Documentation-only change; no runtime tests are required.

AI assistance was used to help draft the documentation update; the issue, existing documentation, and resulting diff were reviewed manually.