### PR TITLE
Fix AsyncResponse.log_to_db

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -673,6 +673,15 @@ print(response.text())
 response.log_to_db(db)
 ```
 
+For an `AsyncResponse`, wait for the response before logging it:
+
+```python
+async_model = llm.get_async_model("gpt-5.5")
+response = async_model.prompt("A short pelican fact")
+print(await response.text())
+response.log_to_db(db)
+```
+
 `log_to_db()` takes a `sqlite_utils.Database` and records the response's thread, turn, messages, parts, fragments, attachments and tools in the content-addressed tables. It applies any outstanding migrations itself, so it is safe to call against a brand new database file or one created by an older version of LLM. The underlying `LogStore` class is internal and its API may change - `log_to_db()` and the table schema documented on this page are the supported interfaces.
 
 (logging-sql-schema)=

--- a/llm/models.py
+++ b/llm/models.py
@@ -2139,6 +2139,19 @@ class AsyncResponse(_BaseResponse):
     model: "AsyncModel"
     conversation: Optional["AsyncConversation"] = None
 
+    def log_to_db(self, db):
+        """Record this completed response in a log database.
+
+        Call this after awaiting the response, for example with
+        ``await response.text()``. Like the synchronous response API, this
+        performs the database write immediately.
+        """
+        if not self._done:
+            raise ValueError(
+                "Response not yet awaited — call `await response` before log_to_db()"
+            )
+        self._to_sync_response().log_to_db(db)
+
     async def reply(
         self,
         prompt: str | None = None,
@@ -2630,6 +2643,9 @@ class AsyncResponse(_BaseResponse):
 
     async def to_sync_response(self) -> Response:
         await self._force()
+        return self._to_sync_response()
+
+    def _to_sync_response(self) -> Response:
         # This conversion might be tricky if the model is AsyncModel,
         # as Response expects a sync Model. For simplicity, we'll assume
         # the primary use case is data transfer after completion.

--- a/tests/test_logs_store.py
+++ b/tests/test_logs_store.py
@@ -1528,6 +1528,35 @@ class TestAsyncLogging:
         assert parts[0].provider_metadata == {"anthropic": {"signature": "SIG"}}
         assert store.verify() == []
 
+    @pytest.mark.asyncio
+    async def test_async_response_log_to_db(self, store, async_mock_model):
+        self.enqueue_reasoning(async_mock_model)
+        conversation = async_mock_model.conversation()
+        response = conversation.prompt("q")
+        await response.text()
+
+        response.log_to_db(store.db)
+
+        turn = next(iter(store.db["turns"].rows))
+        assert turn["id"] == response.id
+        assert turn["thread_id"] == conversation.id
+        parts = store.load_chain(turn["tip_message_hash"])[-1].parts
+        assert [type(part).__name__ for part in parts] == [
+            "ReasoningPart",
+            "TextPart",
+        ]
+        assert parts[0].provider_metadata == {"anthropic": {"signature": "SIG"}}
+        assert store.verify() == []
+
+    @pytest.mark.asyncio
+    async def test_async_response_log_to_db_requires_completion(
+        self, store, async_mock_model
+    ):
+        response = async_mock_model.prompt("q")
+
+        with pytest.raises(ValueError, match="Response not yet awaited"):
+            response.log_to_db(store.db)
+
 
 # ---- llm logs against the new tables ---------------------------------
 


### PR DESCRIPTION
`AsyncResponse` inherited the synchronous `log_to_db()` implementation, which passed its awaitable `duration_ms()` and `datetime_utc()` results to SQLite after completion and raised `sqlite3.ProgrammingError`.

This preserves the synchronous `log_to_db()` call shape after awaiting the response, reuses the existing completed-response conversion used by the CLI, and raises the established await-required `ValueError` before completion.

The regression covers persisted response and conversation IDs, structured reasoning parts, and the precompletion guard.

Tests: `pytest tests/test_logs_store.py::TestAsyncLogging tests/test_async_parity.py -q; offline echo persistence; Ruff; Black; MyPy; cog --check docs/logging.md`.