### PR TITLE
Catch ValueError from schema_dsl in resolve_schema_input

### DIFF
--- a/llm/utils.py
+++ b/llm/utils.py
@@ -292,7 +292,10 @@ def resolve_schema_input(db, schema_input, load_template):
             pass
     if " " in schema_input.strip() or "," in schema_input:
         # Treat it as schema DSL
-        return schema_dsl(schema_input)
+        try:
+            return schema_dsl(schema_input)
+        except ValueError as e:
+            raise click.BadParameter(str(e))
     # Is it a file on disk?
     path = pathlib.Path(schema_input)
     if path.exists():

--- a/llm/utils.py
+++ b/llm/utils.py
@@ -295,7 +295,7 @@ def resolve_schema_input(db, schema_input, load_template):
         try:
             return schema_dsl(schema_input)
         except ValueError as e:
-            raise click.BadParameter(str(e))
+            raise click.BadParameter(str(e)) from None
     # Is it a file on disk?
     path = pathlib.Path(schema_input)
     if path.exists():

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -782,6 +782,21 @@ def test_schema_using_dsl(mock_model, tmpdir, monkeypatch, args, expected):
     assert json.loads(rows[0]["content"]) == expected
 
 
+def test_schema_using_invalid_dsl(tmpdir, monkeypatch):
+    monkeypatch.setenv("LLM_USER_PATH", str(tmpdir / "user"))
+    result = CliRunner().invoke(
+        cli,
+        ["prompt", "--schema", "name, age badtype", "test"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 2
+    assert (
+        "Error: Invalid value: Invalid schema DSL: unknown type 'badtype' "
+        "for field 'age'"
+    ) in result.output
+    assert "Traceback" not in result.output
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("use_pydantic", (False, True))
 async def test_schema_async(async_mock_model, use_pydantic):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,11 +3,14 @@ import json
 import pytest
 
 from llm import Toolbox, get_key
+import click
+
 from llm.utils import (
     extract_fenced_code_block,
     instantiate_from_spec,
     maybe_fenced_code,
     monotonic_ulid,
+    resolve_schema_input,
     schema_dsl,
     simplify_usage_dict,
     truncate_string,
@@ -289,6 +292,12 @@ def test_schema_dsl_duplicate_field_name():
     with pytest.raises(ValueError) as ex:
         schema_dsl("name, age int, name")
     assert str(ex.value) == "Invalid schema DSL: duplicate field name 'name'"
+
+
+def test_resolve_schema_input_invalid_dsl_raises_bad_parameter():
+    with pytest.raises(click.BadParameter) as ex:
+        resolve_schema_input(None, "name, age badtype", load_template=None)
+    assert "badtype" in str(ex.value)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,9 @@
 import json
 
+import click
 import pytest
 
 from llm import Toolbox, get_key
-import click
-
 from llm.utils import (
     extract_fenced_code_block,
     instantiate_from_spec,


### PR DESCRIPTION
When an invalid schema DSL string is passed to the --schema flag (for example an unknown type or a duplicate field name), resolve_schema_input() allowed the ValueError from schema_dsl() to propagate as a raw Python traceback instead of a clean Click error message. This fix wraps the schema_dsl() call in a try/except and raises click.BadParameter with the same message so the CLI prints a clean 'Error: Invalid value: ...' line.