### PR TITLE
Fix template evaluation mutating params

### DIFF
--- a/llm/templates.py
+++ b/llm/templates.py
@@ -43,7 +43,9 @@ class Template(BaseModel):
         self, input: str, params: dict[str, Any] | None = None
     ) -> tuple[str | None, str | None]:
         """Evaluate the template with the given input and parameters, returning (prompt, system)."""
-        params = params or {}
+        # Template-only values such as ``input`` and defaults should not leak
+        # into the mapping supplied by the caller.
+        params = dict(params or {})
         params["input"] = input
         if self.defaults:
             for k, v in self.defaults.items():

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -49,6 +49,20 @@ def test_template_evaluate(
         assert system == expected_system
 
 
+def test_template_evaluate_does_not_modify_params():
+    params = {"name": "Ada", "input": "stale input"}
+    template = Template(
+        name="greeting",
+        prompt="$name: $input ($language)",
+        defaults={"language": "English"},
+    )
+
+    prompt, system = template.evaluate("Hello", params)
+
+    assert (prompt, system) == ("Ada: Hello (English)", None)
+    assert params == {"name": "Ada", "input": "stale input"}
+
+
 def test_templates_list_no_templates_found():
     runner = CliRunner()
     result = runner.invoke(cli, ["templates", "list"])


### PR DESCRIPTION
  ## Summary

  - Prevent `Template.evaluate()` from modifying the caller-provided `params` dictionary.
  - Add a regression test covering both the implicit `input` value and template defaults.