### PR TITLE
Add llm-omlx to plugin directory

### DIFF
--- a/docs/plugins/directory.md
+++ b/docs/plugins/directory.md
@@ -15,7 +15,8 @@ These plugins all help you run LLMs directly on your own computer:
 - **[llm-mlc](https://github.com/simonw/llm-mlc)** can run local models released by the [MLC project](https://mlc.ai/mlc-llm/), including models that can take advantage of the GPU on Apple Silicon M1/M2 devices.
 - **[llm-gpt4all](https://github.com/simonw/llm-gpt4all)** adds support for various models released by the [GPT4All](https://gpt4all.io/) project that are optimized to run locally on your own machine. These models include versions of Vicuna, Orca, Falcon and MPT - here's [a full list of models](https://observablehq.com/@simonw/gpt4all-models).
 - **[llm-mpt30b](https://github.com/simonw/llm-mpt30b)** adds support for the [MPT-30B](https://huggingface.co/mosaicml/mpt-30b) local model.
-- **[llm-lmstudio](https://github.com/agustif/llm-lmstudio)** provides access to local models using [LM Studio](https://lmstudio.ai/),
+- **[llm-lmstudio](https://github.com/agustif/llm-lmstudio)** provides access to local models using [LM Studio](https://lmstudio.ai/).
+- **[llm-omlx](https://github.com/serialx/llm-omlx)** (Mac only) provides access to text, vision and embedding models served by [oMLX](https://github.com/jundot/omlx), an OpenAI-compatible server built on Apple's MLX framework.
 
 (plugin-directory-remote-apis)=
 ## Remote APIs


### PR DESCRIPTION
Adds [llm-omlx](https://github.com/serialx/llm-omlx) to the Local models section. It discovers and uses text, vision and embedding models served by [oMLX](https://github.com/jundot/omlx), an OpenAI-compatible server built on Apple's MLX framework, and is on PyPI as `llm-omlx`.