### PR TITLE
Add llm-openzoo to plugin directory

### DIFF
--- a/docs/plugins/directory.md
+++ b/docs/plugins/directory.md
@@ -42,7 +42,7 @@ These plugins can be used to interact with remotely hosted models via their API:
 - **[llm-deepseek](https://github.com/abrasumente233/llm-deepseek)** adds support for the [DeepSeek](https://deepseek.com)'s DeepSeek-Chat and DeepSeek-Coder models.
 - **[llm-lambda-labs](https://github.com/simonw/llm-lambda-labs)** provides access to models hosted by [Lambda Labs](https://docs.lambdalabs.com/public-cloud/lambda-chat-api/), including the Nous Hermes 3 series.
 - **[llm-venice](https://github.com/ar-jan/llm-venice)** provides access to uncensored models hosted by privacy-focused [Venice AI](https://docs.venice.ai/), including Llama 3.1 405B.
-- **[llm-openzoo](https://github.com/staccDOTsol/llm-openzoo)** provides access to models hosted by [OpenZoo](https://openzoo.fun), an OpenAI-compatible endpoint with no signup: any API key value works and usage is billed per call.
+- **[llm-openzoo](https://github.com/staccDOTsol/llm-openzoo)** provides access to models served by [OpenZoo](https://openzoo.fun) through its local `npx openzoo` proxy, an OpenAI-compatible endpoint that needs no account or API key and pays for each call over x402.
 
 If an API model host provides an OpenAI-compatible API you can also [configure LLM to talk to it](https://llm.datasette.io/en/stable/other-models.html#openai-compatible-models) without needing an extra plugin.
 

--- a/docs/plugins/directory.md
+++ b/docs/plugins/directory.md
@@ -42,6 +42,7 @@ These plugins can be used to interact with remotely hosted models via their API:
 - **[llm-deepseek](https://github.com/abrasumente233/llm-deepseek)** adds support for the [DeepSeek](https://deepseek.com)'s DeepSeek-Chat and DeepSeek-Coder models.
 - **[llm-lambda-labs](https://github.com/simonw/llm-lambda-labs)** provides access to models hosted by [Lambda Labs](https://docs.lambdalabs.com/public-cloud/lambda-chat-api/), including the Nous Hermes 3 series.
 - **[llm-venice](https://github.com/ar-jan/llm-venice)** provides access to uncensored models hosted by privacy-focused [Venice AI](https://docs.venice.ai/), including Llama 3.1 405B.
+- **[llm-openzoo](https://github.com/staccDOTsol/llm-openzoo)** provides access to models hosted by [OpenZoo](https://openzoo.fun), an OpenAI-compatible endpoint with no signup: any API key value works and usage is billed per call.
 
 If an API model host provides an OpenAI-compatible API you can also [configure LLM to talk to it](https://llm.datasette.io/en/stable/other-models.html#openai-compatible-models) without needing an extra plugin.
 


### PR DESCRIPTION
Adds [llm-openzoo](https://github.com/staccDOTsol/llm-openzoo) ([PyPI](https://pypi.org/project/llm-openzoo/)) to the Remote APIs section.

It mirrors llm-openrouter's structure: models fetched from the model catalog at `<base>/models` (hourly cache in `llm.user_dir()`), registered as `openzoo/<model-id>`, with `llm openzoo models`/`refresh` commands. The base defaults to OpenZoo's local proxy, `http://localhost:8402/v1` (`npx openzoo`, override with `OPENZOO_API_BASE`), which speaks the OpenAI API and pays for each call over x402 from a local burner wallet — no account, no API key. The proxy ignores the key, so `get_key()` falls back to a placeholder instead of erroring: `npx openzoo` then `llm -m openzoo/z-ai/glm-5.3-flash 'hi'` works with no key setup. When the proxy is not running the plugin falls back to the free hosted catalog so `llm models` still lists them. The hosted gateway `https://api.openzoo.fun/v1` itself answers 402 unless the caller pays x402 or presents an OpenZoo subscription key (`llm keys set openzoo`).

Disclosure: I operate OpenZoo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
