### PR TITLE
Fix 'llm logs -t' leaving system and reasoning untruncated

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -1719,6 +1719,11 @@ def annotate_log_rows(db, rows, expand=False, truncate=False):
         if truncate:
             row["prompt"] = truncate_string(row["prompt"] or "")
             row["response"] = truncate_string(row["response"] or "")
+            # Null when absent (no system prompt, no reasoning
+            # emitted); keep null rather than turning it into ""
+            for key in ("system", "reasoning"):
+                if row.get(key):
+                    row[key] = truncate_string(row[key])
         # Add prompt and system fragments
         for key in ("prompt_fragments", "system_fragments"):
             row[key] = [


### PR DESCRIPTION
`llm logs -t` only truncates `prompt` and `response`. The `reasoning` column (added in the visible-reasoning commit) and `system` pass through at full length, so `llm logs --json -t -n1` still dumps multi-KB reasoning blobs. The same rows feed the markdown renderer.

`annotate_log_rows()` now truncates `system` and `reasoning` to the same 100-char limit. A null value stays null rather than becoming `""`, matching the truthiness check the renderer already uses for reasoning.

Created with help of Fable-5.1.