### PR TITLE
Index the columns 'llm logs' looks rows up by, use 'union all' for the latest-conversation lookup

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1419,12 +1419,15 @@ def load_conversation(
     migrate(db)
     if conversation_id is None:
         # Most recent conversation from either generation of tables -
-        # thread ids are conversation ids, so the union dedupes rows
-        # from the dual-write era.
+        # thread ids are conversation ids, so a dual-write era id can
+        # show up on both sides, but the outer limit 1 makes that
+        # harmless. "union all" lets SQLite walk each primary key
+        # backwards and stop at the first row, where a distinct
+        # "union" would first materialize every id from both tables.
         matches = list(db.query("""
                 select id from (
                     select id from threads
-                    union
+                    union all
                     select id from conversations
                 ) order by id desc limit 1
                 """))

--- a/llm/migrations.py
+++ b/llm/migrations.py
@@ -732,3 +732,38 @@ def m027_turns_response_json(db):
     # response. NULL for turns logged before this column existed and
     # for models that expose no raw payload.
     db["turns"].add_column("response_json", str)
+
+
+# FORK-LOCAL migration (rs) - note for future rebases onto upstream:
+# a same-numbered upstream m028_* does NOT clash (migrations are
+# recorded by function name, and these indexes depend only on tables
+# from m010/m017/m023, so ordering against future upstream migrations
+# is irrelevant). The clash to watch for is upstream shipping
+# equivalent indexes: sqlite-utils auto-generates the same
+# idx_<table>_<columns> names, so if_not_exists below keeps this
+# migration a no-op when upstream's version ran first. If upstream's
+# equivalent lacks that guard and would run AFTER this one, drop this
+# migration during the rebase instead.
+@migration
+def m028_log_lookup_indexes(db):
+    # Indexes for the columns `llm logs` looks rows up by but
+    # previously had to scan for.
+    # The legacy tool tables are only ever read through correlated
+    # subqueries on response_id - without an index that is one full
+    # scan per listed response, and tool_results rows carry the actual
+    # tool outputs, so those scans read the payloads too.
+    # tool_responses' primary key starts with tool_id, so it cannot
+    # serve a response_id probe either.
+    db["tool_calls"].create_index(["response_id"], if_not_exists=True)
+    db["tool_results"].create_index(["response_id"], if_not_exists=True)
+    db["tool_responses"].create_index(["response_id"], if_not_exists=True)
+    # -c/--cid filtering on the legacy side was a full responses scan:
+    # turns got idx_turns_thread_id in m023, but the equivalent
+    # responses.conversation_id was never indexed.
+    db["responses"].create_index(["conversation_id"], if_not_exists=True)
+    # The -T/--tool filter resolves "which messages carry a tool_result
+    # part (with this tool name)" - previously a full scan of parts,
+    # the fastest-growing table in the store, plus a transient
+    # automatic index sqlite built on every query. Trailing
+    # message_hash makes the index covering for exactly that subquery.
+    db["parts"].create_index(["type", "tool_name", "message_hash"], if_not_exists=True)

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -56,6 +56,26 @@ def test_migrate_blank():
     }
 
 
+def test_migrate_creates_log_lookup_indexes():
+    """m028: the columns `llm logs` filters and joins on are indexed,
+    so listings never scan the tool, parts or responses tables."""
+    db = sqlite_utils.Database(memory=True)
+    migrate(db)
+    indexed = {
+        (table.name, tuple(index.columns))
+        for table in db.tables
+        for index in table.indexes
+    }
+    for expected in (
+        ("tool_calls", ("response_id",)),
+        ("tool_results", ("response_id",)),
+        ("tool_responses", ("response_id",)),
+        ("responses", ("conversation_id",)),
+        ("parts", ("type", "tool_name", "message_hash")),
+    ):
+        assert expected in indexed
+
+
 @pytest.mark.parametrize("has_record", [True, False])
 def test_migrate_from_original_schema(has_record):
     db = sqlite_utils.Database(memory=True)


### PR DESCRIPTION
`EXPLAIN QUERY PLAN` over the queries `llm logs` runs shows five lookups that scan a whole table. Fine at hundreds of rows, painful as the store grows. This adds one migration with five indexes and a one-word query change:

- `parts(type, tool_name, message_hash)` - the `--tools` / `-T` filters resolve "messages with a tool_result part" by scanning `parts`, the fastest-growing table, and building a transient automatic index on every query.
- `tool_calls`, `tool_results`, `tool_responses` on `response_id` - the legacy extras and the legacy `--tools` filter probe these per listed response through correlated subqueries.
- `responses(conversation_id)` - legacy `--cid` filtering; `turns.thread_id` got its index in m023, this column never did.
- `load_conversation()` for `prompt -c` used a distinct `union` of `threads` and `conversations`, which materializes every id before taking one row. `union all` lets SQLite stop at the first row of each primary key; the outer `limit 1` already discards any dual-write duplicate.

Measured on a copy of my logs.db (442 legacy responses, 359 turns, 1202 parts) and the same database replicated 50x (22k responses, 18k turns, 60k parts). Query timings, median of 15 runs:

| Query | real, before | real, after | 50x, before | 50x, after |
|---|---|---|---|---|
| legacy extras for 20 rows (tool_calls + tool_results subqueries) | 0.32 ms | 0.09 ms | 38.6 ms | 0.10 ms |
| legacy `--tools` filter | 0.13 ms | 0.08 ms | 4.3 ms | 0.18 ms |
| legacy `--cid` filter | 1.90 ms | 0.03 ms | 108.8 ms | 0.03 ms |
| `--tools` filter (parts) | 6.4 ms | 0.4 ms | 12 695 ms | 27 ms |
| `-T name` filter (parts) | 3.8 ms | 0.2 ms | 5 427 ms | 11 ms |
| latest conversation for `prompt -c` (12k threads) | - | - | 36 ms | 0.1 ms |

End to end at 50x, hyperfine mean of 3 runs (about 2 s of each is interpreter and plugin startup):

| Command | before | after |
|---|---|---|
| `llm logs list --tools -n 5` | 14.4 s | 2.2 s |
| `llm logs list -T Brave_context -n 5` | 42.1 s | 2.2 s |
| `llm logs list --cid ID -n 5` | 2.2 s | 2.1 s |

The five indexes add about 0.6% to the file size. If you prefer a smaller footprint on `parts`, a partial index `on parts (tool_name, message_hash) where type = 'tool_result'` serves the same query; happy to switch.

Created with help of Fable-5.1 during migration of llm-openai-codex from llm-0.32 to llm-0.33.
