### PR TITLE
Cache build_options_class() - model registration rebuilt pydantic classes per instance

### DIFF
--- a/llm/default_plugins/openai_models.py
+++ b/llm/default_plugins/openai_models.py
@@ -1,4 +1,5 @@
 import datetime
+import functools
 import json
 import os
 import sys
@@ -1000,6 +1001,12 @@ def enum_values_sentence(enum_class):
     return "{}, and {}".format(", ".join(values[:-1]), values[-1])
 
 
+# Cached: pure function of five booleans (at most 32 classes), and
+# building a pydantic class is expensive enough to dominate model
+# registration when a plugin instantiates hundreds of models. Sharing
+# one class across instances follows the existing pattern of the
+# default Options being a shared class attribute.
+@functools.cache
 def build_options_class(
     *,
     reasoning=False,

--- a/tests/test_cli_openai_models.py
+++ b/tests/test_cli_openai_models.py
@@ -734,3 +734,19 @@ def test_gpt4o_mini_sync_and_async(monkeypatch, tmpdir, httpx_mock, async_, usag
     store = LogStore(db)
     chain = store.load_chain(turn["tip_message_hash"])
     assert chain[-1].parts[0].text == "Ho ho ho"
+
+
+def test_build_options_class_is_cached():
+    """Same feature-flag combination -> the same shared Options class.
+
+    Plugins that register hundreds of OpenAI-compatible models call
+    this once per model; without the cache each call builds a fresh
+    pydantic class and dominates registration time."""
+    from llm.default_plugins.openai_models import build_options_class
+
+    reasoning = build_options_class(reasoning=True)
+    assert build_options_class(reasoning=True) is reasoning
+    plain = build_options_class()
+    assert plain is not reasoning
+    assert "reasoning_effort" in reasoning.model_fields
+    assert "reasoning_effort" not in plain.model_fields


### PR DESCRIPTION
`build_options_class()` is a pure function of five booleans (at most 32 distinct classes), but every OpenAI-compatible model instance called `pydantic.create_model()` afresh. A plugin registering many models pays for it on every `register_models` pass, and `get_model()` re-runs that pass on each call. With llm-openrouter installed (~1200 models × 2 classes) one pass took ~7.5s.

This caches the class per flag combination with `functools.cache`. Tests check identity per combination and the field shape.

Wall clock with llm-openrouter, llm-gemini, llm-cerebras and llm-openai-codex installed (hyperfine, 3 runs):

| Command | 0.33 | 0.33 + this PR |
|---|---|---|
| `llm models list` | 11.0 s | 2.3 s |
| `llm logs list -m cerebras-gpt-oss-120b -n 5` | 18.7 s | 2.9 s |
| `llm logs list -n 0` (361 rows) | 37.6 s | 3.7 s |

The #1654 optimizations skip `get_model()` only for rows without model markers; rows that carry them still pay a full registration per model, which this fixes at the source.

Created with help of Fable-5.1 during migration of llm-openai-codex from llm-0.32 to llm-0.33.
