### PR TITLE
Close provider generator when async event stream closes

### DIFF
--- a/llm/models.py
+++ b/llm/models.py
@@ -2561,7 +2561,8 @@ class AsyncResponse(_BaseResponse):
                 self._process_chunk(chunk)
                 yield self._stream_events[-1]
         finally:
-            pass
+            if not self._done:
+                await self._generator.aclose()
 
     async def messages(self) -> list[Any]:
         """List of Message objects produced by this response.

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -1,4 +1,5 @@
 import json
+from contextlib import aclosing
 
 import pytest
 
@@ -916,6 +917,30 @@ class TestAsyncStreamEvents:
         async for event in response.astream_events():
             seen_types.append(event.type)
         assert seen_types == ["reasoning", "text"]
+
+    @pytest.mark.asyncio
+    async def test_closing_stream_events_closes_provider_generator(self):
+        class ResourceModel(llm.AsyncModel):
+            model_id = "resource-model"
+
+            def __init__(self):
+                self.resource_closed = False
+
+            async def execute(self, prompt, stream, response, conversation):
+                try:
+                    yield "first"
+                    yield "second"
+                finally:
+                    self.resource_closed = True
+
+        model = ResourceModel()
+        response = model.prompt("x")
+
+        async with aclosing(response.astream_events()) as events:
+            event = await anext(events)
+            assert event.chunk == "first"
+
+        assert model.resource_closed
 
     @pytest.mark.asyncio
     async def test_async_iter_yields_only_text(self, async_mock_model):


### PR DESCRIPTION
When `AsyncResponse.astream_events()` is explicitly closed or finalized before normal exhaustion, it currently leaves the underlying provider async generator open. That can delay provider cleanup for streaming HTTP responses and plugin-managed resources.

Propagate early closure to the provider generator while preserving the existing normal-completion path through `_async_finalize()`. Add a regression test that consumes one event through `contextlib.aclosing` and verifies that provider cleanup runs.

Validation:

- `uv run pytest`: 1125 passed
- `uv run black . --check`: passed
- `uv run mypy llm`: passed
- `uv run ruff check .`: passed
- package sdist and wheel build: passed
- the new regression fails on the untouched base and passes with this change

The Cog generated-fragment check still reports the existing `docs/fragments.md (changed)` result, which was reproduced on the untouched base commit.