### PR TITLE
DOC: Add llm-hubris plugin to docs/plugins/directory.md

### DIFF
--- a/docs/plugins/directory.md
+++ b/docs/plugins/directory.md
@@ -42,6 +42,7 @@ These plugins can be used to interact with remotely hosted models via their API:
 - **[llm-deepseek](https://github.com/abrasumente233/llm-deepseek)** adds support for the [DeepSeek](https://deepseek.com)'s DeepSeek-Chat and DeepSeek-Coder models.
 - **[llm-lambda-labs](https://github.com/simonw/llm-lambda-labs)** provides access to models hosted by [Lambda Labs](https://docs.lambdalabs.com/public-cloud/lambda-chat-api/), including the Nous Hermes 3 series.
 - **[llm-venice](https://github.com/ar-jan/llm-venice)** provides access to uncensored models hosted by privacy-focused [Venice AI](https://docs.venice.ai/), including Llama 3.1 405B.
+- **[llm-hubris](https://github.com/Aimagine-life/llm-hubris)** provides access to models hosted on [Hubris](https://hubris.pw/), an OpenAI-compatible gateway billed in Russian rubles.
 
 If an API model host provides an OpenAI-compatible API you can also [configure LLM to talk to it](https://llm.datasette.io/en/stable/other-models.html#openai-compatible-models) without needing an extra plugin.
 


### PR DESCRIPTION
Adds [llm-hubris](https://github.com/Aimagine-life/llm-hubris) to the Remote APIs section.

[Hubris](https://hubris.pw) is an OpenAI-compatible LLM gateway billed in Russian rubles (OpenAI, Anthropic, Google, DeepSeek, Qwen and other models behind one key). The plugin registers every chat model from the user's Hubris catalog as `hubris/<vendor>/<model>`, built on the `Chat` / `AsyncChat` classes from the default OpenAI plugin, plus `llm hubris refresh` and `llm hubris models` commands. Published on PyPI: https://pypi.org/project/llm-hubris/ (`llm install llm-hubris`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)