### PR TITLE
Fix KeyError 'options_json' crash in 'llm logs -t' markdown output

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -2234,7 +2234,8 @@ def logs_list(
                 should_show_conversation = False
             click.echo("## Prompt\n\n{}".format(row["prompt"] or "-- none --"))
             _display_fragments(row["prompt_fragments"], "Prompt fragments")
-            if row["options_json"]:
+            # .get(): annotate_log_rows removes the *_json keys under -t
+            if row.get("options_json"):
                 options = row["options_json"]
                 if isinstance(options, str):
                     options = json.loads(options)
@@ -2248,7 +2249,7 @@ def logs_list(
                     click.echo("\n## System\n\n{}".format(row["system"]))
                 current_system = row["system"]
             _display_fragments(row["system_fragments"], "System fragments")
-            if row["schema_json"]:
+            if row.get("schema_json"):
                 click.echo(
                     "\n## Schema\n\n```json\n{}\n```".format(
                         json.dumps(row["schema_json"], indent=2)
@@ -2337,7 +2338,7 @@ def logs_list(
 
             # If a schema was provided and the row is valid JSON, pretty print and syntax highlight it
             response = row["response"]
-            if row["schema_json"]:
+            if row.get("schema_json"):
                 try:
                     parsed = json.loads(response)
                     response = f"```json\n{json.dumps(parsed, indent=2)}\n```"

--- a/tests/test_llm_logs.py
+++ b/tests/test_llm_logs.py
@@ -1452,3 +1452,48 @@ def test_logs_markdown_omits_reasoning_heading_when_empty(log_path):
     result = runner.invoke(cli, ["logs", "-p", str(log_path)], catch_exceptions=False)
     assert result.exit_code == 0
     assert "## Reasoning" not in result.output
+
+
+def test_logs_truncate_markdown_with_options_and_schema(user_path):
+    """-t removes the *_json keys from rows; the markdown renderer must
+    render without them (it used to crash with KeyError: 'options_json')."""
+    log_path = str(user_path / "logs_truncate.db")
+    db = sqlite_utils.Database(log_path)
+    migrate(db)
+    db["schemas"].insert({"id": SINGLE_ID, "content": '{"name": "string"}'})
+    db["responses"].insert(
+        {
+            "id": str(monotonic_ulid()).lower(),
+            "system": "system",
+            "prompt": "prompt",
+            "response": "response",
+            "model": "davinci",
+            "datetime_utc": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "conversation_id": "abc123",
+            "options_json": '{"temperature": 0.5}',
+            "schema_id": SINGLE_ID,
+        }
+    )
+    runner = CliRunner()
+    result = runner.invoke(cli, ["logs", "-t", "-p", log_path], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "## Options" not in result.output
+    assert "## Schema" not in result.output
+    # Without -t the same row still renders both sections
+    result2 = runner.invoke(cli, ["logs", "-p", log_path], catch_exceptions=False)
+    assert result2.exit_code == 0
+    assert "- temperature: 0.5" in result2.output
+    assert "## Schema" in result2.output
+
+
+def test_logs_truncate_markdown_new_store(logs_db, mock_model):
+    """Same for rows from the new tables, whose builder always fills
+    options_json - so -t always removed the key."""
+    mock_model.enqueue(["hello"])
+    response = mock_model.prompt("hi")
+    response.text()
+    response.log_to_db(logs_db)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["logs", "-t"], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "## Response\n\nhello" in result.output


### PR DESCRIPTION
`llm logs list -t` crashes with `KeyError: 'options_json'` as soon as a listed row has options or a schema. `annotate_log_rows()` deletes every `*_json` key under `--truncate`, but the markdown renderer still reads `row["options_json"]` and `row["schema_json"]` unconditionally. Turn rows always carry at least `"{}"` there, so the truncated listing is broken for both the new and the legacy store.

The three renderer sites now use `row.get(...)`, so a stripped key means the section is omitted. Regression tests cover both stores.

Created with help of Fable-5.1 during migration of llm-openai-codex from llm-0.32 to llm-0.33.
