### PR TITLE
Fix default model options when constructing Prompt directly

### DIFF
--- a/llm/models.py
+++ b/llm/models.py
@@ -519,7 +519,7 @@ class Prompt:
         self.schema = schema
         self.tools = _wrap_tools(tools or [])
         self.tool_results = tool_results or []
-        self.options = options or {}
+        self.options = options or model.Options()
         self.hide_reasoning = hide_reasoning
         # Explicit messages= list, if the caller supplied one. Copied so
         # later mutation by the caller doesn't alter the Prompt.

--- a/tests/test_options_parameter.py
+++ b/tests/test_options_parameter.py
@@ -6,6 +6,29 @@ continues to work undocumented for backwards compatibility.
 
 import pytest
 
+import llm
+
+
+@pytest.mark.parametrize("kwargs", ({}, {"options": None}, {"options": {}}))
+def test_direct_prompt_default_options(mocked_openai_responses, kwargs):
+    model = llm.get_model("gpt-5.5")
+    prompt = llm.Prompt("hello", model, **kwargs)
+    response = llm.Response(prompt=prompt, model=model, stream=False, key="test-key")
+
+    assert response.text() == "Bob, Alice, Eve"
+    assert isinstance(prompt.options, model.Options)
+    assert prompt.options == model.Options()
+
+
+def test_direct_prompt_preserves_options(mocked_openai_responses):
+    model = llm.get_model("gpt-5.5")
+    options = model.Options(temperature=0.5)
+    prompt = llm.Prompt("hello", model, options=options)
+    response = llm.Response(prompt=prompt, model=model, stream=False, key="test-key")
+
+    assert response.text() == "Bob, Alice, Eve"
+    assert prompt.options is options
+
 
 def test_prompt_with_options_dict(mock_model):
     mock_model.enqueue(["ok"])


### PR DESCRIPTION
Directly constructing `llm.Prompt("hello", model)` leaves `prompt.options` as a dict. Providers that access option attributes then raise `AttributeError`; this also reproduces with the built-in OpenAI Responses provider on current main.

Use the model's `Options()` for the existing empty/default fallback. Explicit Options instances remain unchanged. Four regression cases exercise the public Prompt/Response path using the existing mocked HTTP response fixture: omitted options, `None`, an empty dict, and a populated Options instance.

Fixes #1028.

Validation (Python 3.12.9):
- Before the fix, all three default-option cases fail on `prompt.options.json_object`; the explicit-options control passes. After the fix, all 13 options tests pass.
- Full suite: 1,128 passed (18 warnings).
- Black, Ruff, mypy and package build pass.
- Local tests use `httpx2-pytest==1.0.1`: version 2.0.0 renames the `httpx_mock` fixture required by the existing suite. No dependency files changed.
- Cog reports an existing version mismatch in unchanged `docs/fragments.md` (0.33) versus `pyproject.toml` (0.34), also present on the base commit `2f49eec9`.
