### PR TITLE
cache generated options classes to speed up model lookup

### DIFF
--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -4,6 +4,7 @@ import os
 import sys
 from collections.abc import AsyncGenerator, Iterable, Iterator
 from enum import Enum
+from functools import cache
 from typing import Any, ClassVar, Literal
 
 import click
@@ -1000,6 +1001,7 @@ def enum_values_sentence(enum_class):
     return "{}, and {}".format(", ".join(values[:-1]), values[-1])
 
 
+@cache
 def build_options_class(
     *,
     reasoning=False,

--- a/tests/test_openai_responses.py
+++ b/tests/test_openai_responses.py
@@ -7,9 +7,21 @@ import pytest
 from pytest_httpx2 import IteratorStream
 
 import llm
-from llm.default_plugins.openai_models import CodeInterpreter, Responses, WebSearch
+from llm.default_plugins.openai_models import (
+    CodeInterpreter,
+    Responses,
+    WebSearch,
+    build_options_class,
+)
 
 API_KEY = os.environ.get("PYTEST_OPENAI_API_KEY", None) or "badkey"
+
+
+def test_build_options_class_is_cached_by_capabilities():
+    reasoning_options = build_options_class(reasoning=True)
+
+    assert build_options_class(reasoning=True) is reasoning_options
+    assert build_options_class(reasoning=False) is not reasoning_options
 
 
 def _text_response_json(model="gpt-5.6-luna", text="ok"):


### PR DESCRIPTION
## problem

`Responses` and `AsyncResponses` currently call `build_options_class()` for every model instance. this creates a new pydantic model class each time, even when another model has exactly the same capabilities.

this becomes expensive when a plugin registers a large number of models, since the same options classes are rebuilt whenever `llm.get_models()` or `llm.get_model()` is called.

## change

this caches `build_options_class()` using its existing capability flags. different capability combinations still receive separate classes, while identical combinations reuse the class that has already been built.

## timings

| llm version | llm-openrouter version | repeated `llm.get_models()` |
|---|---|---:|
| `llm==0.31.1` | `llm-openrouter==0.6.0` | 0.435 seconds |
| `llm==0.33` | `llm-openrouter==0.6.0` | 0.908 seconds |
| `llm==0.33` | `llm-openrouter==0.7` | 18.9 seconds |
| `llm==0.33` with this change | `llm-openrouter==0.7` | 5.531 seconds |
| `llm==0.33` with this change | `llm-openrouter==0.7` with its corresponding cache | 0.027 seconds |

## tests

- 1,106 tests passed
- black passed
- ruff passed
- mypy passed
- documentation checks passed