### PR TITLE
docs: explain templates and fragments together

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -3,7 +3,16 @@
 
 A **template** can combine a prompt, system prompt, model, default model options, schema, and fragments into a single reusable unit.
 
-Only one template can be used at a time. To compose multiple shorter pieces of prompts together consider using {ref}`fragments <fragments>` instead.
+Use a template to save **how to run a prompt**, such as the instructions, model options, and output schema for a recurring task. Use {ref}`fragments <fragments>` to supply **text to include in a prompt**, such as a document or a set of instructions. Fragments do not configure the model or output schema, and their text is stored only once in the logs database even when reused across prompts.
+
+You can use both together. This saves summarization instructions as a template, then supplies a document as a fragment when running it:
+
+```bash
+llm --system 'Summarize the supplied document in three bullet points' --save summarize
+llm -t summarize -f document.txt
+```
+
+Repeat `-f` to include several fragments, or `-t` to combine templates from left to right. A template can also include fragments; see {ref}`prompt-templates-yaml` for the YAML format.
 
 (prompt-templates-save)=
 


### PR DESCRIPTION
Closes #918.

The opening of the templates page now explains when to use templates and fragments, then shows them working together: save summarization instructions as a template and provide a document with `-f`. It links to the YAML form for templates that include fragments.

This also removes the stale opening statement that only one template can be used at a time. Current CLI code, the existing multiple-template test, and the later section on the same page support repeated `-t` options applied from left to right.

Validation:
- `uv run --python 3.11 --with-requirements docs/requirements.txt make -C docs html`: build succeeded.
- Executed the example with the repository's local `echo` model and an isolated `LLM_USER_PATH`; verified the saved system instructions and document text arrive together in the prompt. No provider call.
- `git diff --check`: passed.
- The existing template/fragment test run could not complete successfully: current main uses `httpx2-pytest` while these test modules request `httpx_mock`. This docs-only diff does not change that fixture setup.

Prepared with AI assistance.
