### PR TITLE
Fix `llm -- prompt` not treating argument as positional

### DIFF
--- a/llm/cli.py
+++ b/llm/cli.py
@@ -24,6 +24,19 @@ import pydantic
 import sqlite_utils
 import yaml
 from click_default_group import DefaultGroup
+
+
+class _DefaultGroupWithDoubleDash(DefaultGroup):
+    def parse_args(self, ctx, args):
+        # When the user writes `llm -- <arg>` the group's parser consumes `--`
+        # and passes `<arg>` to the subcommand resolver without the separator.
+        # If `<arg>` starts with `-` the subcommand's parser then mistakes it
+        # for an option.  Inserting the default command name before `--` turns
+        # `['--', arg]` into `['prompt', '--', arg]` so the separator is
+        # forwarded intact and the subcommand treats the arg as positional.
+        if args and args[0] == "--" and self.default_cmd_name:
+            args.insert(0, self.default_cmd_name)
+        return super().parse_args(ctx, args)
 from sqlite_utils.utils import Format, rows_from_file
 
 from llm import (
@@ -532,7 +545,7 @@ def tool_options(fn):
 
 
 @click.group(
-    cls=DefaultGroup,
+    cls=_DefaultGroupWithDoubleDash,
     default="prompt",
     default_if_no_args=True,
     context_settings={"help_option_names": ["-h", "--help"]},

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -714,6 +714,19 @@ def test_schema(mock_model, use_pydantic):
     assert response.prompt.schema == dog_schema
 
 
+def test_double_dash_separator(monkeypatch):
+    # `llm -- "--option-like"` should treat "--option-like" as the prompt, not
+    # as an option for the prompt command.  Previously the group consumed `--`
+    # and the subcommand received "--option-like" without the separator,
+    # causing Click to raise "No such option".
+    monkeypatch.setenv("LLM_MODEL", "echo")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--", "--find me"], catch_exceptions=False)
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["prompt"] == "--find me"
+
+
 def test_model_environment_variable(monkeypatch):
     monkeypatch.setenv("LLM_MODEL", "echo")
     runner = CliRunner()


### PR DESCRIPTION
When running `llm -- "--find me"`, the cli group (DefaultGroup) consumes the `--` separator and forwards `"--find me"` to the prompt subcommand without the separator, so Click's parser mistakes it for an option and raises "No such option: --find me". The equivalent `llm prompt -- "--find me"` works correctly because the separator reaches the prompt command intact.

The fix detects when `--` is the first argument to the cli group and injects the default command name (`prompt`) before it, so `['--', arg]` becomes `['prompt', '--', arg]` and the separator is forwarded to the subcommand as intended. A regression test using the echo model verifies the prompt value is received correctly.

Fixes #245

---
_Generated by [Claude Code](https://claude.ai/code/session_015J3gVny9MN8kFEQaQvMqSk)_